### PR TITLE
Build mac.app bundle on github actions

### DIFF
--- a/.github/workflows/package-mac.yml
+++ b/.github/workflows/package-mac.yml
@@ -1,0 +1,84 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 0.59
+
+jobs:
+  build-macos:
+    name: Build macOS .app (Homebrew)
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install \
+            ninja \
+            pkg-config \
+            sdl2 \
+            sdl2_image \
+            sdl2_mixer \
+            libzip \
+            gd \
+            libvorbis \
+            freealut \
+            openal-soft \
+            boost \
+            dylibbundler
+
+      - name: Install CMake 3.x
+        # The repo's CMakeLists use cmake_policy(SET CMP0003 OLD) etc.,
+        # which CMake 4.x no longer supports. Pin to the last 3.x release.
+        run: |
+          CMAKE_VERSION=3.31.6
+          curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-macos-universal.tar.gz" -o /tmp/cmake.tgz
+          mkdir -p /tmp/cmake
+          tar -xzf /tmp/cmake.tgz -C /tmp/cmake --strip-components=1
+          echo "/tmp/cmake/CMake.app/Contents/bin" >> "$GITHUB_PATH"
+
+      - name: Configure
+        run: |
+          # Homebrew keeps libxml2 and openal-soft keg-only because macOS
+          # ships its own/legacy versions, so expose their .pc files to
+          # pkg-config.
+          LIBXML2_PREFIX="$(brew --prefix libxml2)"
+          OPENAL_PREFIX="$(brew --prefix openal-soft)"
+          export PKG_CONFIG_PATH="${LIBXML2_PREFIX}/lib/pkgconfig:${OPENAL_PREFIX}/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+          cmake --version
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DHAWKNL_BUILTIN=Yes \
+            -DLIBZIP_BUILTIN=No \
+            -DLIBLUA_BUILTIN=Yes \
+            -DBREAKPAD=No \
+            -DHASBFD=No \
+            -DDEBUG=No
+
+      - name: Build
+        run: |
+          mkdir -p build/bin
+          cmake --build build -j$(sysctl -n hw.ncpu)
+
+      - name: Package (.app)
+        run: ./package-macos.sh
+
+      - name: Detect bundle filename
+        id: bundle
+        run: echo "name=$(basename openlierox_*_macos.zip)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload openlierox-macos
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.bundle.outputs.name }}
+          path: openlierox_*_macos.zip
+          if-no-files-found: error

--- a/CMakeOlxCommon.cmake
+++ b/CMakeOlxCommon.cmake
@@ -61,6 +61,11 @@ IF(UNIX)
 		SET(LIBLUA_BUILTIN ON)
 		SET(X11 OFF)
 		#SET(BOOST_LINK_STATIC ON)
+		# libbfd isn't available by default on macOS.
+		SET(HASBFD OFF)
+		# Use the plain int main() from src/main.cpp — the legacy
+		# src/MacMain.m SDL1 entry point is not part of the cmake build.
+		ADD_DEFINITIONS(-DOLX_USE_STD_MAIN)
 	ENDIF(APPLE)
 
 	IF (CYGWIN)
