### PR TITLE
[work in progress] Add .deb build on github actions

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+cd $(dirname $0)"/../.."
+cmake -S . -B build-output -DCMAKE_BUILD_TYPE=Release -DHAWKNL_BUILTIN=Yes
+mkdir -p build-output/bin
+cmake --build build-output -j$(nproc)

--- a/.github/workflows/package-deb.sh
+++ b/.github/workflows/package-deb.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Build a .deb package from an already-compiled openlierox binary.
+#
+# Inputs (env):
+#   BUILD_DIR - cmake build directory (default: build)
+#
+# Output: openlierox_<version>_<arch>.deb in the current directory.
+
+set -euo pipefail
+
+cd $(dirname $0)"/../.."
+REPO_ROOT=$(pwd)
+
+BUILD_DIR=./build-output
+BINARY="$BUILD_DIR/bin/openlierox"
+
+if [ ! -x "$BINARY" ]; then
+    echo "ERROR: $BINARY not found — build the project first" >&2
+    exit 1
+fi
+
+
+STAGE="$REPO_ROOT/deb-stage"
+rm -rf "$STAGE"
+mkdir -p \
+    "$STAGE/DEBIAN" \
+    "$STAGE/usr/games" \
+    "$STAGE/usr/share/games" \
+    "$STAGE/usr/share/doc" \
+    "$STAGE/usr/share/applications" \
+    "$STAGE/usr/share/pixmaps" \
+    "$STAGE/usr/share/icons/hicolor/scalable/apps" \
+    "$STAGE/usr/share/icons/hicolor/128x128/apps" \
+    "$STAGE/usr/share/icons/hicolor/32x32/apps" \
+    "$STAGE/usr/share/icons/hicolor/16x16/apps"
+
+# install.sh looks for bin/openlierox in cwd; point it at the build output.
+rm -rf "$REPO_ROOT/bin"
+mkdir -p "$REPO_ROOT/bin"
+cp "$BINARY" "$REPO_ROOT/bin/openlierox"
+
+PREFIX="$STAGE" \
+BIN_DIR=usr/games \
+SYSTEM_DATA_DIR=usr/share/games \
+DOC_DIR=usr/share/doc \
+    ./install.sh
+
+install -m 644 share/OpenLieroX.xpm     "$STAGE/usr/share/pixmaps/"
+install -m 644 share/OpenLieroX.svg     "$STAGE/usr/share/icons/hicolor/scalable/apps/"
+install -m 644 share/OpenLieroX.128.png "$STAGE/usr/share/icons/hicolor/128x128/apps/"
+install -m 644 share/OpenLieroX.32.png  "$STAGE/usr/share/icons/hicolor/32x32/apps/"
+install -m 644 share/OpenLieroX.16.png  "$STAGE/usr/share/icons/hicolor/16x16/apps/"
+install -m 644 debian/openlierox.desktop "$STAGE/usr/share/applications/"
+
+# Auto-compute runtime deps from the linked ELF. dpkg-shlibdeps reads
+# debian/control (which exists at the repo root) to learn the package name.
+DEPS="$(dpkg-shlibdeps -O --ignore-missing-info "$BINARY" \
+        | sed 's/^shlibs:Depends=//')"
+if [ -z "$DEPS" ]; then
+    echo "ERROR: dpkg-shlibdeps produced no Depends line" >&2
+    exit 1
+fi
+
+# dpkg version strings can't contain underscores; use tilde so "beta"
+# sorts before the final release.
+VERSION="$(tr '_' '~' < VERSION)"
+ARCH="$(dpkg --print-architecture)"
+INSTALLED_SIZE="$(du -sk "$STAGE" | cut -f1)"
+
+cat > "$STAGE/DEBIAN/control" <<EOF
+Package: openlierox
+Version: $VERSION
+Section: games
+Priority: optional
+Architecture: $ARCH
+Installed-Size: $INSTALLED_SIZE
+Maintainer: OpenLieroX CI <noreply@openlierox.net>
+Depends: $DEPS
+Homepage: https://openlierox.net
+Description: a real-time excessive Worms-clone with network support
+ Remake of the original Liero game with network support,
+ better graphics and many maps and mods.
+EOF
+
+DEB="openlierox_${VERSION}_${ARCH}.deb"
+dpkg-deb --build --root-owner-group "$STAGE" "$REPO_ROOT/$DEB"
+echo ">>> built $DEB"

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -1,0 +1,56 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 0.59
+
+jobs:
+  build-linux:
+    name: Build (Ubuntu 24.04)
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            build-essential \
+            dpkg-dev \
+            libsdl2-dev \
+            libsdl2-image-dev \
+            libsdl2-mixer-dev \
+            libxml2-dev \
+            libgd-dev \
+            zlib1g-dev \
+            libzip-dev \
+            libx11-dev \
+            libcurl4-openssl-dev \
+            libboost-dev \
+            libopenal-dev \
+            libalut-dev \
+            libvorbis-dev \
+            binutils-dev \
+            libiberty-dev
+
+      - name: Build
+        run: |
+          ./.github/workflows/build.sh
+
+      - name: Package (.deb)
+        run: ./.github/workflows/package-deb.sh
+
+      - name: Upload .deb
+        uses: actions/upload-artifact@v4
+        with:
+          name: openlierox-deb
+          path: openlierox_*.deb
+          if-no-files-found: error


### PR DESCRIPTION
Builds .deb packages wth Github actoins. 

### Benifits:

1. Easier to detect if we accidently break the code
2. Easier to detect if we accidently break debian packaging
3. Reproducable packaging (same every time)
4. Easier to tests PRs locally when reviewing them

### Downsides:
1. Not much, it takes some time to run the Github action job, but it runs in the background with zero human intervention needed, so does not add much extra burden. It is probably not a good idea to merge a PR anyway before it has been varified that it can build properly

### Testing it locally
The build pipeline can also be runed locally for those who want to debug it
```
./.github/workflows/build.sh
./.github/workflows/package-deb.sh
```

### 
See output from existing jobs:


https://github.com/openlierox/openlierox/actions/runs/24469760186


<img width="892" height="482" alt="Screenshot from 2026-04-15 20-04-23" src="https://github.com/user-attachments/assets/64c95284-02ac-4c2f-95f3-03511c573e88" />
