### PR TITLE
Support modern SDL controller API, with D-pad and Triggers

### DIFF
--- a/include/CInput.h
+++ b/include/CInput.h
@@ -42,6 +42,9 @@
 #define		JOY_TURN_RIGHT		6
 #define		JOY_THROTTLE_LEFT	7
 #define		JOY_THROTTLE_RIGHT	8
+#define		JOY_HAT				9
+#define		JOY_TRIGGER_LEFT	10
+#define		JOY_TRIGGER_RIGHT	11
 
 struct KeyboardEvent;
 
@@ -60,7 +63,7 @@ private:
 
 	int		Type; // keyboard, mouse or joystick
 	int		Data;
-	int		Extra;
+	int		SdlIndex;
 	std::string m_EventName;
 	ModifiersState m_modifiers; // required modifier keys for keyboard bindings
 	bool	resetEachFrame;
@@ -90,7 +93,6 @@ public:
 	void	setResetEachFrame(bool r)	{ resetEachFrame = r; }
 	bool	getResetEachFrame()			{ return resetEachFrame; }
 	int		getJoystickValue();
-	bool	isJoystickAxis();
 	bool	isJoystickThrottle();
 
 	bool	isUp();
@@ -125,8 +127,7 @@ struct keys_t {
 struct joystick_t {
 	char	text[16];	// Keep string local to speed up lookup.
 	int		value;
-	int		extra;
-	int		axis;
+	int		sdl_index;
 };
 
 

--- a/src/client/AuxLib.cpp
+++ b/src/client/AuxLib.cpp
@@ -148,8 +148,8 @@ bool InitializeAuxLib()
 
 #ifndef DISABLE_JOYSTICK
 	if(bJoystickSupport) {
-		if(SDL_InitSubSystem(SDL_INIT_JOYSTICK) != 0) {
-			warnings << "WARNING: couldn't init joystick subystem: " << SDL_GetError() << endl;
+		if(SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) != 0) {
+			warnings << "WARNING: couldn't init gamecontroller/joystick subystem: " << SDL_GetError() << endl;
 			bJoystickSupport = false;
 		}
 	}

--- a/src/client/CInput.cpp
+++ b/src/client/CInput.cpp
@@ -187,213 +187,182 @@ void CInput::UnInitJoysticksTemp() {}
 
 #define HAVE_JOYSTICK
 
-// Joystick axes
-// TODO: these are set up according to my joystick, are they general enough?
-enum {
-	axis_None = -1,
-	axis_X = 0,
-	axis_Y = 1,
-	axis_Z = 3,
-	axis_Throttle = 2
-};
+// Analog stick deadzone (axes range -32768..32767)
+static const int JOY_DEADZONE = 8000;
+// Trigger threshold: triggers range 0..32767; fire at 75% travel
+static const int JOY_TRIGGER_THRESHOLD = 24576;
 
+// Binding table — maps config string to JOY_* flag and SDL constant (sdl_index).
+// Text names use SDL's naming: SDL_GameControllerGetStringForButton/Axis
+// For axes:    sdl_index = SDL_GameControllerAxis
+// For buttons: sdl_index = SDL_GameControllerButton
 joystick_t Joysticks[] = {
-	{ "joy1_up",JOY_UP,0, axis_Y},
-	{ "joy1_down",JOY_DOWN,0, axis_Y},
-	{ "joy1_left",JOY_LEFT,0, axis_X},
-	{ "joy1_right",JOY_RIGHT,0, axis_X},
-	{ "joy1_but1",JOY_BUTTON,0, axis_None},
-	{ "joy1_but2",JOY_BUTTON,1, axis_None},
-	{ "joy1_but3",JOY_BUTTON,2, axis_None},
-	{ "joy1_but4",JOY_BUTTON,3, axis_None},
-	{ "joy1_but5",JOY_BUTTON,4, axis_None},
-	{ "joy1_but6",JOY_BUTTON,5, axis_None},
-	{ "joy1_but7",JOY_BUTTON,6, axis_None},
-	{ "joy1_but8",JOY_BUTTON,7, axis_None},
-	{ "joy1_but9",JOY_BUTTON,8, axis_None},
-	{ "joy1_but10",JOY_BUTTON,9, axis_None},
-	{ "joy1_but11",JOY_BUTTON,10, axis_None},
-	{ "joy1_but12",JOY_BUTTON,11, axis_None},
-	{ "joy1_turnleft",JOY_TURN_LEFT,0, axis_Z},
-	{ "joy1_turnright",JOY_TURN_RIGHT,0, axis_Z},
-	{ "joy1_thr_up",JOY_THROTTLE_LEFT,0, axis_Throttle},
-	{ "joy1_thr_down",JOY_THROTTLE_RIGHT,0, axis_Throttle},
-	{ "joy2_up",JOY_UP,0, axis_Y},
-	{ "joy2_down",JOY_DOWN,0, axis_Y},
-	{ "joy2_left",JOY_LEFT,0, axis_X},
-	{ "joy2_right",JOY_RIGHT,0, axis_X},
-	{ "joy2_but1",JOY_BUTTON,0, axis_None},
-	{ "joy2_but2",JOY_BUTTON,1, axis_None},
-	{ "joy2_but3",JOY_BUTTON,2, axis_None},
-	{ "joy2_but4",JOY_BUTTON,3, axis_None},
-	{ "joy2_but5",JOY_BUTTON,4, axis_None},
-	{ "joy2_but6",JOY_BUTTON,5, axis_None},
-	{ "joy2_but7",JOY_BUTTON,6, axis_None},
-	{ "joy2_but8",JOY_BUTTON,7, axis_None},
-	{ "joy2_but9",JOY_BUTTON,8, axis_None},
-	{ "joy2_but10",JOY_BUTTON,9, axis_None},
-	{ "joy2_but11",JOY_BUTTON,10, axis_None},
-	{ "joy2_but12",JOY_BUTTON,11, axis_None},
-	{ "joy2_turnleft",JOY_TURN_LEFT,0, axis_Z},
-	{ "joy2_turnright",JOY_TURN_RIGHT,0, axis_Z},
-	{ "joy2_thr_up",JOY_THROTTLE_LEFT,0, axis_Throttle},
-	{ "joy2_thr_down",JOY_THROTTLE_RIGHT,0, axis_Throttle},
+	{ "j1_lefty_up",      JOY_UP,             SDL_CONTROLLER_AXIS_LEFTY},
+	{ "j1_lefty_down",    JOY_DOWN,           SDL_CONTROLLER_AXIS_LEFTY},
+	{ "j1_leftx_left",    JOY_LEFT,           SDL_CONTROLLER_AXIS_LEFTX},
+	{ "j1_leftx_right",   JOY_RIGHT,          SDL_CONTROLLER_AXIS_LEFTX},
+	{ "j1_button_south",  JOY_BUTTON,         SDL_CONTROLLER_BUTTON_A},
+	{ "j1_button_east",   JOY_BUTTON,         SDL_CONTROLLER_BUTTON_B},
+	{ "j1_button_west",   JOY_BUTTON,         SDL_CONTROLLER_BUTTON_X},
+	{ "j1_button_north",  JOY_BUTTON,         SDL_CONTROLLER_BUTTON_Y},
+	{ "j1_back",          JOY_BUTTON,         SDL_CONTROLLER_BUTTON_BACK},
+	{ "j1_guide",         JOY_BUTTON,         SDL_CONTROLLER_BUTTON_GUIDE},
+	{ "j1_start",         JOY_BUTTON,         SDL_CONTROLLER_BUTTON_START},
+	{ "j1_leftstick",     JOY_BUTTON,         SDL_CONTROLLER_BUTTON_LEFTSTICK},
+	{ "j1_rightstick",    JOY_BUTTON,         SDL_CONTROLLER_BUTTON_RIGHTSTICK},
+	{ "j1_lshoulder",     JOY_BUTTON,         SDL_CONTROLLER_BUTTON_LEFTSHOULDER},
+	{ "j1_rshoulder",     JOY_BUTTON,         SDL_CONTROLLER_BUTTON_RIGHTSHOULDER},
+	{ "j1_rightx_left",   JOY_TURN_LEFT,      SDL_CONTROLLER_AXIS_RIGHTX},
+	{ "j1_rightx_right",  JOY_TURN_RIGHT,     SDL_CONTROLLER_AXIS_RIGHTX},
+	{ "j1_righty_up",     JOY_THROTTLE_LEFT,  SDL_CONTROLLER_AXIS_RIGHTY},
+	{ "j1_righty_down",   JOY_THROTTLE_RIGHT, SDL_CONTROLLER_AXIS_RIGHTY},
+	{ "j1_d_up",          JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_UP},
+	{ "j1_d_down",        JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_DOWN},
+	{ "j1_d_left",        JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_LEFT},
+	{ "j1_d_right",       JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_RIGHT},
+	{ "j1_triggerleft",   JOY_TRIGGER_LEFT,   SDL_CONTROLLER_AXIS_TRIGGERLEFT},
+	{ "j1_triggerright",  JOY_TRIGGER_RIGHT,  SDL_CONTROLLER_AXIS_TRIGGERRIGHT},
+	{ "j2_lefty_up",      JOY_UP,             SDL_CONTROLLER_AXIS_LEFTY},
+	{ "j2_lefty_down",    JOY_DOWN,           SDL_CONTROLLER_AXIS_LEFTY},
+	{ "j2_leftx_left",    JOY_LEFT,           SDL_CONTROLLER_AXIS_LEFTX},
+	{ "j2_leftx_right",   JOY_RIGHT,          SDL_CONTROLLER_AXIS_LEFTX},
+	{ "j2_button_south",  JOY_BUTTON,         SDL_CONTROLLER_BUTTON_A},
+	{ "j2_button_east",   JOY_BUTTON,         SDL_CONTROLLER_BUTTON_B},
+	{ "j2_button_west",   JOY_BUTTON,         SDL_CONTROLLER_BUTTON_X},
+	{ "j2_button_north",  JOY_BUTTON,         SDL_CONTROLLER_BUTTON_Y},
+	{ "j2_back",          JOY_BUTTON,         SDL_CONTROLLER_BUTTON_BACK},
+	{ "j2_guide",         JOY_BUTTON,         SDL_CONTROLLER_BUTTON_GUIDE},
+	{ "j2_start",         JOY_BUTTON,         SDL_CONTROLLER_BUTTON_START},
+	{ "j2_leftstick",     JOY_BUTTON,         SDL_CONTROLLER_BUTTON_LEFTSTICK},
+	{ "j2_rightstick",    JOY_BUTTON,         SDL_CONTROLLER_BUTTON_RIGHTSTICK},
+	{ "j2_lshoulder",     JOY_BUTTON,         SDL_CONTROLLER_BUTTON_LEFTSHOULDER},
+	{ "j2_rshoulder",     JOY_BUTTON,         SDL_CONTROLLER_BUTTON_RIGHTSHOULDER},
+	{ "j2_rightx_left",   JOY_TURN_LEFT,      SDL_CONTROLLER_AXIS_RIGHTX},
+	{ "j2_rightx_right",  JOY_TURN_RIGHT,     SDL_CONTROLLER_AXIS_RIGHTX},
+	{ "j2_righty_up",     JOY_THROTTLE_LEFT,  SDL_CONTROLLER_AXIS_RIGHTY},
+	{ "j2_righty_down",   JOY_THROTTLE_RIGHT, SDL_CONTROLLER_AXIS_RIGHTY},
+	{ "j2_d_up",          JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_UP},
+	{ "j2_d_down",        JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_DOWN},
+	{ "j2_d_left",        JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_LEFT},
+	{ "j2_d_right",       JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_RIGHT},
+	{ "j2_triggerleft",   JOY_TRIGGER_LEFT,   SDL_CONTROLLER_AXIS_TRIGGERLEFT},
+	{ "j2_triggerright",  JOY_TRIGGER_RIGHT,  SDL_CONTROLLER_AXIS_TRIGGERRIGHT},
 };
 
-static SDL_Joystick* joys[2] = {NULL, NULL};
-static short oldJoystickAxisValues[2][4]; // Used for checking if any of the joystick axes changed its value
+static SDL_GameController* controllers[2] = {NULL, NULL};
 
-///////////////////
-// Updates the oldJoystickAcisValues array
-void updateAxisStates()
-{
-	for (size_t i = 0; i < sizeof(joys)/sizeof(SDL_Joystick *); i++)  {
-		oldJoystickAxisValues[i][axis_X] = SDL_JoystickGetAxis(joys[i], axis_X);
-		oldJoystickAxisValues[i][axis_Y] = SDL_JoystickGetAxis(joys[i], axis_Y);
-		oldJoystickAxisValues[i][axis_Z] = SDL_JoystickGetAxis(joys[i], axis_Z);
-		oldJoystickAxisValues[i][axis_Throttle] = SDL_JoystickGetAxis(joys[i], axis_Throttle);
-	}
-}
+// Called each frame by the event loop — nothing to snapshot with the GameController API
+void updateAxisStates() {}
 
-static int getJoystickControlValue(int flag, int extra, SDL_Joystick* joy)
+static int getControllerValue(int flag, int sdl_index, int idx)
 {
+	SDL_GameController *gc = controllers[idx];
+	if(!gc) return 0;
+
 	switch(flag) {
 		case JOY_UP:
-			return SDL_JoystickGetAxis(joy, axis_Y);
 		case JOY_DOWN:
-			return SDL_JoystickGetAxis(joy, axis_Y);
 		case JOY_LEFT:
-			return SDL_JoystickGetAxis(joy, axis_X);
 		case JOY_RIGHT:
-			return SDL_JoystickGetAxis(joy, axis_X);
-		case JOY_BUTTON:
-			return SDL_JoystickGetButton(joy, extra);
 		case JOY_TURN_LEFT:
-			return SDL_JoystickGetAxis(joy, axis_Z);
 		case JOY_TURN_RIGHT:
-			return SDL_JoystickGetAxis(joy, axis_Z);
 		case JOY_THROTTLE_LEFT:
-			return SDL_JoystickGetAxis(joy, axis_Throttle);
 		case JOY_THROTTLE_RIGHT:
-			return SDL_JoystickGetAxis(joy, axis_Throttle);
-
+		case JOY_TRIGGER_LEFT:
+		case JOY_TRIGGER_RIGHT:
+			return SDL_GameControllerGetAxis(gc, (SDL_GameControllerAxis)sdl_index);
+		case JOY_BUTTON:
+		case JOY_HAT:
+			return SDL_GameControllerGetButton(gc, (SDL_GameControllerButton)sdl_index);
 		default:
-			warnings << "getJoystickValue: unknown flag" << endl;
+			warnings << "getControllerValue: unknown flag" << endl;
 	}
-
 	return 0;
 }
 
-static bool checkJoystickState(int flag, int extra, int j_index) {
-	SDL_Joystick *joy = joys[j_index];
+static bool checkControllerState(int flag, int sdl_index, int idx)
+{
 	if(!bJoystickSupport) return false;
-	if(joy == NULL) return false;
+	SDL_GameController *gc = controllers[idx];
+	if(!gc) return false;
 
-	int val;
-
-	// TODO: atm these limits are hardcoded; make them constants (or perhaps also configurable)
 	switch(flag) {
 		case JOY_UP:
-			val = SDL_JoystickGetAxis(joy, axis_Y);
-			if(val < -3200)
-				return true;
-			break;
-		case JOY_DOWN:
-			val = SDL_JoystickGetAxis(joy, axis_Y);
-			if(val > 3200)
-				return true;
-			break;
 		case JOY_LEFT:
-			val = SDL_JoystickGetAxis(joy, axis_X);
-			if(val < -3200)
-				return true;
-			break;
-		case JOY_RIGHT:
-			val = SDL_JoystickGetAxis(joy, axis_X);
-			if(val > 3200)
-				return true;
-			break;
-		case JOY_BUTTON:
-			if(SDL_JoystickGetButton(joy,extra))
-				return true;
-			break;
 		case JOY_TURN_LEFT:
-			val = SDL_JoystickGetAxis(joy, axis_Z);
-			if (val < -3200)
-				return true;
-			break;
-		case JOY_TURN_RIGHT:
-			val = SDL_JoystickGetAxis(joy, axis_Z);
-			if (val > 3200)
-				return true;
-			break;
-
-		// HINT: throttle is "static", i.e. it doesn't return back to a default position
-		// Therefore we check if the value has changed instead of getting the state
 		case JOY_THROTTLE_LEFT:
-			if (SDL_JoystickGetAxis(joy, axis_Throttle) - oldJoystickAxisValues[j_index][axis_Throttle] < -50)
-				return true;
-			break;
+			return SDL_GameControllerGetAxis(gc, (SDL_GameControllerAxis)sdl_index) < -JOY_DEADZONE;
+		case JOY_DOWN:
+		case JOY_RIGHT:
+		case JOY_TURN_RIGHT:
 		case JOY_THROTTLE_RIGHT:
-			if (SDL_JoystickGetAxis(joy, axis_Throttle) - oldJoystickAxisValues[j_index][axis_Throttle] > 50)
-				return true;
-			break;
-
+			return SDL_GameControllerGetAxis(gc, (SDL_GameControllerAxis)sdl_index) >  JOY_DEADZONE;
+		case JOY_TRIGGER_LEFT:
+		case JOY_TRIGGER_RIGHT:
+			return SDL_GameControllerGetAxis(gc, (SDL_GameControllerAxis)sdl_index) > JOY_TRIGGER_THRESHOLD;
+		case JOY_BUTTON:
+		case JOY_HAT:
+			return SDL_GameControllerGetButton(gc, (SDL_GameControllerButton)sdl_index) != 0;
 		default:
-			warnings << "checkJoystickState: unknown flag" << endl;
+			warnings << "checkControllerState: unknown flag" << endl;
 	}
-
-
 	return false;
 }
 
-static bool joysticks_inited_temp[2] = {false, false};
+static bool controllers_inited_temp[2] = {false, false};
 
-static void initJoystick(int i, bool isTemp) {
+static void initController(int i, bool isTemp) {
 	assert(i == 0 || i == 1);
 	if(!bJoystickSupport) return;
+	if(controllers[i] != NULL) return;
+	if(SDL_NumJoysticks() <= i) return;
 
-	if(joys[i] == NULL && SDL_NumJoysticks() > i) {
-		notes << "opening joystick " << i << endl;
-		notes << " (\"" << SDL_JoystickNameForIndex(i) << "\")" << endl;
-		joys[i] = SDL_JoystickOpen(i);
-		if(joys[i]) {
-			notes << "  Number of Axes: " << SDL_JoystickNumAxes(joys[i]) << endl;
-			notes << "  Number of Buttons: " << SDL_JoystickNumButtons(joys[i]) << endl;
-			notes << "  Number of Balls: " << SDL_JoystickNumBalls(joys[i]) << endl;
-			if(isTemp) joysticks_inited_temp[i] = true;
-		} else
-			warnings << "Could not open joystick" << endl;
+	const char* name = SDL_GameControllerNameForIndex(i);
+	notes << "opening controller " << i << " (\"" << (name ? name : "unknown") << "\")" << endl;
+
+	if(!SDL_IsGameController(i)) {
+		warnings << "  Device is not a recognised SDL GameController — skipping" << endl;
+		return;
 	}
 
-	// Save the initial axis values
-	SDL_Delay(40); // Small hack: this little delay is needed here for the joysticks to initialize correctly (bug in SDL?)
-	SDL_JoystickUpdate();
-	updateAxisStates();
+	controllers[i] = SDL_GameControllerOpen(i);
+	if(!controllers[i]) {
+		warnings << "  Could not open game controller: " << SDL_GetError() << endl;
+		return;
+	}
 
-	if(!isTemp) joysticks_inited_temp[i] = false;
+	SDL_Joystick* joy = SDL_GameControllerGetJoystick(controllers[i]);
+	notes << "  Axes: "    << SDL_JoystickNumAxes(joy)    << endl;
+	notes << "  Buttons: " << SDL_JoystickNumButtons(joy) << endl;
+	notes << "  Hats: "    << SDL_JoystickNumHats(joy)    << endl;
+
+	if(isTemp) controllers_inited_temp[i] = true;
+
+	// Small delay needed for the controller to initialise correctly (SDL bug workaround)
+	SDL_Delay(40);
+	SDL_GameControllerUpdate();
 }
 
 void CInput::InitJoysticksTemp() {
 	if(!bJoystickSupport) return;
-	notes << "Initing joysticks temporary..." << endl;
-	notes << "Amout of available joysticks: " << SDL_NumJoysticks() << endl;
-	initJoystick(0, true);
-	initJoystick(1, true);
+	notes << "Initing controllers temporary..." << endl;
+	notes << "Available joysticks: " << SDL_NumJoysticks() << endl;
+	initController(0, true);
+	initController(1, true);
 }
 
-static void uninitTempJoystick(int i) {
-	if(joysticks_inited_temp[i]) {
-		notes << "Uninit temporary loaded joystick " << i << endl;
-		SDL_JoystickClose(joys[i]);
-		joys[i] = NULL;
-		joysticks_inited_temp[i] = false;
+static void uninitTempController(int i) {
+	if(controllers_inited_temp[i]) {
+		notes << "Uninit temporary controller " << i << endl;
+		SDL_GameControllerClose(controllers[i]);
+		controllers[i] = NULL;
+		controllers_inited_temp[i] = false;
 	}
 }
 
 void CInput::UnInitJoysticksTemp() {
-	uninitTempJoystick(0);
-	uninitTempJoystick(1);
+	uninitTempController(0);
+	uninitTempController(1);
 }
 
 #endif // !DEDICATED_ONLY
@@ -406,7 +375,7 @@ void CInput::UnInitJoysticksTemp() {
 CInput::CInput() {
 	Type = INP_NOTUSED;
 	Data = 0;
-	Extra = 0;
+	SdlIndex = 0;
 	resetEachFrame = true;
 	bDown = false;
 	reset();
@@ -494,13 +463,12 @@ int CInput::Wait(std::string& strText)
 	}
 
 #ifdef HAVE_JOYSTICK
-	// joystick
-	// TODO: more joysticks
+	// controller
+	// TODO: more controllers
 	for(uint n = 0; n < sizeof(Joysticks) / sizeof(joystick_t); n++) {
-		int i = Joysticks[n].text[3] - '1'; // at pos 3, there is the number ("joy1_...")
+		int i = Joysticks[n].text[1] - '1'; // at pos 1, there is the number ("j1_...")
 
-		// Check if any of the axes has been moved or a button press occured
-		if(joys[i] != NULL && checkJoystickState(Joysticks[n].value, Joysticks[n].extra, i)) {
+		if(controllers[i] != NULL && checkControllerState(Joysticks[n].value, Joysticks[n].sdl_index, i)) {
 			strText = Joysticks[n].text;
 			return true;
 		}
@@ -572,7 +540,7 @@ int CInput::Setup(const std::string& string)
 #ifdef HAVE_JOYSTICK
 	// Check if it's a joystick #1
 	// TODO: allow more joysticks
-	if(remaining.substr(0,5) == "joy1_") {
+	if(remaining.substr(0,3) == "j1_") {
 		Type = INP_JOYSTICK1;
 		Data = 0;
 
@@ -582,21 +550,21 @@ int CInput::Setup(const std::string& string)
 			return false;
 		}
 
-		// Open the joystick if it hasn't been already opened
-		initJoystick(0, false);
+		// Open the controller if it hasn't been already opened
+		initController(0, false);
 
 		// Go through the joystick list
 		for(uint32_t n=0; n<sizeof(Joysticks) / sizeof(joystick_t); n++) {
 			if(strcasecmp(Joysticks[n].text, remaining.c_str()) == 0) {
 				Data = Joysticks[n].value;
-				Extra = Joysticks[n].extra;
+				SdlIndex = Joysticks[n].sdl_index;
 				return true;
 			}
 		}
 	}
 
 	// Check if it's a joystick #2
-	if(remaining.substr(0,5) == "joy2_") {
+	if(remaining.substr(0,3) == "j2_") {
 		Type = INP_JOYSTICK2;
 		Data = 0;
 
@@ -604,14 +572,14 @@ int CInput::Setup(const std::string& string)
 		if(SDL_NumJoysticks()<=1)
 			return false;
 
-		// Open the joystick if it hasn't been already opened
-		initJoystick(1, false);
+		// Open the controller if it hasn't been already opened
+		initController(1, false);
 
 		// Go through the joystick list
 		for(uint32_t n=0; n < sizeof(Joysticks) / sizeof(joystick_t); n++) {
 			if(strcasecmp(Joysticks[n].text, remaining.c_str()) == 0) {
 				Data = Joysticks[n].value;
-				Extra = Joysticks[n].extra;
+				SdlIndex = Joysticks[n].sdl_index;
 				return true;
 			}
 		}
@@ -641,9 +609,9 @@ int CInput::getJoystickValue()
 #ifdef HAVE_JOYSTICK
 	switch (Type)  {
 	case INP_JOYSTICK1:
-		return getJoystickControlValue(Data, Extra, joys[0]);
+		return getControllerValue(Data, SdlIndex, 0);
 	case INP_JOYSTICK2:
-		return getJoystickControlValue(Data, Extra, joys[1]);
+		return getControllerValue(Data, SdlIndex, 1);
 	default:
 		return 0;
 	}
@@ -651,16 +619,6 @@ int CInput::getJoystickValue()
 	return 0;
 }
 
-/////////////////////
-// Returns true if this input is a joystick axis
-bool CInput::isJoystickAxis()
-{
-#ifdef HAVE_JOYSTICK
-	if (Type == INP_JOYSTICK1 || Type == INP_JOYSTICK2)
-		return Data != JOY_BUTTON;
-#endif
-	return false;
-}
 
 ////////////////////
 // Returns true if this joystick is a throttle
@@ -725,9 +683,9 @@ bool CInput::isDown() const
 #ifdef HAVE_JOYSTICK
 		// Joystick
 		case INP_JOYSTICK1:
-			return checkJoystickState(Data, Extra, 0);
+			return checkControllerState(Data, SdlIndex, 0);
 		case INP_JOYSTICK2:
-			return checkJoystickState(Data, Extra, 1);
+			return checkControllerState(Data, SdlIndex, 1);
 #endif
 	}
 

--- a/src/client/InputEvents.cpp
+++ b/src/client/InputEvents.cpp
@@ -577,7 +577,7 @@ void ProcessEvents()
 #ifndef DEDICATED_ONLY
 #ifndef DISABLE_JOYSTICK
 		if(bJoystickSupport)  {
-			SDL_JoystickUpdate();
+			SDL_GameControllerUpdate();
 			updateAxisStates();
 		}
 #endif


### PR DESCRIPTION
## Support modern SDL controller API

In this PR:
+ Change to more modern SDL_CONTROLLER instead of SDL_JOYSTICK
+ Supports D-Pad (also called HAT buttons)
+ Support trigger buttons

Background
Long time ago, like before 2010 there was no standardization of game controllers. Now they have been standardized so that almost all of them use 2 sticks, 1 D-pad, 4 buttons, 2 bumpers and 2 triggers. Examples are:  Xbox (all generations), Playstation(everything since playstation 2) and Also Nintendo pro controllers do, and basicly all third party controllers.  SDL_JOYSTICK API reflects how controllers worked pre 2010, while SDL_CONTROLLER is the newer and reflects how post 2010 controllers works, with all their standard functionality.

I have personally tested this PR with:
* Xbox 360 controller
* Playstation 5 controller
* Stadia conroller
* 8bit do controller
* Steam Deck

And they all worked perfect

Demo of me running this PR to conrol OpenLieroX on Steam Deck
https://youtu.be/kSgRiVeeh94

Here is the open source database that SDL use for mapping different controls for SDL_CONTROLLER
https://github.com/mdqinc/SDL_GameControllerDB

Read more about the SDL Controller API
https://blog.rubenwardy.com/2023/01/24/using_sdl_gamecontroller/

To review this PR, please build it locally, and try it out with the controllers you have at home, Especially try the D-pad and the Triggers, as they are new to be supported.
