### PR TITLE
DeprecatedGUI: Stop using DWORD for pointers

### DIFF
--- a/include/DeprecatedGUI/CAnimation.h
+++ b/include/DeprecatedGUI/CAnimation.h
@@ -81,9 +81,9 @@ public:
 	int		KeyDown(UnicodeChar c, int keysym, const ModifiersState& modstate)		{ return ANI_NONE; }
 	int		KeyUp(UnicodeChar c, int keysym, const ModifiersState& modstate)		{ return ANI_NONE; }
 
-	DWORD SendMessage(int iMsg, DWORD Param1, DWORD Param2) { return 0; }
-	DWORD SendMessage(int iMsg, const std::string& sStr, DWORD Param) { return 0; }
-	DWORD SendMessage(int iMsg, std::string *sStr, DWORD Param)  { return 0; }
+	uintptr_t SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2) { return 0; }
+	uintptr_t SendMessage(int iMsg, const std::string& sStr, uintptr_t Param) { return 0; }
+	uintptr_t SendMessage(int iMsg, std::string *sStr, uintptr_t Param)  { return 0; }
 
 	void	Draw(SDL_Surface * bmpDest);
 

--- a/include/DeprecatedGUI/CBox.h
+++ b/include/DeprecatedGUI/CBox.h
@@ -73,9 +73,9 @@ public:
 	int		KeyDown(UnicodeChar c, int keysym, const ModifiersState& modstate)		{ return BOX_NONE; }
 	int		KeyUp(UnicodeChar c, int keysym, const ModifiersState& modstate)		{ return BOX_NONE; }
 
-	DWORD SendMessage(int iMsg, DWORD Param1, DWORD Param2)	{ return 0; }
-	DWORD SendMessage(int iMsg, const std::string& sStr, DWORD Param) { return 0; }
-	DWORD SendMessage(int iMsg, std::string *sStr, DWORD Param)  { return 0; }
+	uintptr_t SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2)	{ return 0; }
+	uintptr_t SendMessage(int iMsg, const std::string& sStr, uintptr_t Param) { return 0; }
+	uintptr_t SendMessage(int iMsg, std::string *sStr, uintptr_t Param)  { return 0; }
 
 	int		CheckEvent();
 

--- a/include/DeprecatedGUI/CBrowser.h
+++ b/include/DeprecatedGUI/CBrowser.h
@@ -350,9 +350,9 @@ public:
 	int		KeyDown(UnicodeChar c, int keysym, const ModifiersState& modstate);
 	int		KeyUp(UnicodeChar c, int keysym, const ModifiersState& modstate) { return BRW_NONE; }
 
-	DWORD SendMessage(int iMsg, DWORD Param1, DWORD Param2) { return 0; }
-	DWORD SendMessage(int iMsg, const std::string& sStr, DWORD Param) { return 0; }
-	DWORD SendMessage(int iMsg, std::string *sStr, DWORD Param)  { return 0; }
+	uintptr_t SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2) { return 0; }
+	uintptr_t SendMessage(int iMsg, const std::string& sStr, uintptr_t Param) { return 0; }
+	uintptr_t SendMessage(int iMsg, std::string *sStr, uintptr_t Param)  { return 0; }
 
 	void	Draw(SDL_Surface * bmpDest);
 	void	LoadStyle() {}

--- a/include/DeprecatedGUI/CButton.h
+++ b/include/DeprecatedGUI/CButton.h
@@ -122,9 +122,9 @@ public:
 	int		KeyDown(UnicodeChar c, int keysym, const ModifiersState& modstate)	{ return BTN_NONE; }
 	int		KeyUp(UnicodeChar c, int keysym, const ModifiersState& modstate)	{ return BTN_NONE; }
 
-	DWORD SendMessage(int iMsg, DWORD Param1, DWORD Param2)	{ return 0; }
-	DWORD SendMessage(int iMsg, const std::string& sStr, DWORD Param) { return 0; }
-	DWORD SendMessage(int iMsg, std::string *sStr, DWORD Param)  { return 0; }
+	uintptr_t SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2)	{ return 0; }
+	uintptr_t SendMessage(int iMsg, const std::string& sStr, uintptr_t Param) { return 0; }
+	uintptr_t SendMessage(int iMsg, std::string *sStr, uintptr_t Param)  { return 0; }
 
 	// Draw the button
 	void	Draw(SDL_Surface * bmpDest);

--- a/include/DeprecatedGUI/CCheckbox.h
+++ b/include/DeprecatedGUI/CCheckbox.h
@@ -84,7 +84,7 @@ public:
 
 
 	// Process a message sent
