### PR TITLE
Build cross distribution linux bundle on github-actions

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+cd $(dirname $0)"/../.."
+cmake -S . -B build-output -DCMAKE_BUILD_TYPE=Release -DHAWKNL_BUILTIN=Yes
+mkdir -p build-output/bin
+cmake --build build-output -j$(nproc)

--- a/.github/workflows/package-linux-bundle.sh
+++ b/.github/workflows/package-linux-bundle.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+cd $(dirname $0)"/../.."
+
+PACKAGE_NAME="openlierox-$(./get_version.sh)-linux-bundle"
+PACKAGE_DIR="distrib/"$PACKAGE_NAME
+
+rm -Rf $PACKAGE_DIR
+mkdir -p $PACKAGE_DIR
+cp build-output/bin/openlierox $PACKAGE_DIR
+cp -av share/gamedir $PACKAGE_DIR/gamedir
+
+# Copy all .so files this binary was built for, to make a self contained bundle
+mkdir -p $PACKAGE_DIR/lib
+ldd $PACKAGE_DIR/openlierox | grep -v "libc.so*" | grep "=> /" | awk '{print $3}' | xargs -I '{}' cp -v '{}' $PACKAGE_DIR/lib/
+
+cd $PACKAGE_DIR
+
+# Patch openlierox binary to use local lib/ folder
+patchelf --set-rpath '$ORIGIN/lib' --force-rpath openlierox
+
+# Patch libraries to use local lib/ folder for transitive dependencies
+patchelf --set-rpath '$ORIGIN' --force-rpath ./lib/*.so*

--- a/.github/workflows/package-linux-bundle.yml
+++ b/.github/workflows/package-linux-bundle.yml
@@ -1,0 +1,62 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 0.59
+
+jobs:
+  build-linux:
+    name: Build Linux-bundle
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            build-essential \
+            patchelf \
+            dpkg-dev \
+            libsdl2-dev \
+            libsdl2-image-dev \
+            libsdl2-mixer-dev \
+            libxml2-dev \
+            libgd-dev \
+            zlib1g-dev \
+            libzip-dev \
+            libx11-dev \
+            libcurl4-openssl-dev \
+            libboost-dev \
+            libopenal-dev \
+            libalut-dev \
+            libvorbis-dev \
+            binutils-dev \
+            libiberty-dev
+
+      - name: Build
+        run: |
+          ./.github/workflows/build.sh
+
+      - name: Package
+        run: ./.github/workflows/package-linux-bundle.sh
+
+      - name: Detect bundle filename
+        id: bundle
+        run: echo "name=$(basename distrib/openlierox-*-linux-bundle*)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload openlierox-linux-bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.bundle.outputs.name }}
+          path: distrib/openlierox-*-linux-bundle*
+          if-no-files-found: error

--- a/src/common/FindFile.cpp
+++ b/src/common/FindFile.cpp
@@ -484,6 +484,7 @@ void InitBaseSearchPaths() {
 	AddToFileList(&basesearchpaths, "${HOME}/.OpenLieroX");
 	AddToFileList(&basesearchpaths, ".");
 	AddToFileList(&basesearchpaths, SYSTEM_DATA_DIR"/OpenLieroX"); // no use of ${SYSTEM_DATA}, because it is uncommon and could cause confusion to the user
+	AddToFileList(&basesearchpaths, "${BIN}/gamedir");
 #endif
 }
 


### PR DESCRIPTION
Builds a bundle (zipped file containing all necessary files) that can just be unzipped and run on Linux. Should work across all common distributions

The bundle this PR produces is tested and work out of the box on:
 * Debian 13
 * Ubuntu 24.04
 * Ubuntu 25.10
 * Steam OS (based on Arch Linux)
 * Fedora Workstatoin 43 (Red Hat RPM based)
 
 No dependencies needs to be installed on any of the above platforms, since all dependencies are self contained in the bundle
 
 Packaging binaries together with all the .so files they were compiled for is common practice for cross-linux-distribution bundles.  Same is done for the main Linux downloads for [Firefox](https://getfirefox.com/) and [Blender3D](https://www.blender.org/) among others. 
 
 Here is a demo of how easy it is to get running on a newly installed Fedora 43, with no specific dependencies installed at all:
 
 
<img width="1268" height="888" alt="Linux bundle on Fodoroa Demo" src="https://github.com/user-attachments/assets/4c137a6f-22c0-4634-970d-d9d0b74ecb88" />

Link to [build](https://github.com/openlierox/openlierox/actions/runs/24520232155)
