### PR TITLE
Fix Ubuntu 24.04 / GCC 13 build issues (missing standard headers + safe ctype usage)

### DIFF
--- a/include/MathLib.h
+++ b/include/MathLib.h
@@ -22,6 +22,7 @@
 #define __MATHLIB_H__
 
 #include <cmath>
+#include <cstdint>
 
 #include "CVec.h"
 

--- a/src/common/Debug.cpp
+++ b/src/common/Debug.cpp
@@ -368,11 +368,16 @@ void OlxWriteCoreDump(const char* fileName)
 #ifdef GCOREDUMPER
 #include <google/coredumper.h>
 #endif
+#include <limits.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <cstring>
 #include <cstdio>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
 
 #ifndef GCOREDUMPER
 static void GdbWriteCoreDump(const char* fname) {

--- a/src/common/sex.cpp
+++ b/src/common/sex.cpp
@@ -14,6 +14,7 @@
 
 #include "MathLib.h"
 #include "StringUtils.h"
+#include <cctype>
 
 
 static const char     *faster[] = {
@@ -259,7 +260,7 @@ std::string sex(short wraplen) {
 				buffer[lastword] = '\n';
 				lwidth = pos - lastword;
 			}
-			if (isspace(*cp)) {
+			if (std::isspace(static_cast<unsigned char>(*cp))) {
 				lastword = pos;
 			} 
 			pos++;

--- a/tools/UDPMasterServer/src/svr_udp.cpp
+++ b/tools/UDPMasterServer/src/svr_udp.cpp
@@ -1,6 +1,7 @@
 // That's the same as svr_udp.php but needs no MySQL or PHP :)
 
 #include "svr_udp.h"
+#include <ctime>
 
 static bool quit = false;	// Signal here on Ctrl-C
 

--- a/tools/UDPMasterServer/src/svr_udp6.cpp
+++ b/tools/UDPMasterServer/src/svr_udp6.cpp
@@ -1,6 +1,7 @@
 // That's the same as svr_udp.php but needs no MySQL or PHP :)
 
 #include "svr_udp.h"
+#include <ctime>
 
 static bool quit = false;	// Signal here on Ctrl-C
 


### PR DESCRIPTION
## Summary

Fixes build errors on Ubuntu 24.04 / GCC 13 by adding missing standard headers and one safe `isspace` usage update.

## What this fixes

- `uint32_t` not found
- `PATH_MAX` not found
- `time_t` / `time()` not declared in UDP master sources
- unsafe `isspace(char)` usage

## Verification

Built successfully with:

```bash
cmake -DHAWKNL_BUILTIN=1 -DLIBZIP_BUILTIN=1 -DDEBUG=0 .
make -j8