-	DWORD SendMessage(int iMsg, DWORD Param1, DWORD Param2) {
+	uintptr_t SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2) {
 
 				switch(iMsg) {
 					case CKM_SETCHECK:
@@ -97,8 +97,8 @@ public:
 
 				return 0;
 			}
-	DWORD SendMessage(int iMsg, const std::string& sStr, DWORD Param) { return 0; }
-	DWORD SendMessage(int iMsg, std::string *sStr, DWORD Param)  { return 0; }
+	uintptr_t SendMessage(int iMsg, const std::string& sStr, uintptr_t Param) { return 0; }
+	uintptr_t SendMessage(int iMsg, std::string *sStr, uintptr_t Param)  { return 0; }
 
 
 	// Draw the title button

--- a/include/DeprecatedGUI/CCombobox.h
+++ b/include/DeprecatedGUI/CCombobox.h
@@ -157,9 +157,9 @@ public:
 	void	Draw(SDL_Surface * bmpDest);
 	void	LoadStyle() {}
 	
-	DWORD SendMessage(int iMsg, DWORD Param1, DWORD Param2);
-	DWORD SendMessage(int iMsg, const std::string& sStr, DWORD Param);
-	DWORD SendMessage(int iMsg, std::string *sStr, DWORD Param);
+	uintptr_t SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2);
+	uintptr_t SendMessage(int iMsg, const std::string& sStr, uintptr_t Param);
+	uintptr_t SendMessage(int iMsg, std::string *sStr, uintptr_t Param);
 
 	void	setListBackend(const GuiList::Pt& l) { listBackend = l; }
 	/*

--- a/include/DeprecatedGUI/CGuiLayout.h
+++ b/include/DeprecatedGUI/CGuiLayout.h
@@ -127,9 +127,9 @@ public:
 	CWidget		*getFocusedWidget()		{ return cFocused; }
 
 	// Messaging
-	DWORD		SendMessage(int iControl, int iMsg, DWORD Param1, DWORD Param2);
-	DWORD		SendMessage(int iControl, int iMsg, const std::string& sStr, DWORD Param);
-	DWORD		SendMessage(int iControl, int iMsg, std::string *sStr, DWORD Param);
+	uintptr_t		SendMessage(int iControl, int iMsg, uintptr_t Param1, uintptr_t Param2);
+	uintptr_t		SendMessage(int iControl, int iMsg, const std::string& sStr, uintptr_t Param);
+	uintptr_t		SendMessage(int iControl, int iMsg, std::string *sStr, uintptr_t Param);
 
 	// Variables
 	int			getID()		{ return iID; }

--- a/include/DeprecatedGUI/CGuiSkinnedLayout.h
+++ b/include/DeprecatedGUI/CGuiSkinnedLayout.h
@@ -94,9 +94,9 @@ public:
 	int		KeyUp(UnicodeChar c, int keysym, const ModifiersState& modstate);
 
 	// Other functions are empty, because GUI layout don't do any actions itself
-	DWORD	SendMessage(int iMsg, DWORD Param1, DWORD Param2) { return 0; };
-	DWORD	SendMessage(int iMsg, const std::string& sStr, DWORD Param) { return 0; };
-	DWORD	SendMessage(int iMsg, std::string *sStr, DWORD Param) { return 0; };
+	uintptr_t	SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2) { return 0; };
+	uintptr_t	SendMessage(int iMsg, const std::string& sStr, uintptr_t Param) { return 0; };
+	uintptr_t	SendMessage(int iMsg, std::string *sStr, uintptr_t Param) { return 0; };
 
 	void	LoadStyle() { };
 	

--- a/include/DeprecatedGUI/CImage.h
+++ b/include/DeprecatedGUI/CImage.h
@@ -104,9 +104,9 @@ public:
 	int		KeyDown(UnicodeChar c, int keysym, const ModifiersState& modstate)		{ return IMG_NONE; }
 	int		KeyUp(UnicodeChar c, int keysym, const ModifiersState& modstate)		{ return IMG_NONE; }
 
-	DWORD SendMessage(int iMsg, DWORD Param1, DWORD Param2);
-	DWORD SendMessage(int iMsg, const std::string& sStr, DWORD Param) { return 0; }
-	DWORD SendMessage(int iMsg, std::string *sStr, DWORD Param)  { return 0; }
+	uintptr_t SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2);
+	uintptr_t SendMessage(int iMsg, const std::string& sStr, uintptr_t Param) { return 0; }
+	uintptr_t SendMessage(int iMsg, std::string *sStr, uintptr_t Param)  { return 0; }
 
 	void	Draw(SDL_Surface * bmpDest);
 

--- a/include/DeprecatedGUI/CInputBox.h
+++ b/include/DeprecatedGUI/CInputBox.h
@@ -80,7 +80,7 @@ public:
 
 
 	// Process a message sent
-	INLINE DWORD SendMessage(int iMsg, DWORD Param1, DWORD Param2) {
+	INLINE uintptr_t SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2) {
 
 				if(iMsg == INM_GETVALUE) {
 						return iKeyvalue;
@@ -89,8 +89,8 @@ public:
 				return 0;
 			}
 
-	DWORD SendMessage(int iMsg, const std::string& sStr, DWORD Param) { return 0; }
-	DWORD SendMessage(int iMsg, std::string *sStr, DWORD Param)  {
+	uintptr_t SendMessage(int iMsg, const std::string& sStr, uintptr_t Param) { return 0; }
+	uintptr_t SendMessage(int iMsg, std::string *sStr, uintptr_t Param)  {
 		if (iMsg == INS_GETTEXT)  {
 			*sStr = sText;
 		}

--- a/include/DeprecatedGUI/CLabel.h
+++ b/include/DeprecatedGUI/CLabel.h
@@ -85,9 +85,9 @@ public:
 	int		KeyDown(UnicodeChar c, int keysym, const ModifiersState& modstate)	{ return LBL_NONE; }
 	int		KeyUp(UnicodeChar c, int keysym, const ModifiersState& modstate)	{ return LBL_NONE; }
 
-	DWORD SendMessage(int iMsg, DWORD Param1, DWORD Param2);
-	DWORD SendMessage(int iMsg, const std::string& sStr, DWORD Param);
-	DWORD SendMessage(int iMsg, std::string *sStr, DWORD Param);
+	uintptr_t SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2);
+	uintptr_t SendMessage(int iMsg, const std::string& sStr, uintptr_t Param);
+	uintptr_t SendMessage(int iMsg, std::string *sStr, uintptr_t Param);
 
 	void	ChangeColour(Color col);
 	void	setText(const std::string& sStr);

--- a/include/DeprecatedGUI/CLine.h
+++ b/include/DeprecatedGUI/CLine.h
@@ -52,11 +52,11 @@ public:
 	int		KeyDown(UnicodeChar c, int keysym, const ModifiersState& modstate)	{ return LIN_NONE; }
 	int		KeyUp(UnicodeChar c, int keysym, const ModifiersState& modstate)	{ return LIN_NONE; }
 
-	DWORD SendMessage(int iMsg, DWORD Param1, DWORD Param2)	{ 
+	uintptr_t SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2)	{ 
 							return 0;
 						}
-	DWORD SendMessage(int iMsg, const std::string& sStr, DWORD Param) { return 0; }
-	DWORD SendMessage(int iMsg, std::string *sStr, DWORD Param)  { return 0; }
+	uintptr_t SendMessage(int iMsg, const std::string& sStr, uintptr_t Param) { return 0; }
+	uintptr_t SendMessage(int iMsg, std::string *sStr, uintptr_t Param)  { return 0; }
 
 	void	ChangeColour(Color col)			{ iColour = col; }
 

--- a/include/DeprecatedGUI/CListview.h
+++ b/include/DeprecatedGUI/CListview.h
@@ -237,9 +237,9 @@ public:
 
 	void	LoadStyle() {}
 
-	DWORD SendMessage(int iMsg, DWORD Param1, DWORD Param2);
-	DWORD SendMessage(int iMsg, const std::string& sStr, DWORD Param);
-	DWORD SendMessage(int iMsg, std::string *sStr, DWORD Param);
+	uintptr_t SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2);
+	uintptr_t SendMessage(int iMsg, const std::string& sStr, uintptr_t Param);
+	uintptr_t SendMessage(int iMsg, std::string *sStr, uintptr_t Param);
 
 	void	ReadjustScrollbar();
 	void	SetupScrollbar(int x, int y, int h, bool always_visible);

--- a/include/DeprecatedGUI/CMenu.h
+++ b/include/DeprecatedGUI/CMenu.h
@@ -76,9 +76,9 @@ public:
 	int		KeyDown(UnicodeChar c, int keysym, const ModifiersState& modstate);
 	int		KeyUp(UnicodeChar c, int keysym, const ModifiersState& modstate)	{ return MNU_NONE; }
 
-	DWORD SendMessage(int iMsg, DWORD Param1, DWORD Param2);
-	DWORD SendMessage(int iMsg, const std::string& sStr, DWORD Param);
-	DWORD SendMessage(int iMsg, std::string *sStr, DWORD Param)  { return 0; }
+	uintptr_t SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2);
+	uintptr_t SendMessage(int iMsg, const std::string& sStr, uintptr_t Param);
+	uintptr_t SendMessage(int iMsg, std::string *sStr, uintptr_t Param)  { return 0; }
     
 	void	Draw(SDL_Surface * bmpDest);
 

--- a/include/DeprecatedGUI/CProgressbar.h
+++ b/include/DeprecatedGUI/CProgressbar.h
@@ -57,11 +57,11 @@ public:
 	int		KeyDown(UnicodeChar c, int keysym, const ModifiersState& modstate)	{ return BAR_NONE; }
 	int		KeyUp(UnicodeChar c, int keysym, const ModifiersState& modstate)	{ return BAR_NONE; }
 
-	DWORD SendMessage(int iMsg, DWORD Param1, DWORD Param2)	{ 
+	uintptr_t SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2)	{ 
 							return 0;
 						}
-	DWORD SendMessage(int iMsg, const std::string& sStr, DWORD Param) { return 0; }
-	DWORD SendMessage(int iMsg, std::string *sStr, DWORD Param)  { return 0; }
+	uintptr_t SendMessage(int iMsg, const std::string& sStr, uintptr_t Param) { return 0; }
+	uintptr_t SendMessage(int iMsg, std::string *sStr, uintptr_t Param)  { return 0; }
 
 	// Draw the line
 	INLINE void	Draw(SDL_Surface * bmpDest) {

--- a/include/DeprecatedGUI/CScrollbar.h
+++ b/include/DeprecatedGUI/CScrollbar.h
@@ -108,9 +108,9 @@ public:
 	int		getMax()					{ return iMax; } // TODO: that should return the max possible value!!
 	bool	getGrabbed()				{ return bSliderGrabbed; }
 
-	DWORD SendMessage(int iMsg, DWORD Param1, DWORD Param2);
-	DWORD SendMessage(int iMsg, const std::string& sStr, DWORD Param) { return 0; }
-	DWORD SendMessage(int iMsg, std::string *sStr, DWORD Param)  { return 0; }
+	uintptr_t SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2);
+	uintptr_t SendMessage(int iMsg, const std::string& sStr, uintptr_t Param) { return 0; }
+	uintptr_t SendMessage(int iMsg, std::string *sStr, uintptr_t Param)  { return 0; }
 
 	static CWidget * WidgetCreator( const std::vector< ScriptVar_t > & p, CGuiLayoutBase * layout, int id, int x, int y, int dx, int dy )
 	{

--- a/include/DeprecatedGUI/CSlider.h
+++ b/include/DeprecatedGUI/CSlider.h
@@ -91,9 +91,9 @@ public:
 
 	void	LoadStyle() {}
 
-	DWORD SendMessage(int iMsg, DWORD Param1, DWORD Param2);
-	DWORD SendMessage(int iMsg, const std::string& sStr, DWORD Param) { return 0; }
-	DWORD SendMessage(int iMsg, std::string *sStr, DWORD Param)  { return 0; }
+	uintptr_t SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2);
+	uintptr_t SendMessage(int iMsg, const std::string& sStr, uintptr_t Param) { return 0; }
+	uintptr_t SendMessage(int iMsg, std::string *sStr, uintptr_t Param)  { return 0; }
 
 	int		getValue()						{ return iValue; }
 	void	setValue(int v)						{ iValue = v; }

--- a/include/DeprecatedGUI/CTextButton.h
+++ b/include/DeprecatedGUI/CTextButton.h
@@ -58,9 +58,9 @@ public:
 	int		KeyDown(UnicodeChar c, int keysym, const ModifiersState& modstate)	{ return CLabel::KeyDown( c, keysym, modstate ); }
 	int		KeyUp(UnicodeChar c, int keysym, const ModifiersState& modstate)	{ return CLabel::KeyUp( c, keysym, modstate ); }
 
-	DWORD SendMessage(int iMsg, DWORD Param1, DWORD Param2)	{ return CLabel::SendMessage( iMsg, Param1, Param2 ); }
-	DWORD SendMessage(int iMsg, const std::string& sStr, DWORD Param) { return CLabel::SendMessage( iMsg, sStr, Param ); }
-	DWORD SendMessage(int iMsg, std::string *sStr, DWORD Param)  { return CLabel::SendMessage( iMsg, sStr, Param ); }
+	uintptr_t SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2)	{ return CLabel::SendMessage( iMsg, Param1, Param2 ); }
+	uintptr_t SendMessage(int iMsg, const std::string& sStr, uintptr_t Param) { return CLabel::SendMessage( iMsg, sStr, Param ); }
+	uintptr_t SendMessage(int iMsg, std::string *sStr, uintptr_t Param)  { return CLabel::SendMessage( iMsg, sStr, Param ); }
 
 	void	Draw(SDL_Surface * bmpDest);
 

--- a/include/DeprecatedGUI/CTextbox.h
+++ b/include/DeprecatedGUI/CTextbox.h
@@ -142,9 +142,9 @@ public:
 
 	void	LoadStyle() {}
 
-	DWORD	SendMessage(int iMsg, DWORD Param1, DWORD Param2);
-	DWORD	SendMessage(int iMsg, const std::string& sStr, DWORD Param);
-	DWORD	SendMessage(int iMsg, std::string *sStr, DWORD Param);
+	uintptr_t	SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2);
+	uintptr_t	SendMessage(int iMsg, const std::string& sStr, uintptr_t Param);
+	uintptr_t	SendMessage(int iMsg, std::string *sStr, uintptr_t Param);
 
 	void	Backspace();
 	void	Delete();

--- a/include/DeprecatedGUI/CTitleButton.h
+++ b/include/DeprecatedGUI/CTitleButton.h
@@ -68,9 +68,9 @@ public:
 	int		KeyDown(UnicodeChar c, int keysym, const ModifiersState& modstate)	{ return TBT_NONE; }
 	int		KeyUp(UnicodeChar c, int keysym, const ModifiersState& modstate)	{ return TBT_NONE; }
 
-	DWORD SendMessage(int iMsg, DWORD Param1, DWORD Param2)	{ return 0; }
-	DWORD SendMessage(int iMsg, const std::string& sStr, DWORD Param) { return 0; }
-	DWORD SendMessage(int iMsg, std::string *sStr, DWORD Param)  { return 0; }
+	uintptr_t SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2)	{ return 0; }
+	uintptr_t SendMessage(int iMsg, const std::string& sStr, uintptr_t Param) { return 0; }
+	uintptr_t SendMessage(int iMsg, std::string *sStr, uintptr_t Param)  { return 0; }
 
 	// Draw the title button
 	void	Draw(SDL_Surface * bmpDest);

--- a/include/DeprecatedGUI/CWidget.h
+++ b/include/DeprecatedGUI/CWidget.h
@@ -155,9 +155,9 @@ public:
 	virtual	void	LoadStyle() = 0;	// Not used anywhere
 	virtual	void	Draw(SDL_Surface * bmpDest) = 0;
 
-	virtual DWORD	SendMessage(int iMsg, DWORD Param1, DWORD Param2) = 0;
-	virtual DWORD	SendMessage(int iMsg, const std::string& sStr, DWORD Param) = 0;
-	virtual DWORD	SendMessage(int iMsg, std::string *sStr, DWORD Param) = 0;
+	virtual uintptr_t	SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2) = 0;
+	virtual uintptr_t	SendMessage(int iMsg, const std::string& sStr, uintptr_t Param) = 0;
+	virtual uintptr_t	SendMessage(int iMsg, std::string *sStr, uintptr_t Param) = 0;
 	
 	virtual void	ProcessGuiSkinEvent(int iEvent) {};
 };

--- a/include/olx-types.h
+++ b/include/olx-types.h
@@ -24,6 +24,7 @@
 
 #include <SDL.h>
 #include <cassert>
+#include <cstdint>
 
 struct TimeDiff {
 	Uint64 timeDiff;
@@ -97,7 +98,6 @@ typedef unsigned char	uchar;
 typedef unsigned long	ulong;
 typedef unsigned char	uint24[3];
 
-typedef unsigned long DWORD;
 typedef uchar byte;
 typedef unsigned short ushort;
 

--- a/src/client/CClient_Draw.cpp
+++ b/src/client/CClient_Draw.cpp
@@ -2269,7 +2269,7 @@ void CClient::DrawViewportManager(SDL_Surface * bmpDest)
             if(ev->iEventMsg == DeprecatedGUI::CHK_CHANGED) {
                 // If there is only one worm, disable the 2nd viewport
                 if( game.worms()->size() <= 1 )
-                    ViewportMgr.SendMessage(v2_On, DeprecatedGUI::CKM_SETCHECK,(DWORD)0,0);
+                    ViewportMgr.SendMessage(v2_On, DeprecatedGUI::CKM_SETCHECK,(uintptr_t)0,0);
             }
             break;
 
@@ -2279,15 +2279,15 @@ void CClient::DrawViewportManager(SDL_Surface * bmpDest)
 
                 // If there is only one worm, disable the 2nd viewport
                 if( game.worms()->size() <= 1 )
-                    ViewportMgr.SendMessage(v2_On, DeprecatedGUI::CKM_SETCHECK,(DWORD)0,0);
+                    ViewportMgr.SendMessage(v2_On, DeprecatedGUI::CKM_SETCHECK,(uintptr_t)0,0);
 
 				DeprecatedGUI::CCombobox *v1Target = (DeprecatedGUI::CCombobox *)ViewportMgr.getWidget(v1_Target);
 				DeprecatedGUI::CCombobox *v2Target = (DeprecatedGUI::CCombobox *)ViewportMgr.getWidget(v2_Target);
 
                 // Grab settings
-                int a_type = (int) ViewportMgr.SendMessage(v1_Type, DeprecatedGUI::CBM_GETCURINDEX, (DWORD)0,0);
-                int b_on = (int) ViewportMgr.SendMessage(v2_On, DeprecatedGUI::CKM_GETCHECK, (DWORD)0,0);
-                int b_type = (int) ViewportMgr.SendMessage(v2_Type, DeprecatedGUI::CBM_GETCURINDEX, (DWORD)0,0);
+                int a_type = (int) ViewportMgr.SendMessage(v1_Type, DeprecatedGUI::CBM_GETCURINDEX, (uintptr_t)0,0);
+                int b_on = (int) ViewportMgr.SendMessage(v2_On, DeprecatedGUI::CKM_GETCHECK, (uintptr_t)0,0);
+                int b_type = (int) ViewportMgr.SendMessage(v2_Type, DeprecatedGUI::CBM_GETCURINDEX, (uintptr_t)0,0);
 				if (!v1Target->getSelectedItem().get() || !v2Target->getSelectedItem().get())
 					return;
 

--- a/src/client/DeprecatedGUI/CCombobox.cpp
+++ b/src/client/DeprecatedGUI/CCombobox.cpp
@@ -583,7 +583,7 @@ int CCombobox::KeyDown(UnicodeChar c, int keysym, const ModifiersState& modstate
 
 ///////////////////
 // Process a message sent to this widget
-DWORD CCombobox::SendMessage(int iMsg, DWORD Param1, DWORD Param2)
+uintptr_t CCombobox::SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2)
 {
 
 	switch(iMsg) {
@@ -623,7 +623,7 @@ DWORD CCombobox::SendMessage(int iMsg, DWORD Param1, DWORD Param2)
 	return 0;
 }
 
-DWORD CCombobox::SendMessage(int iMsg, const std::string& sStr, DWORD Param)
+uintptr_t CCombobox::SendMessage(int iMsg, const std::string& sStr, uintptr_t Param)
 {
 	switch (iMsg)  {
 	// Add item message
@@ -632,7 +632,7 @@ DWORD CCombobox::SendMessage(int iMsg, const std::string& sStr, DWORD Param)
 		break;
 	// Add item message (string index)
 	case CBS_ADDSITEM:
-		addItem(0, sStr, *((std::string *) Param)); // TODO: 64bit unsafe
+		addItem(0, sStr, *((std::string *) Param));
 		break;
 	// Set the current item based on the string index
 	case CBS_SETCURSINDEX:
@@ -643,7 +643,7 @@ DWORD CCombobox::SendMessage(int iMsg, const std::string& sStr, DWORD Param)
 	return 0;
 }
 
-DWORD CCombobox::SendMessage(int iMsg, std::string *sStr, DWORD Param)
+uintptr_t CCombobox::SendMessage(int iMsg, std::string *sStr, uintptr_t Param)
 {
 	switch (iMsg)  {
 	// Get the current item's string index

--- a/src/client/DeprecatedGUI/CGuiLayout.cpp
+++ b/src/client/DeprecatedGUI/CGuiLayout.cpp
@@ -976,7 +976,7 @@ void CGuiLayout::SetGlobalProperty(int property, int value)
 
 ///////////////////
 // Send a message to a widget
-DWORD CGuiLayout::SendMessage(int iControl, int iMsg, DWORD Param1, DWORD Param2)
+uintptr_t CGuiLayout::SendMessage(int iControl, int iMsg, uintptr_t Param1, uintptr_t Param2)
 {
 	CWidget *w = getWidget(iControl);
 
@@ -999,7 +999,7 @@ DWORD CGuiLayout::SendMessage(int iControl, int iMsg, DWORD Param1, DWORD Param2
 	return w->SendMessage(iMsg, Param1, Param2);
 }
 
-DWORD CGuiLayout::SendMessage(int iControl, int iMsg, const std::string& sStr, DWORD Param)
+uintptr_t CGuiLayout::SendMessage(int iControl, int iMsg, const std::string& sStr, uintptr_t Param)
 {
 	CWidget *w = getWidget(iControl);
 
@@ -1011,7 +1011,7 @@ DWORD CGuiLayout::SendMessage(int iControl, int iMsg, const std::string& sStr, D
 
 }
 
-DWORD CGuiLayout::SendMessage(int iControl, int iMsg, std::string *sStr, DWORD Param)
+uintptr_t CGuiLayout::SendMessage(int iControl, int iMsg, std::string *sStr, uintptr_t Param)
 {
 	// Check the string
 	if (!sStr)

--- a/src/client/DeprecatedGUI/CImage.cpp
+++ b/src/client/DeprecatedGUI/CImage.cpp
@@ -72,7 +72,7 @@ void CImage::Change(const SmartPointer<DynDrawIntf>& bmpImg)
 
 /////////////////////
 // This widget is a sendmessage
-DWORD CImage::SendMessage(int iMsg, DWORD Param1, DWORD Param2)
+uintptr_t CImage::SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2)
 {
 	return 0;
 }

--- a/src/client/DeprecatedGUI/CLabel.cpp
+++ b/src/client/DeprecatedGUI/CLabel.cpp
@@ -19,13 +19,13 @@ namespace DeprecatedGUI {
 			iX -= iWidth / 2;
 	}
 		
-	DWORD CLabel::SendMessage(int iMsg, DWORD Param1, DWORD Param2)	{ return 0; }
-	DWORD CLabel::SendMessage(int iMsg, const std::string& sStr, DWORD Param) { 
+	uintptr_t CLabel::SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2)	{ return 0; }
+	uintptr_t CLabel::SendMessage(int iMsg, const std::string& sStr, uintptr_t Param) { 
 		if (iMsg == LBS_SETTEXT) 
 		{sText = sStr; iWidth = tLX->cFont.GetWidth(sText); iHeight = tLX->cFont.GetHeight(sText);} 
 		return 0; 	}
 	
-	DWORD CLabel::SendMessage(int iMsg, std::string *sStr, DWORD Param)  { return 0; }
+	uintptr_t CLabel::SendMessage(int iMsg, std::string *sStr, uintptr_t Param)  { return 0; }
 	
 	void	CLabel::ChangeColour(Color col)			{ iColour = col; }
 	void	CLabel::setText(const std::string& sStr)	{sText = sStr; iWidth = tLX->cFont.GetWidth(sText); iHeight = tLX->cFont.GetHeight(sText);};

--- a/src/client/DeprecatedGUI/CListview.cpp
+++ b/src/client/DeprecatedGUI/CListview.cpp
@@ -1687,7 +1687,7 @@ lv_subitem_t *CListview::getCurSubitem(int index)
 
 ///////////////////
 // This widget is send a message
-DWORD CListview::SendMessage(int iMsg, DWORD Param1, DWORD Param2)
+uintptr_t CListview::SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2)
 {
 	std::string s = "";
 
@@ -1721,7 +1721,7 @@ DWORD CListview::SendMessage(int iMsg, DWORD Param1, DWORD Param2)
         // Return the current item
         case LVM_GETCURITEM:
             if(tSelected)
-                return (DWORD)tSelected; // TODO: 64bit unsafe (pointer cast)
+                return (uintptr_t)tSelected;
             return 0;
 
 		// Set the old-style property
@@ -1742,7 +1742,7 @@ DWORD CListview::SendMessage(int iMsg, DWORD Param1, DWORD Param2)
 	return 0;
 }
 
-DWORD CListview::SendMessage(int iMsg, const std::string& sStr, DWORD Param)
+uintptr_t CListview::SendMessage(int iMsg, const std::string& sStr, uintptr_t Param)
 {
 	switch (iMsg)  {
 
@@ -1764,7 +1764,7 @@ DWORD CListview::SendMessage(int iMsg, const std::string& sStr, DWORD Param)
 }
 
 
-DWORD CListview::SendMessage(int iMsg, std::string *sStr, DWORD Param)
+uintptr_t CListview::SendMessage(int iMsg, std::string *sStr, uintptr_t Param)
 {
 	switch (iMsg)  {
 

--- a/src/client/DeprecatedGUI/CMenu.cpp
+++ b/src/client/DeprecatedGUI/CMenu.cpp
@@ -40,7 +40,7 @@ CMenu::CMenu(int nPosX, int nPosY)
 
 ///////////////////
 // Handle a menu message
-DWORD CMenu::SendMessage(int iMsg, DWORD Param1, DWORD Param2)
+uintptr_t CMenu::SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2)
 {
     switch(iMsg) {
 
@@ -53,7 +53,7 @@ DWORD CMenu::SendMessage(int iMsg, DWORD Param1, DWORD Param2)
     return 0;
 }
 
-DWORD CMenu::SendMessage(int iMsg, const std::string& sStr, DWORD Param)
+uintptr_t CMenu::SendMessage(int iMsg, const std::string& sStr, uintptr_t Param)
 {
 	switch (iMsg)  {
 

--- a/src/client/DeprecatedGUI/CScrollbar.cpp
+++ b/src/client/DeprecatedGUI/CScrollbar.cpp
@@ -272,7 +272,7 @@ void CScrollbar::UpdatePos()
 
 ///////////////////
 // Process a sent message
-DWORD CScrollbar::SendMessage(int iMsg, DWORD Param1, DWORD Param2)
+uintptr_t CScrollbar::SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2)
 {
     switch( iMsg ) {
 

--- a/src/client/DeprecatedGUI/CSlider.cpp
+++ b/src/client/DeprecatedGUI/CSlider.cpp
@@ -76,7 +76,7 @@ int CSlider::MouseDown(mouse_t *tMouse, int nDown)
 
 ///////////////////
 // This widget is send a message
-DWORD CSlider::SendMessage(int iMsg, DWORD Param1, DWORD Param2)
+uintptr_t CSlider::SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2)
 {
 	switch(iMsg) {
 

--- a/src/client/DeprecatedGUI/CTextbox.cpp
+++ b/src/client/DeprecatedGUI/CTextbox.cpp
@@ -705,13 +705,13 @@ void CTextbox::setText(const std::string& buf) {
 
 ///////////////////
 // This widget is send a message
-DWORD CTextbox::SendMessage(int iMsg, DWORD Param1, DWORD Param2) {
+uintptr_t CTextbox::SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2) {
 
 	switch(iMsg) {
 
 		// Get the text length
 		case TXM_GETTEXTLENGTH:
-			return (DWORD)Utf8StringSize(sText);
+			return (uintptr_t)Utf8StringSize(sText);
 			break;
 
 		// Set some flags
@@ -732,7 +732,7 @@ DWORD CTextbox::SendMessage(int iMsg, DWORD Param1, DWORD Param2) {
 	return 0;
 }
 
-DWORD CTextbox::SendMessage(int iMsg, const std::string& sStr, DWORD Param)
+uintptr_t CTextbox::SendMessage(int iMsg, const std::string& sStr, uintptr_t Param)
 {
 	switch (iMsg)  {
 
@@ -746,7 +746,7 @@ DWORD CTextbox::SendMessage(int iMsg, const std::string& sStr, DWORD Param)
 }
 
 
-DWORD CTextbox::SendMessage(int iMsg, std::string *sStr, DWORD Param)
+uintptr_t CTextbox::SendMessage(int iMsg, std::string *sStr, uintptr_t Param)
 {
 	switch (iMsg)  {
 

--- a/src/client/DeprecatedGUI/Menu_FloatingOptions.cpp
+++ b/src/client/DeprecatedGUI/Menu_FloatingOptions.cpp
@@ -463,7 +463,7 @@ void Menu_FloatingOptionsFrame()
 		ev = cFloatingOpt_Game.Process();
 		cFloatingOpt_Game.Draw(VideoPostProcessor::videoSurface().get());
 
-		val = (int)cFloatingOpt_Game.SendMessage(og_BloodAmount, SLM_GETVALUE, (DWORD)0, 0);
+		val = (int)cFloatingOpt_Game.SendMessage(og_BloodAmount, SLM_GETVALUE, (uintptr_t)0, 0);
         DrawImageAdv(VideoPostProcessor::videoSurface().get(), tMenu->bmpBuffer, 385,140, 385,140, 70,40);
 		tLX->cFont.Draw(VideoPostProcessor::videoSurface().get(),385, 148, tLX->clNormalLabel, itoa(val)+"%");
 
@@ -476,7 +476,7 @@ void Menu_FloatingOptionsFrame()
 				// Blood amount
 				case og_BloodAmount:
 					if(ev->iEventMsg == SLD_CHANGE) {
-						val = (int)cFloatingOpt_Game.SendMessage(og_BloodAmount, SLM_GETVALUE, (DWORD)0, 0);
+						val = (int)cFloatingOpt_Game.SendMessage(og_BloodAmount, SLM_GETVALUE, (uintptr_t)0, 0);
 						tLXOptions->iBloodAmount = val;
 					}
 					break;
@@ -500,55 +500,55 @@ void Menu_FloatingOptionsFrame()
 				// Old skool rope throw
 				case og_OldSkoolRope:
 					if(ev->iEventMsg == CHK_CHANGED) {
-						tLXOptions->bOldSkoolRope = cFloatingOpt_Game.SendMessage(og_OldSkoolRope,CKM_GETCHECK,(DWORD)0,0) != 0;
+						tLXOptions->bOldSkoolRope = cFloatingOpt_Game.SendMessage(og_OldSkoolRope,CKM_GETCHECK,(uintptr_t)0,0) != 0;
 					}
 					break;
 
 				// TDM nick colorizing
 				case og_ColorizeNicks:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bColorizeNicks = cFloatingOpt_Game.SendMessage(og_ColorizeNicks, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bColorizeNicks = cFloatingOpt_Game.SendMessage(og_ColorizeNicks, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 
 				// Auto typing
 				case og_AutoTyping:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bAutoTyping = cFloatingOpt_Game.SendMessage(og_AutoTyping, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bAutoTyping = cFloatingOpt_Game.SendMessage(og_AutoTyping, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 
 				// Antialiasing
 				case og_Antialiasing:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bAntiAliasing = cFloatingOpt_Game.SendMessage(og_Antialiasing, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bAntiAliasing = cFloatingOpt_Game.SendMessage(og_Antialiasing, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 
 
 				// Mouse aiming
 				case og_MouseAiming:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bMouseAiming = cFloatingOpt_Game.SendMessage(og_MouseAiming, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bMouseAiming = cFloatingOpt_Game.SendMessage(og_MouseAiming, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 /*
 				case og_AllowMouseAiming:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bAllowMouseAiming = cFloatingOpt_Game.SendMessage(og_AllowMouseAiming, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bAllowMouseAiming = cFloatingOpt_Game.SendMessage(og_AllowMouseAiming, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 */
 
 				// Match logging
 				case og_MatchLogging:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bMatchLogging = cFloatingOpt_Game.SendMessage(og_MatchLogging, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bMatchLogging = cFloatingOpt_Game.SendMessage(og_MatchLogging, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 
 				case og_AntilagMovementPrediction:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bAntilagMovementPrediction = cFloatingOpt_Game.SendMessage(og_AntilagMovementPrediction, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bAntilagMovementPrediction = cFloatingOpt_Game.SendMessage(og_AntilagMovementPrediction, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 					
 /*				case og_ScreenShaking:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bScreenShaking = cFloatingOpt_Game.SendMessage(og_ScreenShaking, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bScreenShaking = cFloatingOpt_Game.SendMessage(og_ScreenShaking, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break; */
 			}
 		}
@@ -598,14 +598,14 @@ void Menu_FloatingOptionsFrame()
 				// Show FPS
 				case os_ShowFPS:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bShowFPS = cFloatingOpt_System.SendMessage(os_ShowFPS, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bShowFPS = cFloatingOpt_System.SendMessage(os_ShowFPS, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 
 				// Logging
 				case os_LogConvos:
 					if(ev->iEventMsg == CHK_CHANGED)  {
 						// check if value is really different
-						if(tLXOptions->bLogConvos != (cFloatingOpt_System.SendMessage(os_LogConvos, CKM_GETCHECK, (DWORD)0, 0) != 0)) {
+						if(tLXOptions->bLogConvos != (cFloatingOpt_System.SendMessage(os_LogConvos, CKM_GETCHECK, (uintptr_t)0, 0) != 0)) {
 							tLXOptions->bLogConvos = ! tLXOptions->bLogConvos;
 							if (convoLogger)  {
 								if (tLXOptions->bLogConvos)  {
@@ -622,14 +622,14 @@ void Menu_FloatingOptionsFrame()
 				// Show ping
 				case os_ShowPing:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bShowPing = cFloatingOpt_System.SendMessage(os_ShowPing, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bShowPing = cFloatingOpt_System.SendMessage(os_ShowPing, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 			}
 		}
 
 
 		// Get the values
-		tLXOptions->iNetworkSpeed = (int)cFloatingOpt_System.SendMessage(os_NetworkSpeed, CBM_GETCURINDEX,(DWORD)0,0);
+		tLXOptions->iNetworkSpeed = (int)cFloatingOpt_System.SendMessage(os_NetworkSpeed, CBM_GETCURINDEX,(uintptr_t)0,0);
 
 		cFloatingOpt_System.getWidget( os_NetworkUploadBandwidth )->setEnabled( tLXOptions->iNetworkSpeed >= NST_LAN );
 		cFloatingOpt_System.getWidget( os_NetworkUploadBandwidthLabel )->setEnabled( tLXOptions->iNetworkSpeed >= NST_LAN );
@@ -638,7 +638,7 @@ void Menu_FloatingOptionsFrame()
 		if( tLXOptions->iMaxUploadBandwidth <= 0 )
 			tLXOptions->iMaxUploadBandwidth = 20000;
 
-		tLXOptions->iScreenshotFormat = (int)cFloatingOpt_System.SendMessage(os_ScreenshotFormat, CBM_GETCURINDEX,(DWORD)0,0);
+		tLXOptions->iScreenshotFormat = (int)cFloatingOpt_System.SendMessage(os_ScreenshotFormat, CBM_GETCURINDEX,(uintptr_t)0,0);
 
 		// Anti-aliasing and fullscreen
 

--- a/src/client/DeprecatedGUI/Menu_Local.cpp
+++ b/src/client/DeprecatedGUI/Menu_Local.cpp
@@ -126,14 +126,14 @@ static void Menu_Local_InitCustomLevel() {
 
 	cLocalMenu.SendMessage(ml_Playing,		LVS_ADDCOLUMN, "Playing", 24);
 	cLocalMenu.SendMessage(ml_Playing,		LVS_ADDCOLUMN, "", 300 - gfxGame.bmpTeamColours[0].get()->w - 50);
-	cLocalMenu.SendMessage(ml_Playing,		LVS_ADDCOLUMN, "", (DWORD)-1);
+	cLocalMenu.SendMessage(ml_Playing,		LVS_ADDCOLUMN, "", (uintptr_t)-1);
 	
-	cLocalMenu.SendMessage(ml_Playing,		LVM_SETOLDSTYLE, (DWORD)1, 0);
+	cLocalMenu.SendMessage(ml_Playing,		LVM_SETOLDSTYLE, (uintptr_t)1, 0);
 	
 	cLocalMenu.SendMessage(ml_PlayerList,	LVS_ADDCOLUMN, "Players", 24);
 	cLocalMenu.SendMessage(ml_PlayerList,	LVS_ADDCOLUMN, "", 60);
 	
-	cLocalMenu.SendMessage(ml_PlayerList,		LVM_SETOLDSTYLE, (DWORD)0, 0);
+	cLocalMenu.SendMessage(ml_PlayerList,		LVM_SETOLDSTYLE, (uintptr_t)0, 0);
 	
 	for(Iterator<CGameMode*>::Ref i = GameModeIterator(); i->isValid(); i->next()) {
 		cLocalMenu.SendMessage(ml_Gametype,    CBS_ADDITEM, i->get()->Name(), GetGameModeIndex(i->get()));
@@ -517,7 +517,7 @@ void Menu_LocalFrame()
 			// Game type
 			case ml_Gametype:
 				if(ev->iEventMsg == CMB_CHANGED) {
-					gameSettings.overwrite[FT_GameMode].as<GameModeInfo>()->mode = GameMode((GameModeIndex)cLocalMenu.SendMessage(ml_Gametype, CBM_GETCURINDEX, (DWORD)0, 0));
+					gameSettings.overwrite[FT_GameMode].as<GameModeInfo>()->mode = GameMode((GameModeIndex)cLocalMenu.SendMessage(ml_Gametype, CBM_GETCURINDEX, (uintptr_t)0, 0));
 
 					// Go through the items and enable/disable the team flags and update worm graphics
 					bool teams_on = gameSettings[FT_GameMode].as<GameModeInfo>()->mode->GameTeams() > 1;
@@ -657,7 +657,7 @@ static void _refillPlayerList() {
 	for_each_iterator(SmartPointer<profile_t>, p, GetProfiles()) {
 		if(playingIds.count(i) == 0) {
 			w->AddItem("", i, tLX->clListView);		
-			//cLocalMenu.SendMessage( ml_PlayerList, LVS_ADDSUBITEM, (DWORD)p->bmpWorm, LVS_IMAGE); // TODO: 64bit unsafe (pointer cast)
+			//cLocalMenu.SendMessage( ml_PlayerList, LVS_ADDSUBITEM, (uintptr_t)p->bmpWorm, LVS_IMAGE); // TODO: 64bit unsafe (pointer cast)
 			//cLocalMenu.SendMessage( ml_PlayerList, LVS_ADDSUBITEM, p->sName, LVS_TEXT);
 			w->AddSubitem( LVS_IMAGE, "", p->get()->cSkin.getPreview(), NULL );
 			w->AddSubitem( LVS_TEXT, p->get()->sName, (DynDrawIntf*)NULL, NULL );
@@ -813,7 +813,7 @@ static bool Menu_LocalStartGame_CustomGame() {
 	//
 	// Game Info
 	//
-	gameSettings.overwrite[FT_GameMode].as<GameModeInfo>()->mode = GameMode((GameModeIndex)cLocalMenu.SendMessage(ml_Gametype, CBM_GETCURINDEX, (DWORD)0, 0));
+	gameSettings.overwrite[FT_GameMode].as<GameModeInfo>()->mode = GameMode((GameModeIndex)cLocalMenu.SendMessage(ml_Gametype, CBM_GETCURINDEX, (uintptr_t)0, 0));
 	
 	gameSettings.overwrite[FT_NewNetEngine] = false; // May become buggy otherwise, new net engine doesn't support any kind of pause
 	
@@ -1604,7 +1604,7 @@ bool Menu_WeaponsRestrictions_Frame()
 	DrawImageAdv(VideoPostProcessor::videoSurface().get(), tMenu->bmpBuffer, 120,150, 120,150, 400,300);
 
     // Draw the list
-    int count = (int)cWeaponsRest.SendMessage(wr_Scroll, SCM_GETVALUE,(DWORD)0,0);
+    int count = (int)cWeaponsRest.SendMessage(wr_Scroll, SCM_GETVALUE,(uintptr_t)0,0);
 
 	int w, j;
 	w = j = 0;
@@ -1649,11 +1649,11 @@ bool Menu_WeaponsRestrictions_Frame()
 
     // Adjust the scrollbar
     cWeaponsRest.SendMessage(wr_Scroll, SCM_SETITEMSPERBOX, 12, 0);
-    cWeaponsRest.SendMessage(wr_Scroll, SCM_SETMIN, (DWORD)0, 0);
+    cWeaponsRest.SendMessage(wr_Scroll, SCM_SETMIN, (uintptr_t)0, 0);
 	if(cWpnRestList.getNumWeapons() > 10)
 		cWeaponsRest.SendMessage(wr_Scroll, SCM_SETMAX, cWpnRestList.getNumWeapons() + 1, 0);
     else
-        cWeaponsRest.SendMessage(wr_Scroll, SCM_SETMAX, (DWORD)0, 0);
+        cWeaponsRest.SendMessage(wr_Scroll, SCM_SETMAX, (uintptr_t)0, 0);
 
 
 	ev = cWeaponsRest.Process();
@@ -1778,7 +1778,7 @@ void Menu_WeaponPresets(bool save, CWpnRest *wpnrest)
 	cWpnPresets.Add( new CListview(),                            wp_PresetList, 180,170, 280,110+(!save)*20);
 	cWpnPresets.Add( new CTextbox(),                             wp_PresetName, 270,285, 190,tLX->cFont.GetHeight());
 
-	cWpnPresets.SendMessage(wp_PresetList,LVM_SETOLDSTYLE,(DWORD)0,0);
+	cWpnPresets.SendMessage(wp_PresetList,LVM_SETOLDSTYLE,(uintptr_t)0,0);
 
 	t = (CTextbox *)cWpnPresets.getWidget(wp_PresetName);
 

--- a/src/client/DeprecatedGUI/Menu_Mapeditor.cpp
+++ b/src/client/DeprecatedGUI/Menu_Mapeditor.cpp
@@ -685,7 +685,7 @@ void Menu_MapEd_LoadSave(int save)
 	cg.Add( new CListview(),                            2, 180,170, 280,110);
 	cg.Add( new CTextbox(),                             3, 260,285, 200,tLX->cFont.GetHeight());
 
-	cg.SendMessage(2,		LVM_SETOLDSTYLE, (DWORD)0, 0);
+	cg.SendMessage(2,		LVM_SETOLDSTYLE, (uintptr_t)0, 0);
 
 	t = (CTextbox *)cg.getWidget(3);
 

--- a/src/client/DeprecatedGUI/Menu_Net_Favourites.cpp
+++ b/src/client/DeprecatedGUI/Menu_Net_Favourites.cpp
@@ -351,7 +351,7 @@ void Menu_Net_FavouritesFrame(int mouse)
                     case MNU_USER+1:
 						{
 							// Remove the menu widget
-							cFavourites.SendMessage(mf_PopupMenu, MNM_REDRAWBUFFER, (DWORD)0, 0);
+							cFavourites.SendMessage(mf_PopupMenu, MNM_REDRAWBUFFER, (uintptr_t)0, 0);
 							cFavourites.removeWidget(mf_PopupMenu);
 
 							server_t::Ptr sv = ServerList::get()->findServerStr(szFavouritesCurServer);
@@ -407,7 +407,7 @@ void Menu_Net_FavouritesFrame(int mouse)
                 ServerList::get()->fillList( (CListview *)cFavourites.getWidget( mf_ServerList ), SLFT_Favourites );
 
                 // Remove the menu widget
-                cFavourites.SendMessage(mf_PopupMenu, MNM_REDRAWBUFFER, (DWORD)0, 0);
+                cFavourites.SendMessage(mf_PopupMenu, MNM_REDRAWBUFFER, (uintptr_t)0, 0);
                 cFavourites.removeWidget(mf_PopupMenu);
                 break;
 		}

--- a/src/client/DeprecatedGUI/Menu_Net_Host.cpp
+++ b/src/client/DeprecatedGUI/Menu_Net_Host.cpp
@@ -140,8 +140,8 @@ bool Menu_Net_HostInitialize()
 	//cHostPly.Add( new CLabel("Server-side Health",			tLX->clNormalLabel),-1,	125, 418,0,  0);
 	//cHostPly.Add( new CCheckbox(false),	                    hs_ServerSideHealth,	270,415,17, 17);
 
-	cHostPly.SendMessage(hs_Playing,		LVM_SETOLDSTYLE, (DWORD)0, 0);
-	cHostPly.SendMessage(hs_PlayerList,		LVM_SETOLDSTYLE, (DWORD)0, 0);
+	cHostPly.SendMessage(hs_Playing,		LVM_SETOLDSTYLE, (uintptr_t)0, 0);
+	cHostPly.SendMessage(hs_PlayerList,		LVM_SETOLDSTYLE, (uintptr_t)0, 0);
 
 	cHostPly.SendMessage(hs_Servername,TXM_SETMAX,32,0);
 	//cHostPly.SendMessage(hs_Password,TXM_SETMAX,32,0);
@@ -169,7 +169,7 @@ bool Menu_Net_HostInitialize()
 	int i = 0;
 	for_each_iterator(SmartPointer<profile_t>, p, GetProfiles()) {
 		cHostPly.SendMessage( hs_PlayerList, LVS_ADDITEM, "", i++);
-		//cHostPly.SendMessage( hs_PlayerList, LVS_ADDSUBITEM, (DWORD)p->bmpWorm, LVS_IMAGE ); // TODO: 64bit unsafe (pointer cast)
+		//cHostPly.SendMessage( hs_PlayerList, LVS_ADDSUBITEM, (uintptr_t)p->bmpWorm, LVS_IMAGE ); // TODO: 64bit unsafe (pointer cast)
 		//cHostPly.SendMessage( hs_PlayerList, LVS_ADDSUBITEM, p->sName, LVS_TEXT);
 		CListview * w = (CListview *) cHostPly.getWidget(hs_PlayerList);
 		w->AddSubitem( LVS_IMAGE, "", p->get()->cSkin.getPreview(), NULL );
@@ -479,13 +479,13 @@ void Menu_Net_HostPlyFrame(int mouse)
 					cHostPly.SendMessage( hs_WelcomeMessage, TXS_GETTEXT, &tLXOptions->sWelcomeMessage, 0);
 					//cHostPly.SendMessage( hs_Password, TXS_GETTEXT, &getGameLobby()->sPassword, 0);
 
-					tLXOptions->bRegServer =  cHostPly.SendMessage( hs_Register, CKM_GETCHECK, (DWORD)0, 0) != 0;
-					tLXOptions->bAllowWantsJoinMsg = cHostPly.SendMessage( hs_AllowWantsJoin, CKM_GETCHECK, (DWORD)0, 0) != 0;
-					tLXOptions->bWantsJoinBanned = cHostPly.SendMessage( hs_WantsJoinBanned,   CKM_GETCHECK, (DWORD)0, 0) != 0;
-					tLXOptions->bAllowRemoteBots = cHostPly.SendMessage( hs_AllowRemoteBots, CKM_GETCHECK, (DWORD)0, 0) != 0;
-					tLXOptions->bAllowNickChange = cHostPly.SendMessage( hs_AllowNickChange, CKM_GETCHECK, (DWORD)0, 0) != 0;
+					tLXOptions->bRegServer =  cHostPly.SendMessage( hs_Register, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
+					tLXOptions->bAllowWantsJoinMsg = cHostPly.SendMessage( hs_AllowWantsJoin, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
+					tLXOptions->bWantsJoinBanned = cHostPly.SendMessage( hs_WantsJoinBanned,   CKM_GETCHECK, (uintptr_t)0, 0) != 0;
+					tLXOptions->bAllowRemoteBots = cHostPly.SendMessage( hs_AllowRemoteBots, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
+					tLXOptions->bAllowNickChange = cHostPly.SendMessage( hs_AllowNickChange, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					tLXOptions->bServerSideHealth = false; // HINT: disable ssh for normal (non-dedicated) servers, as it is very cheaty
-					//tLXOptions->bServerSideHealth = cHostPly.SendMessage( hs_ServerSideHealth, CKM_GETCHECK, (DWORD)0, 0) != 0;
+					//tLXOptions->bServerSideHealth = cHostPly.SendMessage( hs_ServerSideHealth, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 
 					cHostPly.Shutdown();
 
@@ -1079,7 +1079,7 @@ void Menu_Net_HostLobbyFrame(int mouse)
 			// Game type change
 			case hl_Gamemode:
 				if(ev->iEventMsg == CMB_CHANGED) {
-					gameSettings.overwrite[FT_GameMode].as<GameModeInfo>()->mode = GameMode((GameModeIndex)cHostLobby.SendMessage(hl_Gamemode, CBM_GETCURINDEX, (DWORD)0, 0));
+					gameSettings.overwrite[FT_GameMode].as<GameModeInfo>()->mode = GameMode((GameModeIndex)cHostLobby.SendMessage(hl_Gamemode, CBM_GETCURINDEX, (uintptr_t)0, 0));
 					bHost_Update = true;
 					cServer->UpdateGameLobby();
 				}
@@ -1292,7 +1292,7 @@ bool Menu_Net_HostStartGame()
 	}
 	
 	// Get the game type
-	gameSettings.overwrite[FT_GameMode].as<GameModeInfo>()->mode = GameMode((GameModeIndex)cHostLobby.SendMessage(hl_Gamemode, CBM_GETCURINDEX, (DWORD)0, 0));
+	gameSettings.overwrite[FT_GameMode].as<GameModeInfo>()->mode = GameMode((GameModeIndex)cHostLobby.SendMessage(hl_Gamemode, CBM_GETCURINDEX, (uintptr_t)0, 0));
 
 	// Start the game
 	game.startGame();
@@ -1616,11 +1616,11 @@ bool Menu_ServerSettings_Frame()
 					cServerSettings.SendMessage(ss_WeaponSelectionMaxTime, TXS_GETTEXT, &buf, 0);
 					tLXOptions->iWeaponSelectionMaxTime = MAX( 5, atoi(buf) );	// At least 5 seconds (hit Random - Done)
 
-					tLXOptions->bAllowWantsJoinMsg = cServerSettings.SendMessage( ss_AllowWantsJoin, CKM_GETCHECK, (DWORD)0, 0) != 0;
-					tLXOptions->bWantsJoinBanned = cServerSettings.SendMessage( ss_WantsJoinBanned, CKM_GETCHECK, (DWORD)0, 0) != 0;
-					tLXOptions->bAllowRemoteBots = cServerSettings.SendMessage( ss_AllowRemoteBots, CKM_GETCHECK, (DWORD)0, 0) != 0;
-					tLXOptions->bAllowNickChange = cServerSettings.SendMessage( ss_AllowNickChange, CKM_GETCHECK, (DWORD)0, 0) != 0;
-					//tLXOptions->bServerSideHealth = cServerSettings.SendMessage( ss_ServerSideHealth, CKM_GETCHECK, (DWORD)0, 0) != 0;
+					tLXOptions->bAllowWantsJoinMsg = cServerSettings.SendMessage( ss_AllowWantsJoin, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
+					tLXOptions->bWantsJoinBanned = cServerSettings.SendMessage( ss_WantsJoinBanned, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
+					tLXOptions->bAllowRemoteBots = cServerSettings.SendMessage( ss_AllowRemoteBots, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
+					tLXOptions->bAllowNickChange = cServerSettings.SendMessage( ss_AllowNickChange, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
+					//tLXOptions->bServerSideHealth = cServerSettings.SendMessage( ss_ServerSideHealth, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 
 					Menu_ServerSettingsShutdown();
 
@@ -1911,9 +1911,9 @@ void Menu_HostActionsPopupMenuClick(CGuiLayout & layout, int id_PopupMenu, int i
                 }
 
                 // Remove the menu widget
-                layout.SendMessage( id_PopupMenu, MNM_REDRAWBUFFER, (DWORD)0, 0);
+                layout.SendMessage( id_PopupMenu, MNM_REDRAWBUFFER, (uintptr_t)0, 0);
                 layout.removeWidget(id_PopupMenu);
-                layout.SendMessage( id_PopupPlayerInfo, MNM_REDRAWBUFFER, (DWORD)0, 0);
+                layout.SendMessage( id_PopupPlayerInfo, MNM_REDRAWBUFFER, (uintptr_t)0, 0);
 				layout.removeWidget(id_PopupPlayerInfo);
 };
 
@@ -1947,9 +1947,9 @@ void Menu_HostActionsPopupPlayerInfoClick(CGuiLayout & layout, int id_PopupMenu,
 				};
 
                 // Remove the menu widget
-                layout.SendMessage( id_PopupMenu, MNM_REDRAWBUFFER, (DWORD)0, 0);
+                layout.SendMessage( id_PopupMenu, MNM_REDRAWBUFFER, (uintptr_t)0, 0);
                 layout.removeWidget(id_PopupMenu);
-                layout.SendMessage( id_PopupPlayerInfo, MNM_REDRAWBUFFER, (DWORD)0, 0);
+                layout.SendMessage( id_PopupPlayerInfo, MNM_REDRAWBUFFER, (uintptr_t)0, 0);
 				layout.removeWidget(id_PopupPlayerInfo);
 };
 

--- a/src/client/DeprecatedGUI/Menu_Net_Internet.cpp
+++ b/src/client/DeprecatedGUI/Menu_Net_Internet.cpp
@@ -400,7 +400,7 @@ void Menu_Net_NETFrame(int mouse)
 				Menu_Net_NET_ServerList_Refresher();
 
                 // Remove the menu widget
-                cInternet.SendMessage( mi_PopupMenu, MNM_REDRAWBUFFER, (DWORD)0, 0);
+                cInternet.SendMessage( mi_PopupMenu, MNM_REDRAWBUFFER, (uintptr_t)0, 0);
                 cInternet.removeWidget(mi_PopupMenu);
                 break;
 

--- a/src/client/DeprecatedGUI/Menu_Net_Lan.cpp
+++ b/src/client/DeprecatedGUI/Menu_Net_Lan.cpp
@@ -356,7 +356,7 @@ void Menu_Net_LANFrame(int mouse)
                 ServerList::get()->fillList( (CListview *)cLan.getWidget( nl_ServerList ), SLFT_Lan );
 
                 // Remove the menu widget
-                cLan.SendMessage(nl_PopupMenu, MNM_REDRAWBUFFER, (DWORD)0, 0);
+                cLan.SendMessage(nl_PopupMenu, MNM_REDRAWBUFFER, (uintptr_t)0, 0);
                 cLan.removeWidget(nl_PopupMenu);
                 break;
 		}

--- a/src/client/DeprecatedGUI/Menu_Options.cpp
+++ b/src/client/DeprecatedGUI/Menu_Options.cpp
@@ -369,20 +369,20 @@ bool Menu_OptionsInitialize()
 
 	switch (tLXOptions->iColourDepth) {
 	case 0:  // Automatic
-		cOpt_System.SendMessage(os_ColourDepth, CBM_SETCURSEL, (DWORD)0, 0);
-		cOpt_System.SendMessage(os_ColourDepth, CBM_SETCURINDEX, (DWORD)0, 0);
+		cOpt_System.SendMessage(os_ColourDepth, CBM_SETCURSEL, (uintptr_t)0, 0);
+		cOpt_System.SendMessage(os_ColourDepth, CBM_SETCURINDEX, (uintptr_t)0, 0);
 		break;
 	case 16:  // 16 bit
-		cOpt_System.SendMessage(os_ColourDepth, CBM_SETCURSEL, (DWORD)1, 0);
-		cOpt_System.SendMessage(os_ColourDepth, CBM_SETCURINDEX, (DWORD)1, 0);
+		cOpt_System.SendMessage(os_ColourDepth, CBM_SETCURSEL, (uintptr_t)1, 0);
+		cOpt_System.SendMessage(os_ColourDepth, CBM_SETCURINDEX, (uintptr_t)1, 0);
 		break;
 	case 24:  // 24 bit
-		cOpt_System.SendMessage(os_ColourDepth, CBM_SETCURSEL, (DWORD)2, 0);
-		cOpt_System.SendMessage(os_ColourDepth, CBM_SETCURINDEX, (DWORD)2, 0);
+		cOpt_System.SendMessage(os_ColourDepth, CBM_SETCURSEL, (uintptr_t)2, 0);
+		cOpt_System.SendMessage(os_ColourDepth, CBM_SETCURINDEX, (uintptr_t)2, 0);
 		break;
 	case 32:  // 32 bit
-		cOpt_System.SendMessage(os_ColourDepth, CBM_SETCURSEL, (DWORD)3, 0);
-		cOpt_System.SendMessage(os_ColourDepth, CBM_SETCURINDEX, (DWORD)3, 0);
+		cOpt_System.SendMessage(os_ColourDepth, CBM_SETCURSEL, (uintptr_t)3, 0);
+		cOpt_System.SendMessage(os_ColourDepth, CBM_SETCURINDEX, (uintptr_t)3, 0);
 		break;
 	}
 
@@ -573,7 +573,7 @@ void Menu_OptionsFrame()
 		ev = bSpeedTest ? NULL : cOpt_Game.Process();
 		cOpt_Game.Draw(VideoPostProcessor::videoSurface().get());
 
-		val = (int)cOpt_Game.SendMessage(og_BloodAmount, SLM_GETVALUE, (DWORD)0, 0);
+		val = (int)cOpt_Game.SendMessage(og_BloodAmount, SLM_GETVALUE, (uintptr_t)0, 0);
 		//s = (CSlider *)cOpt_Game.getWidget(og_BloodAmount);
         DrawImageAdv(VideoPostProcessor::videoSurface().get(), tMenu->bmpBuffer, 385,140, 385,140, 70,40);
 		tLX->cFont.Draw(VideoPostProcessor::videoSurface().get(),385, 148, tLX->clNormalLabel, itoa(val)+"%");
@@ -591,7 +591,7 @@ void Menu_OptionsFrame()
 				// Blood amount
 				case og_BloodAmount:
 					if(ev->iEventMsg == SLD_CHANGE) {
-						val = (int)cOpt_Game.SendMessage(og_BloodAmount, SLM_GETVALUE, (DWORD)0, 0);
+						val = (int)cOpt_Game.SendMessage(og_BloodAmount, SLM_GETVALUE, (uintptr_t)0, 0);
 						tLXOptions->iBloodAmount = val;
 					}
 					break;
@@ -623,70 +623,70 @@ void Menu_OptionsFrame()
 				// Old skool rope throw
 				case og_OldSkoolRope:
 					if(ev->iEventMsg == CHK_CHANGED) {
-						tLXOptions->bOldSkoolRope = cOpt_Game.SendMessage(og_OldSkoolRope,CKM_GETCHECK,(DWORD)0,0) != 0;
+						tLXOptions->bOldSkoolRope = cOpt_Game.SendMessage(og_OldSkoolRope,CKM_GETCHECK,(uintptr_t)0,0) != 0;
 					}
 					break;
 
 				// Show the worm's health below name
 /*				case og_ShowWormHealth:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->iShowHealth = cOpt_Game.SendMessage(og_ShowWormHealth, CKM_GETCHECK, (DWORD)0, 0);
+						tLXOptions->iShowHealth = cOpt_Game.SendMessage(og_ShowWormHealth, CKM_GETCHECK, (uintptr_t)0, 0);
 					break;*/
 
 				// TDM nick colorizing
 				case og_ColorizeNicks:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bColorizeNicks = cOpt_Game.SendMessage(og_ColorizeNicks, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bColorizeNicks = cOpt_Game.SendMessage(og_ColorizeNicks, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 
 				// Auto typing
 				case og_AutoTyping:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bAutoTyping = cOpt_Game.SendMessage(og_AutoTyping, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bAutoTyping = cOpt_Game.SendMessage(og_AutoTyping, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 
 				// Antialiasing
 				case og_Antialiasing:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bAntiAliasing = cOpt_Game.SendMessage(og_Antialiasing, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bAntiAliasing = cOpt_Game.SendMessage(og_Antialiasing, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 
 				// Mouse aiming
 				case og_MouseAiming:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bMouseAiming = cOpt_Game.SendMessage(og_MouseAiming, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bMouseAiming = cOpt_Game.SendMessage(og_MouseAiming, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 /*
 				case og_AllowMouseAiming:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bAllowMouseAiming = cOpt_Game.SendMessage(og_AllowMouseAiming, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bAllowMouseAiming = cOpt_Game.SendMessage(og_AllowMouseAiming, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 */
 
 				// Match logging
 				case og_MatchLogging:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bMatchLogging = cOpt_Game.SendMessage(og_MatchLogging, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bMatchLogging = cOpt_Game.SendMessage(og_MatchLogging, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 
 				case og_AntilagMovementPrediction:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bAntilagMovementPrediction = cOpt_Game.SendMessage(og_AntilagMovementPrediction, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bAntilagMovementPrediction = cOpt_Game.SendMessage(og_AntilagMovementPrediction, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 					
 		/*		case og_ScreenShaking:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bScreenShaking = cOpt_Game.SendMessage(og_ScreenShaking, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bScreenShaking = cOpt_Game.SendMessage(og_ScreenShaking, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break; */
 
 				case og_DamagePopups:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bDamagePopups = cOpt_Game.SendMessage(og_DamagePopups, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bDamagePopups = cOpt_Game.SendMessage(og_DamagePopups, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 					
 				case og_ColorizeDamageByWorm:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bColorizeDamageByWorm = cOpt_Game.SendMessage(og_ColorizeDamageByWorm, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bColorizeDamageByWorm = cOpt_Game.SendMessage(og_ColorizeDamageByWorm, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 			}
 		}
@@ -800,13 +800,13 @@ void Menu_OptionsFrame()
 				// Show FPS
 				case os_ShowFPS:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bShowFPS = cOpt_System.SendMessage(os_ShowFPS, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bShowFPS = cOpt_System.SendMessage(os_ShowFPS, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 
 				// Logging
 				case os_LogConvos:
 					if(ev->iEventMsg == CHK_CHANGED)  {
-						tLXOptions->bLogConvos = cOpt_System.SendMessage(os_LogConvos, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bLogConvos = cOpt_System.SendMessage(os_LogConvos, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 						if (convoLogger)  {
 							if (tLXOptions->bLogConvos)
 								convoLogger->startLogging();
@@ -819,13 +819,13 @@ void Menu_OptionsFrame()
 				// Show ping
 				case os_ShowPing:
 					if(ev->iEventMsg == CHK_CHANGED)
-						tLXOptions->bShowPing = cOpt_System.SendMessage(os_ShowPing, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bShowPing = cOpt_System.SendMessage(os_ShowPing, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 
 				// Use Ip To Country
 				case os_UseIpToCountry:
 					if(ev->iEventMsg == CHK_CHANGED)  {
-						tLXOptions->bUseIpToCountry = cOpt_System.SendMessage(os_UseIpToCountry, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bUseIpToCountry = cOpt_System.SendMessage(os_UseIpToCountry, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 						if (tLXOptions->bUseIpToCountry && !tIpToCountryDB->Loaded())  {
 							tIpToCountryDB->LoadDBFile(IP_TO_COUNTRY_FILE);
 						}
@@ -834,7 +834,7 @@ void Menu_OptionsFrame()
 
 				case os_ShowCountryFlags:
 					if(ev->iEventMsg == CHK_CHANGED)  {
-						tLXOptions->bShowCountryFlags = cOpt_System.SendMessage(os_ShowCountryFlags, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bShowCountryFlags = cOpt_System.SendMessage(os_ShowCountryFlags, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					}
 					break;
 
@@ -848,7 +848,7 @@ void Menu_OptionsFrame()
 				
 				case os_CheckForUpdates:
 					if(ev->iEventMsg == CHK_CHANGED)  {
-						tLXOptions->bCheckForUpdates = cOpt_System.SendMessage(os_CheckForUpdates, CKM_GETCHECK, (DWORD)0, 0) != 0;
+						tLXOptions->bCheckForUpdates = cOpt_System.SendMessage(os_CheckForUpdates, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					}
 					break;
 				
@@ -862,8 +862,8 @@ void Menu_OptionsFrame()
 		t = (CTextbox *)cOpt_System.getWidget(os_HttpProxy);
 		tLXOptions->sHttpProxy = t->getText();
 
-		tLXOptions->iNetworkSpeed = (int)cOpt_System.SendMessage(os_NetworkSpeed, CBM_GETCURINDEX,(DWORD)0,0);
-		tLXOptions->bCheckBandwidthSanity = cOpt_System.SendMessage(os_NetworkUploadCheck, CKM_GETCHECK, (DWORD)0, 0) != 0;
+		tLXOptions->iNetworkSpeed = (int)cOpt_System.SendMessage(os_NetworkSpeed, CBM_GETCURINDEX,(uintptr_t)0,0);
+		tLXOptions->bCheckBandwidthSanity = cOpt_System.SendMessage(os_NetworkUploadCheck, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 		
 		cOpt_System.getWidget( os_NetworkUploadBandwidth )->setEnabled( tLXOptions->iNetworkSpeed >= NST_LAN );
 		cOpt_System.getWidget( os_NetworkUploadBandwidthLabel )->setEnabled( tLXOptions->iNetworkSpeed >= NST_LAN );
@@ -873,7 +873,7 @@ void Menu_OptionsFrame()
 		if( tLXOptions->iMaxUploadBandwidth <= 0 )
 			tLXOptions->iMaxUploadBandwidth = 50000;
 
-		tLXOptions->iScreenshotFormat = (int)cOpt_System.SendMessage(os_ScreenshotFormat, CBM_GETCURINDEX,(DWORD)0,0);
+		tLXOptions->iScreenshotFormat = (int)cOpt_System.SendMessage(os_ScreenshotFormat, CBM_GETCURINDEX,(uintptr_t)0,0);
 
 		// FPS and fullscreen
 		t = (CTextbox *)cOpt_System.getWidget(os_MaxFPS);

--- a/src/client/DeprecatedGUI/Menu_Player.cpp
+++ b/src/client/DeprecatedGUI/Menu_Player.cpp
@@ -197,7 +197,7 @@ void Menu_PlayerInitialize()
 	cViewPlayers.SendMessage(vp_Name,TXM_SETMAX,20,0);
 	cViewPlayers.SendMessage(vp_Name, TXM_SETFLAGS, TXF_NOUNICODE, 0); // Disable unicode for backward compatibility
 
-	cViewPlayers.SendMessage(vp_Players,		LVM_SETOLDSTYLE, (DWORD)0, 0);
+	cViewPlayers.SendMessage(vp_Players,		LVM_SETOLDSTYLE, (uintptr_t)0, 0);
 
     // Hide the AI stuff until 'Computer' type is selected
     cViewPlayers.getWidget(vp_AIDiffLbl)->setEnabled(false);
@@ -321,7 +321,7 @@ void Menu_Player_ViewPlayerInit()
     Menu_Player_FillSkinCombo( (CCombobox *)cViewPlayers.getWidget(vp_PlySkin) );
 
     // Set the name of the first item in the list
-    int sel = (int)cViewPlayers.SendMessage( vp_Players, LVM_GETCURINDEX,(DWORD)0,0);
+    int sel = (int)cViewPlayers.SendMessage( vp_Players, LVM_GETCURINDEX,(uintptr_t)0,0);
 	SmartPointer<profile_t> p = FindProfile(sel);
     if(p.get()) {
         cViewPlayers.SendMessage( vp_Name,    TXS_SETTEXT, p->sName,0);
@@ -404,8 +404,8 @@ void Menu_Player_NewPlayer(int mouse)
                     cNewPlayer.SendMessage(np_PlySkin, CBS_GETCURSINDEX, &skin, 0);
 
 					// Add the profile
-                    WormType* type = ( (int)cNewPlayer.SendMessage(np_Type,CBM_GETCURINDEX,(DWORD)0,0) == PRF_HUMAN->toInt() ) ? PRF_HUMAN : PRF_COMPUTER;
-                    int level = (int)cNewPlayer.SendMessage(np_AIDiff,SLM_GETVALUE,(DWORD)0,0);
+                    WormType* type = ( (int)cNewPlayer.SendMessage(np_Type,CBM_GETCURINDEX,(uintptr_t)0,0) == PRF_HUMAN->toInt() ) ? PRF_HUMAN : PRF_COMPUTER;
+                    int level = (int)cNewPlayer.SendMessage(np_AIDiff,SLM_GETVALUE,(uintptr_t)0,0);
 
 					AddProfile(name, skin, "", "",r, g, b, type->toInt(), level);
 
@@ -423,7 +423,7 @@ void Menu_Player_NewPlayer(int mouse)
             case np_Type:
                 if(ev->iEventMsg == CMB_CHANGED) {
 
-                    int type = (int)cNewPlayer.SendMessage(np_Type,CBM_GETCURINDEX,(DWORD)0,0);
+                    int type = (int)cNewPlayer.SendMessage(np_Type,CBM_GETCURINDEX,(uintptr_t)0,0);
 
                     // Hide the AI stuff if it is a human type of player
                     cNewPlayer.getWidget(np_AIDiffLbl)->setEnabled(type == PRF_COMPUTER->toInt());
@@ -492,10 +492,10 @@ void Menu_Player_NewPlayer(int mouse)
 
 
     // Draw the difficulty level
-    int type = (int)cNewPlayer.SendMessage(np_Type,CBM_GETCURINDEX,(DWORD)0,0);
+    int type = (int)cNewPlayer.SendMessage(np_Type,CBM_GETCURINDEX,(uintptr_t)0,0);
     if( type == PRF_COMPUTER->toInt() ) {
         static const std::string difflevels[] = {"Easy", "Medium", "Hard", "Xtreme"};
-        int level = (int)cNewPlayer.SendMessage(np_AIDiff,SLM_GETVALUE,(DWORD)0,0);
+        int level = (int)cNewPlayer.SendMessage(np_AIDiff,SLM_GETVALUE,(uintptr_t)0,0);
         tLX->cFont.Draw(VideoPostProcessor::videoSurface().get(), 250,363,tLX->clNormalLabel,difflevels[level]);
 
     }
@@ -592,7 +592,7 @@ void Menu_Player_ViewPlayers(int mouse)
 						}
 
                         // Update the details
-                        int sel = (int)cViewPlayers.SendMessage(vp_Players,LVM_GETCURINDEX,(DWORD)0,0);
+                        int sel = (int)cViewPlayers.SendMessage(vp_Players,LVM_GETCURINDEX,(uintptr_t)0,0);
 	                    p = FindProfile(sel);
                         if(p.get()) {
                             cViewPlayers.SendMessage( vp_Name,		TXS_SETTEXT,    p->sName,0);
@@ -627,7 +627,7 @@ void Menu_Player_ViewPlayers(int mouse)
             // Apply button
             case vp_Apply:
                 if( ev->iEventMsg == BTN_CLICKED ) {
-                    int sel = (int)cViewPlayers.SendMessage(vp_Players, LVM_GETCURINDEX, (DWORD)0,0);
+                    int sel = (int)cViewPlayers.SendMessage(vp_Players, LVM_GETCURINDEX, (uintptr_t)0,0);
 	                SmartPointer<profile_t> p = FindProfile(sel);
 	                if(p.get()) {
 
@@ -648,11 +648,11 @@ void Menu_Player_ViewPlayers(int mouse)
                         p->sName = name;
                         cViewPlayers.SendMessage(vp_Name, TXS_SETTEXT, p->sName, 0);
 
-                        p->R = (Uint8)cViewPlayers.SendMessage(vp_Red,SLM_GETVALUE,(DWORD)0,0);
-                        p->G = (Uint8)cViewPlayers.SendMessage(vp_Green,SLM_GETVALUE,(DWORD)0,0);
-                        p->B = (Uint8)cViewPlayers.SendMessage(vp_Blue,SLM_GETVALUE,(DWORD)0,0);
+                        p->R = (Uint8)cViewPlayers.SendMessage(vp_Red,SLM_GETVALUE,(uintptr_t)0,0);
+                        p->G = (Uint8)cViewPlayers.SendMessage(vp_Green,SLM_GETVALUE,(uintptr_t)0,0);
+                        p->B = (Uint8)cViewPlayers.SendMessage(vp_Blue,SLM_GETVALUE,(uintptr_t)0,0);
                         p->iType = ((CCombobox *)cViewPlayers.getWidget(vp_Type))->getSelectedIndex();
-                        p->nDifficulty = (int)cViewPlayers.SendMessage(vp_AIDiff, SLM_GETVALUE,(DWORD)0,0);
+                        p->nDifficulty = (int)cViewPlayers.SendMessage(vp_AIDiff, SLM_GETVALUE,(uintptr_t)0,0);
 
 						// Reload the graphics
 						std::string buf;
@@ -662,7 +662,7 @@ void Menu_Player_ViewPlayers(int mouse)
 						p->cSkin.ColorizeDefault();
 
                         // Update the item
-                        lv_item_t *it = (lv_item_t *)cViewPlayers.SendMessage(vp_Players, LVM_GETCURITEM, (DWORD)0,0); // TODO: 64bit unsafe (pointer cast)
+                        lv_item_t *it = (lv_item_t *)cViewPlayers.SendMessage(vp_Players, LVM_GETCURITEM, (uintptr_t)0,0);
                         if(it) {
                             if(it->tSubitems) {
 								it->tSubitems->bmpImage = p->cSkin.getPreview();
@@ -691,7 +691,7 @@ void Menu_Player_ViewPlayers(int mouse)
             // Player listbox
             case vp_Players:
                 if( ev->iEventMsg == LV_CHANGED ) {
-                    int sel = (int)cViewPlayers.SendMessage(vp_Players,LVM_GETCURINDEX,(DWORD)0,0);
+                    int sel = (int)cViewPlayers.SendMessage(vp_Players,LVM_GETCURINDEX,(uintptr_t)0,0);
 	                SmartPointer<profile_t> p = FindProfile(sel);
                     if(p.get()) {
                         cViewPlayers.SendMessage( vp_Name,		TXS_SETTEXT,    p->sName,0);
@@ -716,7 +716,7 @@ void Menu_Player_ViewPlayers(int mouse)
             case vp_Type:
                 if( ev->iEventMsg == CMB_CHANGED ) {
 
-                    int type = (int)cViewPlayers.SendMessage(vp_Type,CBM_GETCURINDEX,(DWORD)0,0);
+                    int type = (int)cViewPlayers.SendMessage(vp_Type,CBM_GETCURINDEX,(uintptr_t)0,0);
 
                     // Hide the AI stuff if it is a human type of player
                     cViewPlayers.getWidget(vp_AIDiffLbl)->setEnabled(type == PRF_COMPUTER->toInt());
@@ -794,10 +794,10 @@ void Menu_Player_ViewPlayers(int mouse)
 	}
 
     // Draw the difficulty level
-    int type = (int)cViewPlayers.SendMessage(vp_Type,CBM_GETCURINDEX,(DWORD)0,0);
+    int type = (int)cViewPlayers.SendMessage(vp_Type,CBM_GETCURINDEX,(uintptr_t)0,0);
     if( type == PRF_COMPUTER->toInt() ) {
         static const std::string difflevels[] = {"Easy", "Medium", "Hard", "Xtreme"};
-        int level = (int)(DWORD)CLAMP(cViewPlayers.SendMessage(vp_AIDiff,SLM_GETVALUE,(DWORD)0,0), (DWORD)0, (DWORD)3);
+        int level = (int)(uintptr_t)CLAMP(cViewPlayers.SendMessage(vp_AIDiff,SLM_GETVALUE,(uintptr_t)0,0), (uintptr_t)0, (uintptr_t)3);
         tLX->cFont.Draw(VideoPostProcessor::videoSurface().get(), 530,313,tLX->clNormalLabel, difflevels[level]);
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -183,8 +183,6 @@ static void DoSystemChecks() {
 	static_assert(sizeof(short) == 2, "sizeof_short__equals2");
 	static_assert(sizeof(int) == 4, "sizeof_int__equals4");
 	static_assert(sizeof(float) == 4, "sizeof_float__equals4");
-	// sometimes the return value of SendMessage is used as a pointer
-	static_assert(sizeof(DWORD) == sizeof(void*), "sizeof_dword__equals_p");
 }
 
 


### PR DESCRIPTION
OLX's DeprecatedGUI exposes a Win32-style `SendMessage(int, DWORD, DWORD)` virtual on every widget, and two of the message codes round-trip a **pointer** through those `DWORD` parameters (`LVM_GETCURITEM` returns `(DWORD)lv_item_t*`; `CBS_ADDSITEM` casts `Param` back to `std::string*`). That only works when `DWORD` is pointer-sized.

**`DWORD` is the wrong type here, period — not just unportable.** Per Microsoft's own definition, `DWORD` is *strictly a 32-bit unsigned integer*, never pointer-sized. The Win32 `SendMessage` types for "may carry a pointer" are `WPARAM` / `LPARAM` / `UINT_PTR`, which Microsoft introduced specifically for the 32→64-bit transition. The portable C++ equivalent is `uintptr_t` from `<cstdint>`, defined by the standard as "an unsigned integer type capable of holding a pointer".

The misuse went undetected for 24 years because OLX's `typedef unsigned long DWORD;` coincidentally tracks `void*` size on three of four target data models:

| Platform | `unsigned long` | `void*` | round-trip |
|---|---|---|---|
| ILP32 (Win32, 32-bit Linux) | 4 | 4 | ✓ |
| LP64 (Linux/macOS x64) | 8 | 8 | ✓ (coincidence) |
| **LLP64 (Windows x64)** | **4** | **8** | **✗ — truncates** |

The `static_assert(sizeof(DWORD) == sizeof(void*))` added to `main.cpp` in 2008 (commit `3d4d34a9`) was a tripwire — and it is currently the reason the Windows x64 build fails to compile.

### This PR

- Replaces `DWORD` with `uintptr_t` in `CWidget::SendMessage` and all 20 widget overrides, plus all callers in `Menu_*.cpp` and `CClient_Draw.cpp`.
- Drops the `DWORD` typedef from `include/olx-types.h` and the now-vacuous `static_assert` from `main.cpp`.
- Removes the three now-stale `// TODO: 64bit unsafe (pointer cast)` comments at the round-trip sites.

### What is not changed

Win32-specific files in `src/common/` (`Process.cpp`, `SystemFunctions.cpp`, `HTTP.cpp`, `EventQueue.cpp`, `StackWalker.cpp/.h`, `Debug_DumpCallstack.cpp`) keep using `DWORD` via `<windows.h>`. There it is Microsoft's real `DWORD` in actual Win32 API signatures (`RaiseException`, registry, dbghelp, toolhelp) — the right type for 32-bit error codes / thread IDs / byte counts. That use is correct and orthogonal to the misuse this PR fixes.

### Effect

- Linux x86_64, 32-bit, macOS x64: zero behavioural change. Builds clean (verified locally).
- Windows x64: build unblocks. Previously-truncating listview pointer round-trip on the player setup screen ("select player → context menu") now works correctly.