### PR TITLE
[0.58] Remove dead master servers

### DIFF
--- a/share/gamedir/cfg/masterservers.txt
+++ b/share/gamedir/cfg/masterservers.txt
@@ -1,2 +1,1 @@
 server.openlierox.net
-thelobby.altervista.org/server

--- a/share/gamedir/cfg/udpmasterservers.txt
+++ b/share/gamedir/cfg/udpmasterservers.txt
@@ -1,2 +1,1 @@
 server.az2000.de:23450
-liero.1337.cx:23450


### PR DESCRIPTION
thelobby.altervista.org doesn't exist anymore,
and liero.1337.cx seems to be gone too.
Also, openlierox.net/server is broken, what to do with that?