@@ -135,9 +140,13 @@ ENDIF(NOT WIN32 AND NOT MINGW_CROSS_COMPILE)
 
 file(GLOB_RECURSE ALL_SRCS ${OLXROOTDIR}/src/*.c*)
 
+# The legacy src/MacMain.m is SDL 1.x specific and only used by the
+# old build/Xcode project. The cmake build uses SDL2 and provides its
+# own main() via OLX_USE_STD_MAIN, plus a trimmed Cocoa helper file
+# (src/MacHelpers.m) for clipboard and user-attention shims.
 IF(APPLE)
-	file(GLOB_RECURSE MAC_SRCS ${OLXROOTDIR}/src/*.m*)
-	SET(ALL_SRCS ${MAC_SRCS} ${ALL_SRCS})
+	enable_language(OBJC)
+	SET(ALL_SRCS ${OLXROOTDIR}/src/MacHelpers.m ${ALL_SRCS})
 ENDIF(APPLE)
 
 IF (BREAKPAD)
@@ -265,7 +274,8 @@ IF(WIN32)
 				${OLXROOTDIR}/libs/boost_process)
 ELSE(WIN32)
 	ADD_DEFINITIONS(-Wall)
-	ADD_DEFINITIONS("-std=c++0x")
+	# -std= belongs to CXX only — AppleClang rejects it for C sources.
+	add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-std=c++0x>")
 
 	EXEC_PROGRAM(sh ARGS ${CMAKE_CURRENT_SOURCE_DIR}/get_version.sh OUTPUT_VARIABLE OLXVER)
 	string(REGEX REPLACE "[\r\n]" " " OLXVER "${OLXVER}")
@@ -299,13 +309,39 @@ ENDIF(OPTIM_PROJECTILES)
 # SDL libs
 IF(WIN32)
 ELSEIF(APPLE)
-	INCLUDE_DIRECTORIES(${OLXROOTDIR}/build/Xcode/include)
-	INCLUDE_DIRECTORIES(${OLXROOTDIR}/build/Xcode/freealut/include)
-	INCLUDE_DIRECTORIES(/Library/Frameworks/SDL.framework/Headers)
-	INCLUDE_DIRECTORIES(/Library/Frameworks/SDL_image.framework/Headers)
-	INCLUDE_DIRECTORIES(/Library/Frameworks/SDL_mixer.framework/Headers)
-	INCLUDE_DIRECTORIES(/Library/Frameworks/UnixImageIO.framework/Headers)
-	INCLUDE_DIRECTORIES(/Library/Frameworks/GD.framework/Headers)
+	# Modern macOS cmake build: rely on Homebrew-installed SDL2 and
+	# friends via pkg-config. The old SDL 1.x Framework layout is kept
+	# alive only by the build/Xcode project, not by cmake.
+	find_package(PkgConfig REQUIRED)
+	pkg_check_modules(SDL2 REQUIRED sdl2)
+	pkg_check_modules(SDL2_IMAGE REQUIRED SDL2_image)
+	pkg_check_modules(SDL2_MIXER REQUIRED SDL2_mixer)
+	pkg_check_modules(LIBXML2 REQUIRED libxml-2.0)
+	pkg_check_modules(LIBZIP REQUIRED libzip)
+	pkg_check_modules(LIBGD REQUIRED gdlib)
+	pkg_check_modules(VORBISFILE REQUIRED vorbisfile)
+	pkg_check_modules(OPENAL REQUIRED openal)
+	pkg_check_modules(FREEALUT REQUIRED freealut)
+	INCLUDE_DIRECTORIES(
+		${SDL2_INCLUDE_DIRS}
+		${SDL2_IMAGE_INCLUDE_DIRS}
+		${SDL2_MIXER_INCLUDE_DIRS}
+		${LIBXML2_INCLUDE_DIRS}
+		${LIBZIP_INCLUDE_DIRS}
+		${LIBGD_INCLUDE_DIRS}
+		${VORBISFILE_INCLUDE_DIRS}
+		${OPENAL_INCLUDE_DIRS}
+		${FREEALUT_INCLUDE_DIRS})
+	link_directories(
+		${SDL2_LIBRARY_DIRS}
+		${SDL2_IMAGE_LIBRARY_DIRS}
+		${SDL2_MIXER_LIBRARY_DIRS}
+		${LIBXML2_LIBRARY_DIRS}
+		${LIBZIP_LIBRARY_DIRS}
+		${LIBGD_LIBRARY_DIRS}
+		${VORBISFILE_LIBRARY_DIRS}
+		${OPENAL_LIBRARY_DIRS}
+		${FREEALUT_LIBRARY_DIRS})
 ELSEIF(MINGW_CROSS_COMPILE)
 	INCLUDE_DIRECTORIES(${OLXROOTDIR}/build/mingw/include/SDL)
 ELSE()
@@ -347,34 +383,14 @@ ELSE(BOOST_LINK_STATIC)
 	SET(LIBS ${LIBS} ${Boost_LIBRARIES})
 ENDIF(BOOST_LINK_STATIC)
 
-IF(APPLE)
-	SET(ALL_SRCS ${ALL_SRCS} ${OLXROOTDIR}/build/Xcode/freealut/src/alutBufferData.c)
-	SET(ALL_SRCS ${ALL_SRCS} ${OLXROOTDIR}/build/Xcode/freealut/src/alutCodec.c)
-	SET(ALL_SRCS ${ALL_SRCS} ${OLXROOTDIR}/build/Xcode/freealut/src/alutError.c)
-	SET(ALL_SRCS ${ALL_SRCS} ${OLXROOTDIR}/build/Xcode/freealut/src/alutInit.c)
-	SET(ALL_SRCS ${ALL_SRCS} ${OLXROOTDIR}/build/Xcode/freealut/src/alutInputStream.c)
-	SET(ALL_SRCS ${ALL_SRCS} ${OLXROOTDIR}/build/Xcode/freealut/src/alutLoader.c)
-	SET(ALL_SRCS ${ALL_SRCS} ${OLXROOTDIR}/build/Xcode/freealut/src/alutOutputStream.c)
-	SET(ALL_SRCS ${ALL_SRCS} ${OLXROOTDIR}/build/Xcode/freealut/src/alutUtil.c)
-	SET(ALL_SRCS ${ALL_SRCS} ${OLXROOTDIR}/build/Xcode/freealut/src/alutVersion.c)
-	SET(ALL_SRCS ${ALL_SRCS} ${OLXROOTDIR}/build/Xcode/freealut/src/alutWaveform.c)
-	ADD_DEFINITIONS("-F ${OLXROOTDIR}/build/Xcode")
-ELSE(APPLE)
-	SET(LIBS ${LIBS} alut openal vorbisfile)
-ENDIF(APPLE)
+SET(LIBS ${LIBS} alut openal vorbisfile)
 
 SET(LIBS ${LIBS} curl)
 
+SET(LIBS ${LIBS} SDL2 SDL2_image)
 if(APPLE)
-	FIND_PACKAGE(SDL REQUIRED)
-	FIND_PACKAGE(SDL_image REQUIRED)
-	SET(LIBS ${LIBS} ${SDL_LIBRARY} ${SDLIMAGE_LIBRARY})
-	SET(LIBS ${LIBS} "-framework Cocoa" "-framework Carbon")
-	SET(LIBS ${LIBS} crypto)
-	SET(LIBS ${LIBS} "-framework OpenAL")
-	SET(LIBS ${LIBS} "-logg" "-lvorbis" "-lvorbisfile")
-else(APPLE)
-	SET(LIBS ${LIBS} SDL2 SDL2_image)
+	# Needed by src/MacHelpers.m (clipboard + user-attention shims).
+	SET(LIBS ${LIBS} "-framework Cocoa")
 endif(APPLE)
 
 IF(WIN32)
@@ -386,8 +402,7 @@ IF(WIN32)
 				"${OLXROOTDIR}/build/msvc/libs/zlib.lib"
 				"${OLXROOTDIR}/build/msvc/libs/bgd.lib")
 ELSEIF(APPLE)
-	link_directories(/Library/Frameworks/SDL_mixer.framework)
-	link_directories(/Library/Frameworks/SDL_image.framework)
+	SET(LIBS ${LIBS} SDL2_mixer xml2 zip gd z)
 ELSEIF(MINGW_CROSS_COMPILE)
 
 ELSE()

--- a/package-macos.sh
+++ b/package-macos.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Build a standalone macOS .app bundle containing the openlierox
+# binary, its Homebrew dylib dependencies (rewritten to @executable_path
+# via dylibbundler) and the game data from share/gamedir/.
+#
+# Inputs (env):
+#   BUILD_DIR - cmake build directory (default: build)
+#
+# Output: openlierox_<version>_macos.zip in the current directory,
+#         containing OpenLieroX.app/.
+set -euo pipefail
+
+BUILD_DIR="${BUILD_DIR:-build}"
+BINARY="$BUILD_DIR/bin/openlierox"
+
+if [ ! -x "$BINARY" ]; then
+    echo "ERROR: $BINARY not found — build the project first" >&2
+    exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_ROOT"
+
+APP="$REPO_ROOT/mac-stage/OpenLieroX.app"
+rm -rf "$REPO_ROOT/mac-stage"
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources" "$APP/Contents/Frameworks"
+
+cp "$BINARY" "$APP/Contents/MacOS/openlierox"
+chmod +x "$APP/Contents/MacOS/openlierox"
+
+# Game data — everything OLX searches for at ./ at runtime.
+cp -R share/gamedir/. "$APP/Contents/Resources/gamedir/"
+
+# Docs and licence
+mkdir -p "$APP/Contents/Resources/doc"
+cp -R doc/. "$APP/Contents/Resources/doc/"
+cp README.md COPYING.LIB "$APP/Contents/Resources/doc/" 2>/dev/null || true
+
+# Icon
+if [ -f share/macosx.icns ]; then
+    cp share/macosx.icns "$APP/Contents/Resources/macosx.icns"
+fi
+
+# Info.plist
+VERSION_RAW="$(cat VERSION)"
+cat > "$APP/Contents/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>English</string>
+    <key>CFBundleExecutable</key>
+    <string>openlierox</string>
+    <key>CFBundleIconFile</key>
+    <string>macosx.icns</string>
+    <key>CFBundleIdentifier</key>
+    <string>net.openlierox.OpenLieroX</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>OpenLieroX</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${VERSION_RAW}</string>
+    <key>CFBundleVersion</key>
+    <string>${VERSION_RAW}</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.action-games</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>10.13</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>
+EOF
+
+# Pull in every Homebrew dylib the binary depends on, rewrite the load
+# paths to @executable_path/../Frameworks, and copy them into the bundle.
+# dylibbundler handles the transitive closure.
+if ! command -v dylibbundler >/dev/null 2>&1; then
+    echo "ERROR: dylibbundler not found — install with 'brew install dylibbundler'" >&2
+    exit 1
+fi
+dylibbundler -od -b \
+    -x "$APP/Contents/MacOS/openlierox" \
+    -d "$APP/Contents/Frameworks" \
+    -p "@executable_path/../Frameworks/"
+
+# Zip uses tilde instead of underscore so e.g. "beta9" sorts correctly.
+VERSION="$(tr '_' '~' < VERSION)"
+ZIP="openlierox_${VERSION}_macos.zip"
+rm -f "$REPO_ROOT/$ZIP"
+(cd "$REPO_ROOT/mac-stage" && zip -qry "$REPO_ROOT/$ZIP" OpenLieroX.app)
+echo ">>> built $ZIP"

--- a/src/MacHelpers.m
+++ b/src/MacHelpers.m
@@ -1,0 +1,30 @@
+/*
+    Cocoa helpers used by the OLX C++ side (clipboard + user-attention
+    notifications). The legacy src/MacMain.m also defines these, but it
+    carries an SDL 1.x main() that the cmake build replaces, so this
+    file is the source of truth for the cmake build.
+*/
+
+#import <Cocoa/Cocoa.h>
+
+void mac__copy_to_clipboard(const char* s) {
+    [[NSPasteboard generalPasteboard]
+        declareTypes:[NSArray arrayWithObject:NSPasteboardTypeString]
+               owner:nil];
+    [[NSPasteboard generalPasteboard]
+        setString:[NSString stringWithUTF8String:s]
+          forType:NSPasteboardTypeString];
+}
+
+const char* mac__copy_from_clipboard(void) {
+    NSString *paste = [[NSPasteboard generalPasteboard]
+        stringForType:NSPasteboardTypeString];
+    return [paste UTF8String];
+}
+
+void mac__NotifyUserOnEvent(void) {
+    [NSApp requestUserAttention:NSCriticalRequest];
+}
+
+void mac__ClearUserNotify(void) {
+}

--- a/src/gusanos/blitters/blitters.h
+++ b/src/gusanos/blitters/blitters.h
@@ -12,12 +12,12 @@
 #include "CodeAttributes.h"
 
 // TODO: correct check if we should include MMX/SSE code
-#if !defined(WIN32) && (SDL_BYTEORDER == SDL_LIL_ENDIAN)
+#if !defined(WIN32) && (SDL_BYTEORDER == SDL_LIL_ENDIAN) && (defined(__i386__) || defined(__x86_64__))
 #define HAS_MMX (cpu_capabilities & CPU_MMX)
 #define HAS_SSE (cpu_capabilities & CPU_SSE)
 #define HAS_MMXSSE (cpu_capabilities & CPU_MMXPLUS)
 #define BUILTIN_MMXSSE
-#else  // TODO: currently buggy on Windows
+#else  // TODO: currently buggy on Windows and unavailable on non-x86 archs
 #define HAS_MMX (false)
 #define HAS_SSE (false)
 #define HAS_MMXSSE (false)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -198,7 +198,7 @@ static bool afterCrashInformedUser = false;
 
 extern "C" int real_main(int argc, char *argv[]);
 
-#ifndef __APPLE__
+#if !defined(__APPLE__) || defined(OLX_USE_STD_MAIN)
 int main(int argc, char *argv[]) {
 	return real_main(argc, argv);
 }


### PR DESCRIPTION
While the previous PR about Linux bundle was mostly written by hand by me, this PR about Mac bundle is mostly written by Claude AI. This is because I have a lot experience developing for Linux but very little experience developing for Mac

I have tested this PR on my Macbook M3, and it worked well. Permissons to run the bundle needs to be fixed from the "System Settings"->"Privacy & Security" menu after trying to start the .app bundle. But that is not specific to this PR, but a general Mac problems for apps not signed by someone with a paid Apple Developer account

Here is a picture of this PR running on my Macbook:
<img width="4000" height="3000" alt="OpenLieroX on Macbook" src="https://github.com/user-attachments/assets/1a660ab5-cca9-40ef-b622-6405fba3a33a" />

I think in general it might not be a good idea to have PRs that are mostly AI generated, but I think the benifit of having automatic Mac builds outweights the downside in this case. We can do our best to understand this PR as good as possible together, and fix if we would find any problem

A build of this PR is available [here](https://github.com/openlierox/openlierox/actions/runs/24533362438)

Here is how Claude would describe this PR

    Add macOS .app build pipeline

    - .github/workflows/package-mac.yml: new workflow that installs
      Homebrew deps (incl. openal-soft with its keg-only .pc exported),
      pins CMake 3.x (CMake 4 rejects the legacy cmake_policy OLD calls
      in this tree), configures/builds with Ninja, packages via
      package-macos.sh, and uploads the zipped .app artifact.
    - package-macos.sh: new script that assembles OpenLieroX.app, copies
      gamedir/docs/icon, writes Info.plist, and uses dylibbundler to pull
      Homebrew dylibs into Contents/Frameworks with @executable_path
      relocation.
    - CMakeOlxCommon.cmake: modernize the Apple path — use pkg-config for
      SDL2/SDL2_image/SDL2_mixer/libxml2/libzip/gd/vorbisfile/openal/
      freealut instead of the legacy /Library/Frameworks layout; drop the
      vendored freealut sources and the Xcode-only framework search path;
      scope -std=c++0x to CXX sources (AppleClang errors on .c files);
      enable OBJC and compile src/MacHelpers.m (instead of the SDL1-era
      MacMain.m); disable HASBFD and define OLX_USE_STD_MAIN on Apple.
    - src/MacHelpers.m: new Cocoa shims (clipboard + user attention) that
      the cmake build needs, replacing the parts of MacMain.m that aren't
      SDL1-specific.
    - src/main.cpp: compile the standard main() on Apple when
      OLX_USE_STD_MAIN is defined.
    - src/gusanos/blitters/blitters.h: only enable the x86 inline-asm
      MMX/SSE paths on x86/x86_64 (Apple Silicon runners are arm64).