### PR TITLE
Added missing imports.

### DIFF
--- a/libs/breakpad/src/common/linux/file_id.cc
+++ b/libs/breakpad/src/common/linux/file_id.cc
@@ -40,6 +40,8 @@
 #include <link.h>
 #include <string.h>
 #include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include <cassert>


### PR DESCRIPTION
It won't compile without these imports. I use Debian Testing. Import those files is also recommended in documentation of fstat.
