### PR TITLE
Add modifier key support and bind fullscreen toggle to the standard Alt+Enter

### DIFF
--- a/include/CInput.h
+++ b/include/CInput.h
@@ -21,6 +21,7 @@
 #define __CINPUT_H__
 
 #include <string>
+#include "InputEvents.h"
 
 
 // Input variable types
@@ -61,6 +62,7 @@ private:
 	int		Data;
 	int		Extra;
 	std::string m_EventName;
+	ModifiersState m_modifiers; // required modifier keys for keyboard bindings
 	bool	resetEachFrame;
 
 	// HINT: currently these are only used for keyboard exept nDownOnce

--- a/src/client/CInput.cpp
+++ b/src/client/CInput.cpp
@@ -445,7 +445,27 @@ int CInput::Wait(std::string& strText)
 	for(int i = 0; i < kb->queueLength; ++i) {
 		if(kb->keyQueue[i].down) continue;
 		if(kb->keyQueue[i].sym == 0) continue;
-		
+
+		// Skip bare modifier key releases — they are not useful as standalone bindings
+		// when combined with other modifiers (e.g. releasing Alt after Alt+Enter).
+		// Pure modifier presses (Alt alone) still work since the state will show no other mods.
+		SDL_Keycode sym = kb->keyQueue[i].sym;
+		bool isModifierKey = (sym == SDLK_LALT || sym == SDLK_RALT ||
+		                      sym == SDLK_LCTRL || sym == SDLK_RCTRL ||
+		                      sym == SDLK_LSHIFT || sym == SDLK_RSHIFT ||
+		                      sym == SDLK_LGUI || sym == SDLK_RGUI);
+		const ModifiersState& evMods = kb->keyQueue[i].state;
+		bool anyModHeld = evMods.bAlt || evMods.bCtrl || evMods.bShift || evMods.bGui;
+		if(isModifierKey && anyModHeld)
+			continue;
+
+		// Build modifier prefix string from the event's modifier state
+		std::string modPrefix;
+		if(evMods.bAlt)   modPrefix += "alt+";
+		if(evMods.bCtrl)  modPrefix += "ctrl+";
+		if(evMods.bShift) modPrefix += "shift+";
+		if(evMods.bGui)   modPrefix += "gui+";
+
 		for(uint n = 0; n<sizeof(Keys) / sizeof(keys_t); n++) {
 			if(kb->keyQueue[i].sym == Keys[n].value) {
 #ifdef WIN32
@@ -460,7 +480,7 @@ int CInput::Wait(std::string& strText)
 				}
 #endif
 
-				strText = Keys[n].text;
+				strText = modPrefix + Keys[n].text;
 				return true;
 			}
 		}
@@ -468,7 +488,7 @@ int CInput::Wait(std::string& strText)
 		// Our description is not enough, let's call SDL for help
 		// We use SDL only for the left unknown keys to stay backward and forward compatible.
 		if (kb->keyQueue[i].sym != SDLK_ESCAPE)  {
-			strText = SDL_GetKeyName(kb->keyQueue[i].sym);
+			strText = modPrefix + SDL_GetKeyName(kb->keyQueue[i].sym);
 			return true;
 		}
 	}
