### PR TITLE
[0.59] Remove dead master server

### DIFF
--- a/share/gamedir/cfg/masterservers.txt
+++ b/share/gamedir/cfg/masterservers.txt
@@ -1,2 +1,1 @@
-thelobby.altervista.org/server
 server.openlierox.net


### PR DESCRIPTION
thelobby.altervista.org is gone.
liero.1337.cx seems to have been removed already
from 0.59.
What to do with server.openlierox.net? (it's broken too, database error)