### PR TITLE
Fix right viewport of broken split screen

### DIFF
--- a/src/gusanos/viewport.cpp
+++ b/src/gusanos/viewport.cpp
@@ -117,7 +117,7 @@ void CViewport::gusRender(const SmartPointer<SDL_Surface>& bmpDest)
 			setDestination(destw, desth);
 		
 		destroy_bitmap(dest);
-		dest = create_bitmap_from_sdl(bmpDest, Left/2, Top/2, Width*2, Height*2);
+		dest = create_bitmap_from_sdl(bmpDest, Left, Top, Width*2, Height*2);
 	}
 
 	{


### PR DESCRIPTION
I noticed the split screen mode is broken, has been broken for some versions.

I managed to pinpoint the problem and made a fix for it, so with this PR it works again

Before this PR:


<img width="300"  alt="Screenshot from 2026-04-06 15-30-52" src="https://github.com/user-attachments/assets/3e8f27cf-efc3-426a-962c-e0192efe8245" />


After this PR:

<img width="300" alt="Screenshot from 2026-04-06 15-29-42" src="https://github.com/user-attachments/assets/4028dc7a-7c87-4258-b9fe-9aa42f573c6c" />

### Reviewing this PR
Best way to review this PR, is build the master branch, and try two player split screen

Then switch to this branch, rebuild, and try to player split screen again

To see the difference

### How to run split screen in OpenLieroX

Just start a new game, and add two human players. "OpenLieroXor" and "The Second" are human players that are built into the game by default, so you can add them to a game and start.