@@ -497,11 +517,38 @@ int CInput::Setup(const std::string& string)
 {
 	m_EventName = string;
 	resetEachFrame = true;
+	m_modifiers.clear();
+
+	// Parse optional modifier prefixes: "alt+", "ctrl+", "shift+"
+	std::string remaining = string;
+	bool foundModifier = true;
+	while(foundModifier && remaining.size() >= 4) {
+		foundModifier = false;
+		std::string lower = remaining.substr(0, 6);
+		for(char& c : lower) c = tolower(c);
+		if(lower.substr(0, 4) == "alt+") {
+			m_modifiers.bAlt = true;
+			remaining = remaining.substr(4);
+			foundModifier = true;
+		} else if(lower.substr(0, 5) == "ctrl+") {
+			m_modifiers.bCtrl = true;
+			remaining = remaining.substr(5);
+			foundModifier = true;
+		} else if(lower.substr(0, 6) == "shift+") {
+			m_modifiers.bShift = true;
+			remaining = remaining.substr(6);
+			foundModifier = true;
+		} else if(lower.substr(0, 4) == "gui+") {
+			m_modifiers.bGui = true;
+			remaining = remaining.substr(4);
+			foundModifier = true;
+		}
+	}
 
 	// Check if it's a mouse
-	if(string.substr(0,2) == "ms") {
+	if(remaining.substr(0,2) == "ms") {
 		Type = INP_MOUSE;
-		Data = atoi(string.substr(2).c_str());
+		Data = atoi(remaining.substr(2).c_str());
 		if( Data == 3 ) Data = 2;
 		else if( Data == 2 ) Data = 3;
 		if(Data < 1 || Data > MAX_MOUSEBUTTONS) {
@@ -514,18 +561,18 @@ int CInput::Setup(const std::string& string)
 	}
 	
 	{
-		SDL_Keycode key = SDL_GetKeyFromName(string.c_str());
+		SDL_Keycode key = SDL_GetKeyFromName(remaining.c_str());
 		if(key != SDLK_UNKNOWN) {
 			Type = INP_KEYBOARD;
 			Data = key;
 			return true;
 		}
 	}
-	
+
 #ifdef HAVE_JOYSTICK
 	// Check if it's a joystick #1
 	// TODO: allow more joysticks
-	if(string.substr(0,5) == "joy1_") {
+	if(remaining.substr(0,5) == "joy1_") {
 		Type = INP_JOYSTICK1;
 		Data = 0;
 
@@ -540,16 +587,16 @@ int CInput::Setup(const std::string& string)
 
 		// Go through the joystick list
 		for(uint32_t n=0; n<sizeof(Joysticks) / sizeof(joystick_t); n++) {
-			if(strcasecmp(Joysticks[n].text, string.c_str()) == 0) {
+			if(strcasecmp(Joysticks[n].text, remaining.c_str()) == 0) {
 				Data = Joysticks[n].value;
 				Extra = Joysticks[n].extra;
 				return true;
 			}
 		}
 	}
-	
+
 	// Check if it's a joystick #2
-	if(string.substr(0,5) == "joy2_") {
+	if(remaining.substr(0,5) == "joy2_") {
 		Type = INP_JOYSTICK2;
 		Data = 0;
 
@@ -562,7 +609,7 @@ int CInput::Setup(const std::string& string)
 
 		// Go through the joystick list
 		for(uint32_t n=0; n < sizeof(Joysticks) / sizeof(joystick_t); n++) {
-			if(strcasecmp(Joysticks[n].text, string.c_str()) == 0) {
+			if(strcasecmp(Joysticks[n].text, remaining.c_str()) == 0) {
 				Data = Joysticks[n].value;
 				Extra = Joysticks[n].extra;
 				return true;
@@ -578,7 +625,7 @@ int CInput::Setup(const std::string& string)
 
 	// Go through the key list checking with piece of text it was
 	for(uint32_t n=0; n < sizeof(Keys) / sizeof(keys_t); n++) {
-		if(strcasecmp(Keys[n].text, string.c_str()) == 0) {
+		if(strcasecmp(Keys[n].text, remaining.c_str()) == 0) {
 			Data = Keys[n].value;
 			return true;
 		}

--- a/src/client/InputEvents.cpp
+++ b/src/client/InputEvents.cpp
@@ -140,19 +140,29 @@ static void ResetCInputs() {
 }
 
 void HandleCInputs_KeyEvent(const KeyboardEvent& ev) {
-	for(std::set<CInput*>::iterator it = cInputs.begin(); it != cInputs.end(); it++)
-		if((*it)->isKeyboard() && (*it)->getData() == ev.sym) {
-			if(ev.down) {
-				(*it)->nDown++;
-				if(!(*it)->bDown) {
-					(*it)->nDownOnce++;
-					(*it)->bDown = true;
-				}
-			} else {
-				(*it)->bDown = false;
-				(*it)->nUp++;
-			}
+	for(std::set<CInput*>::iterator it = cInputs.begin(); it != cInputs.end(); it++) {
+		if(!(*it)->isKeyboard() || (*it)->getData() != ev.sym)
+			continue;
+		// If the binding requires specific modifiers, enforce an exact match.
+		// If no modifiers are required, fire regardless of modifier state (backward compat).
+		const ModifiersState& req = (*it)->m_modifiers;
+		if(req.bAlt || req.bCtrl || req.bShift || req.bGui) {
+			if(req.bAlt   != ev.state.bAlt)   continue;
+			if(req.bCtrl  != ev.state.bCtrl)  continue;
+			if(req.bShift != ev.state.bShift) continue;
+			if(req.bGui   != ev.state.bGui)   continue;
 		}
+		if(ev.down) {
+			(*it)->nDown++;
+			if(!(*it)->bDown) {
+				(*it)->nDownOnce++;
+				(*it)->bDown = true;
+			}
+		} else {
+			(*it)->bDown = false;
+			(*it)->nUp++;
+		}
+	}
 }
 
 void HandleCInputs_UpdateDownOnceForNonKeyboard() {

--- a/src/client/Options.cpp
+++ b/src/client/Options.cpp
@@ -49,7 +49,7 @@ const std::string    ply_def1[] =
 #endif
 const std::string    ply_def2[] = {"kp 8",  "kp 5",    "kp 4",    "kp 6",     "kp +", "kp enter", "kp 0", "kp -", "kp .", "6", "7", "8", "9", "0" };
 const std::string    gen_keys[] = {"Chat", "ShowScore", "ShowHealth", "ShowSettings",  "TakeScreenshot",  "ViewportManager", "SwitchMode", "ToggleTopBar", "TeamChat",	"IrcChat", "Console"};
-const std::string    gen_def[]  = {"i",    "tab",		"h",		  "space",	       "F12",				"F2",				 "F5",		   "F8",		   "o",			"F4",	"F3"};
+const std::string    gen_def[]  = {"i",    "tab",		"h",		  "space",	       "F12",				"F2",				 "alt+enter", "F8",		   "o",			"F4",	"F3"};
 
 static_assert( sizeof(ply_keys) / sizeof(std::string) == __SIN_PLY_BOTTOM, "ply_keys__sizecheck" );
 static_assert( sizeof(ply_def1) / sizeof(std::string) == __SIN_PLY_BOTTOM, "ply_def1__sizecheck" );


### PR DESCRIPTION
Add modifier key support to CInput and bind fullscreen toggle to Alt+Enter

Extend the CInput binding system to support modifier+key combinations
(e.g. "alt+enter", "ctrl+f") by parsing modifier prefixes in Setup() and
enforcing an exact modifier match in HandleCInputs_KeyEvent(). The options
UI (Wait()) now records modifier prefixes when the user assigns a binding.
Change the default SwitchMode binding from F5 to Alt+Enter, which is the
conventional fullscreen shortcut for most games, including the original Liero.

Other notable games that uses Alt+Enter for fullscreen toggle: Cuphead, 
Hearthstone, Subnautica, Rust, Escape from Tarkov, Cities: Skylines, 
Fortnite, Rocket League, BioShock Remastered and Borderlands series. 
Alt+Enter is the default for both Unity and Unreal Engine