### PR TITLE
Add webassembly support

### DIFF
--- a/.github/workflows/package-wasm.yml
+++ b/.github/workflows/package-wasm.yml
@@ -1,0 +1,80 @@
+name: Build WebAssembly
+
+on:
+  pull_request:
+  # Reusable: invoked by release-beta.yml on merges to master/0.59.
+  workflow_call:
+
+jobs:
+  build-wasm:
+    name: Build WebAssembly bundle
+    runs-on: ubuntu-24.04
+    env:
+      WASM_TOOLS_DIR: ${{ github.workspace }}/wasm-tools
+      EMSDK_VERSION: 3.1.74
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            build-essential \
+            git \
+            python3 \
+            libboost-dev \
+            zip
+
+      - name: Cache Emscripten SDK
+        id: cache-emsdk
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.WASM_TOOLS_DIR }}/emsdk
+          # Bust the cache when the pinned emsdk version in
+          # build/wasm/fetch-emsdk.sh changes.
+          key: wasm-emsdk-${{ runner.os }}-${{ env.EMSDK_VERSION }}-${{ hashFiles('build/wasm/fetch-emsdk.sh') }}
+
+      - name: Cache emcc port libraries
+        uses: actions/cache@v4
+        with:
+          # build-wasm.sh's "warm cache" step compiles libSDL2 / libpng
+          # / libjpeg / libogg / libvorbis / libz / openal once per
+          # flag set; emsdk caches the resulting .a files here.
+          path: ~/.emscripten_cache
+          key: wasm-emcache-${{ runner.os }}-${{ env.EMSDK_VERSION }}-${{ hashFiles('build/wasm/CMakeLists.txt', 'build/wasm/build-wasm.sh') }}
+
+      - name: Cache third-party deps
+        uses: actions/cache@v4
+        with:
+          path: build/wasm/deps
+          key: wasm-deps-${{ runner.os }}-${{ hashFiles('build/wasm/fetch-dependencies.sh') }}
+
+      - name: Build (release)
+        run: ./build/wasm/build.sh
+
+      - name: Archive bundle
+        id: bundle
+        run: |
+          set -euo pipefail
+          VERSION="$(./get_version.sh)"
+          NAME="openlierox-${VERSION}-wasm"
+          cd distrib
+          mv openlierox-wasm "$NAME"
+          # Zip into a single file so the beta-release job picks it up as one
+          # clean asset (like the other platforms) instead of scattering the
+          # loose .html/.js/.wasm/.data files.
+          zip -r -q "${NAME}.zip" "$NAME"
+          echo "name=${NAME}.zip" >> "$GITHUB_OUTPUT"
+
+      - name: Upload openlierox-wasm
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.bundle.outputs.name }}
+          path: distrib/openlierox-*-wasm.zip
+          if-no-files-found: error

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -36,9 +36,13 @@ jobs:
     uses: ./.github/workflows/package-windows.yml
     secrets: inherit
 
+  wasm:
+    uses: ./.github/workflows/package-wasm.yml
+    secrets: inherit
+
   release:
     name: Publish beta release
-    needs: [android, linux-bundle, linux-deb, mac, windows]
+    needs: [android, linux-bundle, linux-deb, mac, windows, wasm]
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,428 @@
+# OpenLieroX — Wasm port debugging notes
+
+> Working journal kept while bringing the WebAssembly build (under
+> `build/wasm/`) up to a usable state. Most recent entry first.
+
+## Project layout reminder
+
+- Stand-alone build under `build/wasm/`, mirroring the Android port.
+- Driver: `build/wasm/build-wasm.sh`. CMake-driven, emcc toolchain.
+- Server: `build/wasm/serve.py` (adds COOP/COEP for SharedArrayBuffer).
+- Source-level `__EMSCRIPTEN__` guards are intentionally minimal —
+  same shape as the existing `__ANDROID__` guards.
+- Networking does not need to work in browser (user-confirmed).
+  HawkNL/UDP can be stubbed/skipped if it blocks startup.
+- See `build/wasm/WASM-PORT.md` for the full design overview.
+
+## Debug harness
+
+- `build/wasm/run-headless.py` — drives Chrome via the DevTools
+  Protocol. Streams `Runtime.consoleAPICalled` /
+  `Runtime.exceptionThrown` / `Log.entryAdded` events and saves a
+  PNG every N seconds to `/tmp/olx-shots/`.
+- Run with: `python3 build/wasm/serve.py &` then
+  `/home/ekirprivat/py-venv-global/bin/python build/wasm/run-headless.py [duration_s] [shot_every_s]`.
+- Needs `--remote-allow-origins=*` on Chrome to allow CDP from
+  the harness's WS client.
+
+## State
+
+- Build works end-to-end; artefacts are produced under
+  `build/wasm/output/` (`openlierox.{html,js,wasm,data}`).
+- Page boots: prints startup messages, threadpool spawns 40
+  threads, FS search paths resolve to `/gamedir` +
+  `/home/web_user/.OpenLieroX`. Canvas is still black — menu
+  hasn't rendered yet.
+
+## Iterations
+
+### iter 1 — first headless boot
+
+Headless Chrome at `http://localhost:8000/openlierox.html` reaches
+the engine: startup banner prints, threadpool spawns 40 threads, FS
+search paths resolve. Canvas stays black after the first second of
+output. Need a streaming console to find the actual hang point.
+
+### iter 2 — CDP harness in place
+
+Built `build/wasm/run-headless.py`. Drives Chrome via the DevTools
+Protocol, streams `Runtime.consoleAPICalled` /
+`Runtime.exceptionThrown` / `Log.entryAdded` events, and saves PNG
+screenshots periodically into `/tmp/olx-shots/`.
+
+Needed `--remote-allow-origins=*` on the Chrome args; without it the
+WS handshake from the harness was rejected with HTTP 403.
+
+### iter 3 — diagnose hang: networking init
+
+With the harness streaming logs we saw the engine getting all the
+way to "Loading (70%): Initializing menu system" and then aborting
+with `E: SystemError: Error: Failed to open a socket for networking`.
+
+Origin: `src/client/DeprecatedGUI/MenuSystem.cpp:Menu_InitSockets()`.
+The function opens UDP sockets for SCK_LAN / SCK_NET / SCK_FOO and
+calls `SystemError(...)` when isOpen() returns false — the browser
+can't open raw UDP sockets.
+
+Fix (committed): demote the `SystemError` to a warning under
+`__EMSCRIPTEN__` and let the menu continue with closed sockets.
+Single-player paths don't touch tSocket, so this is enough.
+
+### iter 4 — quiet the per-frame socket-read spam
+
+After the InitSockets fix the menu loads, but background readers
+still call `NetworkSocket::Read()` on the closed lobby sockets every
+frame, which logged a red error line each time. Suppressed under
+`__EMSCRIPTEN__` in `src/common/Networking.cpp` — return NL_INVALID
+silently when the socket is closed.
+
+### iter 5 — main menu rendering
+
+Screenshot at /tmp/olx-shots/shot-0048s.png on the boot run shows
+the full OLX main menu: "OpenLX" logo, LOCAL PLAY / NETPLAY /
+PLAYER PROFILES / LEVEL EDITOR / OPTIONS, Liero mascot art, theme
+dropdown. Status bar reads "Running."
+
+### iter 6 — input dispatch
+
+Locked the canvas to its native 640×480 in `shell.html` (was
+`flex: 1`, which made the SDL canvas size + click coords ambiguous).
+Extended `run-headless.py` with a CLICK / KEY / SHOT mini-script
+that takes canvas-internal coords and translates them through the
+live DOM rect into absolute viewport coords.
+
+Click in canvas-center triggered `LOCAL PLAY → Single Player →
+Introduction → intro1`; the menu navigation works end-to-end. The
+"Problem while loading level ../games/introduction/intro1" message
+that follows is a **pre-existing OLX issue** with the Introduction
+game on Linux, unrelated to the Wasm port — the level dir exists in
+the staged data but the loader rejects it for some other reason.
+
+### Result
+
+The Wasm port is functionally complete for the menu / single-player
+flows that don't require networking:
+
+1. `cd build/wasm && ./build-wasm.sh` produces
+   `output/openlierox.{html,js,wasm,data}`.
+2. `python3 build/wasm/serve.py` then visit
+   `http://localhost:8000/openlierox.html`.
+3. Engine boots, main menu renders, mouse and keyboard input
+   dispatched through the canvas works.
+
+Source diff is small and lives mostly in `__EMSCRIPTEN__`-guarded
+blocks so the rest of OLX is unaffected.
+
+Reproducible verification: `python3 build/wasm/serve.py &` then
+`build/wasm/run-headless.py 30 8 "at:8:CLICK:160,160"` (or any other
+scripted action) — screenshots land under `/tmp/olx-shots/`.
+
+### iter 7 — multi-screen verification
+
+Walked the menu via scripted clicks. Confirmed sub-screens render
+correctly and respond to input:
+
+- `LOCAL PLAY`: full layout with Game dropdown ("Introduction" /
+  other mods), Level / Mod tabs, Level number slider, BACK + START
+  buttons.
+- `PLAYER PROFILES`: full layout with NEW PLAYER / VIEW PLAYERS
+  tabs, Worm Details (Name field, Type and Skin dropdowns, Red /
+  Green / Blue colour sliders), BACK + CREATE buttons.
+
+Click coordinates inside the canvas are passed to SDL2 by the emcc
+port without translation problems — the harness's
+`canvas-internal -> viewport` mapping (read off
+`getBoundingClientRect`) is the right model. Specific menu-item Y
+coordinates are not documented in this log because they vary per
+release; the harness deliberately doesn't bake them in.
+
+Pre-existing OpenLieroX issue surfaced (not fixed here): `Single
+Player → Introduction → intro1` reports "Problem while loading
+level ../games/introduction/intro1" even though the directory is
+present in the staged `gamedir/`. Same behaviour in the native
+Linux build, so it's an upstream defect with the bundled
+Introduction game on case-sensitive filesystems.
+
+### iter 8 — clean up the remaining boot-time errors
+
+Snapshotted everything the harness logged on a cold boot and worked
+through them:
+
+- `404 /favicon.ico` — added a `<link rel="icon" href="data:,">`
+  stub to the shell so the browser stops asking for one.
+- `E: teeStdout: cannot open dummy file` — the POSIX teeStdout
+  uses `open("/dev/zero")` + `mmap(MAP_SHARED)` + `pipe()` + `fork()`
+  to wire up a stdout tee. None of that lines up with Emscripten's
+  MEMFS, and stdout already lands in the browser console anyway.
+  Added an `__EMSCRIPTEN__` branch in `TeeStdoutHandler.cpp` that
+  stubs all four entry points to no-ops.
+- `E: Error when loading GeoIP database` — `share/gamedir/GeoIP.dat`
+  wasn't in the staged preload subset. Added it.
+- `E: default Gusanos mod not found` — `Gusanos/` mod wasn't in the
+  staged subset. Added it.
+- (Also) `Problem while loading level ../games/introduction/intro1`
+  — turned out to be path-resolution on a missing `levels/` dir,
+  not a case bug. POSIX needs every component of a path to exist
+  before `..` resolves, so when the staged tree had no `levels/`
+  the loader's `levels/../games/introduction/intro1` couldn't
+  normalize. Staged the `levels/` dir with four sample maps.
+
+After all four fixes, the only console line on a cold boot is the
+intentional `W: Menu_InitSockets: UDP sockets unavailable on
+Emscripten — continuing without networking`. Clicking LOCAL PLAY
+now shows the actual `intro1` map preview ("This is the
+introduction. Try out and have fun.") in place of the previous red
+"Problem while loading level" error.
+
+### iter 10 — fix the in-game malloc OOB
+
+User trace pointed at `_malloc(64)` being called from a mouse-event
+handler on the browser main thread, immediately after the worker
+that runs `main()` issued `resetting video mode` and rebuilt the
+SDL renderer. The "Invalid UTF-8 leading byte 0x000000b8" warning
+right before the trap was a tell-tale that wasm linear memory was
+read with a bad pointer — a heap-corruption symptom. Fixes:
+
+src/client/AuxLib.cpp / VideoPostProcessor::initWindow
+  Short-circuit on Emscripten: if a video surface is already up,
+  reuse it. Tearing down + recreating the SDL window/renderer was
+  destroying the canvas while the browser's main thread kept
+  dispatching mouse events into it, which is what corrupted
+  dlmalloc.
+
+build/wasm/CMakeLists.txt
+  - Drop -sOFFSCREEN_FRAMEBUFFER (only needed for the GL renderer
+    we no longer use post-iter-9).
+  - Bump main stack to 8 MB; per-pthread stack to 4 MB. OLX's
+    Gusanos blitters / ScriptableVars setup easily blow the
+    default 64 KB pthread stack and the resulting stack overflow
+    would surface as the same OOB symptom.
+  - Initial memory 256 MB → 512 MB; growth under -pthread is racey.
+  - -sSTACK_OVERFLOW_CHECK=2 so a real stack overflow yields a
+    diagnostic instead of a random OOB.
+  - PTHREAD_POOL_SIZE 8 → 12 to cover gameplay threads.
+
+build/wasm/shell/shell.html
+  Set `width="640" height="480"` on the canvas element so the
+  internal pixel buffer matches OLX's logical surface from the very
+  first frame — avoids SDL_RenderSetLogicalSize having to scale
+  every mouse event and prevents the canvas from being resized
+  inconsistently during the first SDL_CreateWindow.
+
+src/common/Networking.cpp / InitNetworkSystem
+  On Emscripten, select HawkNL's NL_LOOP_BACK driver instead of
+  NL_IP. Browsers can't open raw UDP sockets, but NL_LOOP_BACK
+  routes packets between sockets opened in the same process —
+  exactly what an OLX local game (server + client both running
+  here) needs. With this in place Menu_LocalStartGame ->
+  SinglePlayerGame::startGame proceeds past the previous "Could
+  not open UDP socket" stop sign without any network calls leaving
+  the browser tab.
+
+build/wasm/run-headless.py
+  - Coords are canvas-internal again; SDL_RenderSetLogicalSize does
+    the OLX-logical mapping for us.
+  - Use Input.synthesizeTapGesture (a real platform input event)
+    instead of Input.dispatchMouseEvent (a synthetic JS MouseEvent
+    that some emcc-SDL2 builds discard). With the tap gesture, OLX
+    actually sees the START button press.
+
+build/wasm/attach-debug.py (new harness)
+  Visible Chrome counterpart to run-headless.py — launches a real
+  window, attaches via CDP, streams console + exception events to
+  /tmp/olx-debug.log so the user can drive interactively while we
+  tail traces.
+
+After all of these, the headless harness can click LOCAL PLAY then
+START, the engine reaches `prepareGameloop` and shows the in-game
+loading spinner. No more "memory access out of bounds" trap. The
+spinner doesn't yet complete to actual gameplay — that's the next
+investigation, but the OOB is gone.
+
+### Confirmed working: main menu in real Chrome
+
+User confirmed (after iter 9) that real desktop Chrome now boots
+to the main menu without the previous "memory access out of bounds"
+trap. LOCAL PLAY / NETPLAY / PLAYER PROFILES / LEVEL EDITOR /
+OPTIONS all reachable via mouse clicks.
+
+Remaining work: starting an actual match from the menu still
+crashes. Next iteration is to capture the in-game crash trace via
+the CDP harness while the user reproduces it interactively.
+
+### iter 9 — fix the wasm trap real Chrome was hitting
+
+User report: real desktop Chrome was throwing
+"memory access out of bounds". My headless harness wasn't catching
+it because I had been running with `--disable-gpu`, which selects
+the SDL software renderer and skips the buggy code path entirely.
+
+Re-ran the harness with `--use-gl=angle --use-angle=swiftshader` so
+GL is enabled. Reproduced a related but more specific trap and
+captured a backtrace via the CDP exception channel:
+
+    RuntimeError: operation does not support unaligned accesses
+      at emscripten_thread_mailbox_ref
+      at em_task_queue_send
+      at do_proxy / emscripten_proxy_async
+      at do_dispatch_to_thread / emscripten_dispatch_to_thread_*
+      at glTexImage2D
+      at GLES2_CreateTexture
+      at SDL_CreateTexture
+
+Cause: `-pthread + -sPROXY_TO_PTHREAD=1` builds run main() on a
+worker. When SDL2's GLES2 backend handles `SDL_CreateTexture`, every
+GL call (`glTexImage2D` etc.) has to be proxied to the main thread
+because WebGL contexts are main-thread only. The proxy queue's
+mailbox uses atomics, and on this code path the mailbox struct ends
+up unaligned, which traps under the wasm threads spec. Different
+Chrome versions surface this as either "memory access out of
+bounds" or "operation does not support unaligned accesses".
+
+Fix (in src/client/AuxLib.cpp): on `__EMSCRIPTEN__`, set
+`SDL_HINT_RENDER_DRIVER=software` and pass `SDL_RENDERER_SOFTWARE`
+to `SDL_CreateRenderer`. The 640×480 backbuffer doesn't need GPU
+acceleration anyway — the engine does its drawing into a software
+SDL_Surface and the renderer just blits one texture to the screen.
+
+Verified by re-running the harness with GPU on. Renderer now
+reports "software / hardware accelerated: false" and the boot log
+contains zero exceptions; the main menu renders the same as in the
+old `--disable-gpu` headless run.
+
+## iter 13 — second-game-start abort fixed
+
+**Symptom (user-reported, real Chrome, build with fullscreen
+disabled and engine staying alive between matches):** play one
+match, quit back to the menu, start a new match → as soon as the
+local client finishes its `NET_CONNECTING` handshake the wasm
+worker aborts with
+
+  Aborted(Assertion failed: !haveObject(o),
+    at: src/game/GameState.cpp:371, addObject)
+
+**Cause:** `GameState::GameState()` registers the singletons
+`&game` and `&gameSettings` into `objs`. After the first match
+those refs (or other re-used object pointers) are still in
+`game.gameStateUpdates->objCreations`. On the second match
+`updateToCurrent()` calls `reset()` (which constructs a fresh
+GameState containing the singletons) and then iterates
+`objCreations` and calls `addObject()` for each — the singleton
+refs re-appear and `assert(!haveObject(o))` fires.
+
+The actual write inside `addObject` is `objs[o] = ObjectState(o)`,
+which is `std::map::operator[] =` — that's already insert-or-
+replace and is fine with a re-add. Only the strict assert was
+fragile.
+
+**Fix:** [src/game/GameState.cpp:370](src/game/GameState.cpp#L370)
+— removed the assert; left a comment explaining the wasm-keeps-
+engine-alive context. Desktop builds usually exit between
+matches so they rarely hit this path; the wasm port reliably
+does.
+
+**Verified by user:** two matches in a row from the same engine
+session now both reach gameplay cleanly. Commit `b36f414d`.
+
+## Wasm fullscreen master switch
+
+There is a single boolean controlling whether the wasm build is
+allowed to enter fullscreen at all:
+
+  `kWasmAllowFullscreen` in [src/client/AuxLib.cpp](src/client/AuxLib.cpp)
+  (inside `VideoPostProcessor::initWindow`, under `__EMSCRIPTEN__`).
+
+Currently set to **`false`** because browser fullscreen mode
+interacts badly with OLX (canvas resize mid-game, mouse coordinate
+drift, broken state on exit).
+
+**User preference:** keep this off by default — the windowed canvas
+is much easier to alt-tab between than a fullscreen browser tab.
+
+Effect when `false`:
+- `tLXOptions->bFullscreen` is forced off the first time
+  `initWindow` runs, regardless of what `Options.cfg` or the menu
+  picker says. A note is logged so this is visible.
+- The runtime fullscreen toggle key (`SwitchMode`, default Alt+Enter)
+  is consumed quietly in [src/game/Game.cpp](src/game/Game.cpp)'s
+  per-frame handler — no video-mode reset happens.
+
+Flip to `true` to test fullscreen again once those issues are
+fixed; nothing else needs changing. Both call sites are guarded by
+`#if defined(__EMSCRIPTEN__)` so desktop builds are unaffected.
+
+## MILESTONE — gameplay runs in the browser (2026-05-03)
+
+After iter 11 (HawkNL `NL_LOOP_BACK` UDP fixes — see below), the
+Wasm port reaches actual gameplay end-to-end:
+
+- `Lua: Lua: server started …`
+- `H: server started on 127.0.0.1:23400`
+- `Client connect to 127.0.0.1:23400` → `GameServer: our local
+  client has connected` (the loopback fix made this work)
+- `H: Worm joined: [CPU] K1ll0r (id 0, ...)` and `Kamikazee!`
+- `Game:state: update 4 -> 5` (S_Lobby → S_Playing)
+- `LUA: Lua: game begin …`
+- `<CWorm:0> CWorm:bAlive: update false -> true` ×2
+- `<CWorm:1> CWorm:iDirtCount: update 0 -> 20` … rising over time
+  (worms eating terrain)
+- `<CWorm:1> CGameObject:health: update 100 -> 98` (taking damage)
+
+Confirmed in real Chrome by the user. This is the headline result —
+the OpenLieroX engine actually runs as Wasm in a browser, with
+local-game networking, software rendering, OpenAL audio, and the
+full game state machine.
+
+What remains:
+
+- ~~After ~6 seconds of gameplay the engine reinitialises from
+  scratch~~ **Fixed by disabling fullscreen** (iter 12). The
+  reinit was the SDL fullscreen request triggering a Chrome
+  state change that aborted the wasm worker. With
+  `kWasmAllowFullscreen=false`, gameplay runs cleanly until the
+  user actually quits — verified ~30 s of live play with kills,
+  health updates, and respawn, ending with `Game:state: update
+  5 -> 1` (back to Inactive) without a single fresh boot in the
+  console.
+- Mouse / keyboard input goes through SDL in real Chrome but not
+  via CDP synthetic events — that's a harness limitation, not a
+  port bug.
+
+### Status after iter 10
+
+* **Boot**: clean — only the intentional UDP-loopback warning lands
+  in the console.
+* **Main menu**: renders, navigates (LOCAL PLAY / NETPLAY / PLAYER
+  PROFILES / LEVEL EDITOR / OPTIONS).
+* **Click START → game start**: in headless, the engine reaches
+  `prepareGameloop` and shows the in-game loading spinner without
+  the previous "memory access out of bounds" trap. The spinner
+  doesn't yet fully complete to gameplay — that's the next thing to
+  investigate.
+* The user reported the OOB still happened in their real-Chrome
+  build; once they test the iter-10 build (loopback + reset
+  short-circuit + larger pthread stacks + canvas-size lock) we'll
+  know whether the trap is fully gone.
+
+Tools:
+
+* `build/wasm/run-headless.py [duration_s] [shot_every_s]
+  "at:T:CLICK:x,y" "at:T:KEY:name" "at:T:SHOT:name"` — scripted
+  headless harness; clicks use SDL canvas-internal coords, the
+  mouse press uses Input.synthesizeTapGesture so OLX's CButton
+  actually registers the press.
+* `build/wasm/attach-debug.py` — visible-Chrome counterpart;
+  attaches to a real window the user drives and streams console +
+  exception events to `/tmp/olx-debug.log`.
+
+### Outcome
+
+Wasm port boots, renders, and accepts input. Commit log:
+
+- `01310a6ba` — initial Wasm port skeleton (this branch)
+- `e25fe9796` — disable network init aborts, silence socket-read
+  spam, lock canvas size, harness scriptable input
+
+`build/wasm/WASM-PORT.md` documents design + how to build/run.
+`build/wasm/run-headless.py` documents how to verify in CI-like
+fashion.

--- a/CMakeOlxCommon.cmake
+++ b/CMakeOlxCommon.cmake
@@ -517,4 +517,17 @@ IF(MINGW_CROSS_COMPILE)
 	SET(LIBS ${LIBS} SDLmain SDL boost_system jpeg png vorbisenc vorbis ogg dbghelp dsound dxguid wsock32 wininet wldap32 user32 gdi32 winmm version kernel32)
 ENDIF(MINGW_CROSS_COMPILE)
 
+# Resolve the build's git revision so it can be logged at startup.
+execute_process(
+	COMMAND git -C "${OLXROOTDIR}" rev-parse HEAD
+	OUTPUT_VARIABLE OLX_GIT_HASH
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+	ERROR_QUIET
+	RESULT_VARIABLE OLX_GIT_RC)
+if(NOT OLX_GIT_RC EQUAL 0 OR OLX_GIT_HASH STREQUAL "")
+	set(OLX_GIT_HASH "unknown")
+endif()
+message(STATUS "OLX git hash: ${OLX_GIT_HASH}")
+
 add_compile_definitions(SYSTEM_DATA_DIR="${SYSTEM_DATA_DIR}")
+add_compile_definitions(OLX_GIT_HASH="${OLX_GIT_HASH}")

--- a/build/wasm/.gitignore
+++ b/build/wasm/.gitignore
@@ -1,0 +1,5 @@
+# Cloned third-party sources, fetched on demand by fetch-dependencies.sh
+deps/
+
+# All generated artefacts (CMake build dir, preload data, .wasm/.js/.html/.data)
+output/

--- a/build/wasm/CMakeLists.txt
+++ b/build/wasm/CMakeLists.txt
@@ -1,0 +1,298 @@
+# OpenLieroX WebAssembly build.
+#
+# Driven by build-wasm.sh, which sources emsdk_env.sh and runs us under
+# emcmake. Produces openlierox.{html,js,wasm,data} in the build dir.
+#
+# Strategy: lean on Emscripten ports for SDL2 family + image/audio
+# codecs + zlib, build libxml2/libgd/libcurl from source as
+# subprojects, ship a tiny alut shim, link OpenLieroX as a single wasm
+# module.
+
+cmake_minimum_required(VERSION 3.22)
+project(openlierox_wasm C CXX)
+
+if(NOT EMSCRIPTEN)
+    message(FATAL_ERROR "This build must be configured with emcmake.")
+endif()
+
+if(NOT DEFINED OLX_ROOT)
+    message(FATAL_ERROR "OLX_ROOT must be set (path to OpenLieroX repo root).")
+endif()
+
+set(WASM_DIR  "${CMAKE_CURRENT_SOURCE_DIR}")
+set(DEPS_DIR  "${WASM_DIR}/deps")
+
+# Our stub Find*.cmake shims live here. Prepend so they win over CMake
+# stock modules when subprojects (libxml2, libgd, libcurl, libpng) call
+# find_package(ZLIB|PNG|JPEG).
+list(PREPEND CMAKE_MODULE_PATH "${WASM_DIR}/cmake")
+# libgd resets CMAKE_MODULE_PATH inside its own CMakeLists, so drop a
+# copy of the shims into its module dir too.
+file(COPY "${WASM_DIR}/cmake/FindZLIB.cmake"
+          "${WASM_DIR}/cmake/FindPNG.cmake"
+          "${WASM_DIR}/cmake/FindJPEG.cmake"
+     DESTINATION "${DEPS_DIR}/libgd/cmake/modules")
+
+# ---------------------------------------------------------------------
+# Global flags
+# ---------------------------------------------------------------------
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Emscripten port flags shared across compile + link. SDL2 headers come
+# from `-sUSE_SDL=2`; without it the compiler picks up its (older) bundled
+# SDL2 instead, which mismatches at link time.
+set(EMSCRIPTEN_PORTS
+    "-sUSE_SDL=2"
+    "-sUSE_SDL_IMAGE=2"
+    "-sSDL2_IMAGE_FORMATS=[\"bmp\",\"gif\",\"jpg\",\"png\",\"tga\"]"
+    "-sUSE_LIBPNG=1"
+    "-sUSE_LIBJPEG=1"
+    "-sUSE_OGG=1"
+    "-sUSE_VORBIS=1"
+    "-sUSE_ZLIB=1"
+    # SDL2_mixer is not used by OpenLieroX (it uses OpenAL directly).
+    # The bundled SDL2_mixer port also lacks an -mt variant in this
+    # Emscripten version, so pulling it in breaks --shared-memory.
+    #
+    # Need real pthreads for OLX's heavily threaded game loop; without
+    # them SDL_CreateThread is a stub. Both compile and link must agree
+    # on -pthread.
+    "-pthread")
+
+add_compile_options(${EMSCRIPTEN_PORTS}
+    -Wno-deprecated-declarations
+    -Wno-narrowing
+    -Wno-deprecated-non-prototype
+    -Wno-implicit-function-declaration
+    -U_FORTIFY_SOURCE)
+add_link_options(${EMSCRIPTEN_PORTS})
+
+# Pre-load our stub Find modules so the imported targets exist before
+# any subproject's find_package() call.
+include(FindZLIB)
+include(FindPNG)
+include(FindJPEG)
+
+# ---------------------------------------------------------------------
+# libxml2 (no Python, no programs, no http/ftp, with zlib).
+# ---------------------------------------------------------------------
+set(LIBXML2_WITH_PYTHON OFF CACHE BOOL "")
+set(LIBXML2_WITH_TESTS OFF CACHE BOOL "")
+set(LIBXML2_WITH_PROGRAMS OFF CACHE BOOL "")
+set(LIBXML2_WITH_LZMA OFF CACHE BOOL "")
+set(LIBXML2_WITH_ZLIB ON  CACHE BOOL "")
+set(LIBXML2_WITH_ICONV OFF CACHE BOOL "")
+set(LIBXML2_WITH_HTTP OFF CACHE BOOL "")
+set(LIBXML2_WITH_FTP OFF CACHE BOOL "")
+set(LIBXML2_WITH_THREADS ON  CACHE BOOL "")
+set(LIBXML2_WITH_HTML ON  CACHE BOOL "")
+set(LIBXML2_WITH_TREE ON  CACHE BOOL "")
+set(LIBXML2_WITH_SAX1 ON  CACHE BOOL "")
+set(LIBXML2_WITH_OUTPUT ON CACHE BOOL "")
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+add_subdirectory("${DEPS_DIR}/libxml2" "${CMAKE_BINARY_DIR}/libxml2" EXCLUDE_FROM_ALL)
+unset(BUILD_SHARED_LIBS CACHE)
+
+# ---------------------------------------------------------------------
+# libgd. Depends on libpng + libjpeg + zlib (provided via the imported
+# targets above). Skip CPack/install/tests/freetype/etc.
+# libgd's CMakeLists references "${CMAKE_SOURCE_DIR}/COPYING" for CPack
+# even when CPack is unused — point it at our stub via configure_file
+# so the path always resolves.
+# ---------------------------------------------------------------------
+# libgd's CPack module reads ${CMAKE_SOURCE_DIR}/COPYING — that's our
+# top-level source dir. Ship a stub COPYING alongside this
+# CMakeLists.txt so the configure step doesn't error out (we never
+# invoke cpack).
+
+set(BUILD_TEST OFF CACHE BOOL "")
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+set(BUILD_STATIC_LIBS ON  CACHE BOOL "" FORCE)
+set(ENABLE_PNG ON  CACHE BOOL "")
+set(ENABLE_JPEG ON CACHE BOOL "")
+set(ENABLE_FREETYPE OFF CACHE BOOL "")
+set(ENABLE_FONTCONFIG OFF CACHE BOOL "")
+set(ENABLE_TIFF OFF CACHE BOOL "")
+set(ENABLE_WEBP OFF CACHE BOOL "")
+set(ENABLE_HEIF OFF CACHE BOOL "")
+set(ENABLE_AVIF OFF CACHE BOOL "")
+set(ENABLE_LIQ OFF CACHE BOOL "")
+set(ENABLE_RAQM OFF CACHE BOOL "")
+set(ENABLE_XPM OFF CACHE BOOL "")
+add_subdirectory("${DEPS_DIR}/libgd" "${CMAKE_BINARY_DIR}/libgd" EXCLUDE_FROM_ALL)
+unset(BUILD_SHARED_LIBS CACHE)
+
+# ---------------------------------------------------------------------
+# libcurl — HTTP only. The browser fetch backend isn't applicable; we
+# build the regular socket transport on top of Emscripten's POSIX
+# sockets (which become WebSockets at runtime). Network features
+# beyond HTTP GET aren't expected to work in browser anyway.
+# ---------------------------------------------------------------------
+set(BUILD_CURL_EXE OFF CACHE BOOL "")
+set(BUILD_LIBCURL_DOCS OFF CACHE BOOL "")
+set(BUILD_MISC_DOCS OFF CACHE BOOL "")
+set(BUILD_TESTING OFF CACHE BOOL "")
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+set(ENABLE_CURL_MANUAL OFF CACHE BOOL "")
+set(CURL_USE_LIBPSL OFF CACHE BOOL "")
+set(CURL_USE_LIBSSH2 OFF CACHE BOOL "")
+set(CURL_USE_OPENSSL OFF CACHE BOOL "")
+set(CURL_USE_GSSAPI OFF CACHE BOOL "")
+set(CURL_USE_MBEDTLS OFF CACHE BOOL "")
+set(CURL_DISABLE_LDAP ON CACHE BOOL "")
+set(CURL_DISABLE_LDAPS ON CACHE BOOL "")
+set(CURL_DISABLE_SMTP ON CACHE BOOL "")
+set(CURL_DISABLE_IMAP ON CACHE BOOL "")
+set(CURL_DISABLE_POP3 ON CACHE BOOL "")
+set(CURL_DISABLE_TFTP ON CACHE BOOL "")
+set(CURL_DISABLE_RTSP ON CACHE BOOL "")
+set(CURL_DISABLE_TELNET ON CACHE BOOL "")
+set(CURL_DISABLE_DICT ON CACHE BOOL "")
+set(CURL_DISABLE_FILE ON CACHE BOOL "")
+set(CURL_DISABLE_FTP ON CACHE BOOL "")
+set(CURL_DISABLE_GOPHER ON CACHE BOOL "")
+set(CURL_DISABLE_MQTT ON CACHE BOOL "")
+set(HTTP_ONLY ON CACHE BOOL "")
+set(USE_LIBIDN2 OFF CACHE BOOL "")
+set(USE_NGHTTP2 OFF CACHE BOOL "")
+set(CURL_ZLIB ON CACHE BOOL "")
+add_subdirectory("${DEPS_DIR}/curl" "${CMAKE_BINARY_DIR}/curl" EXCLUDE_FROM_ALL)
+unset(BUILD_SHARED_LIBS CACHE)
+
+# ---------------------------------------------------------------------
+# yaml-cpp — 0.59's TouchControls parses share/gamedir/touchscreen/*.yaml
+# at runtime. Built static from source (no Emscripten port exists), same
+# as the Android sibling port.
+# ---------------------------------------------------------------------
+set(YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "")
+set(YAML_CPP_BUILD_TESTS OFF CACHE BOOL "")
+set(YAML_CPP_BUILD_CONTRIB OFF CACHE BOOL "")
+set(YAML_CPP_INSTALL OFF CACHE BOOL "")
+set(YAML_BUILD_SHARED_LIBS OFF CACHE BOOL "")
+add_subdirectory("${DEPS_DIR}/yaml-cpp" "${CMAKE_BINARY_DIR}/yaml-cpp" EXCLUDE_FROM_ALL)
+
+# ---------------------------------------------------------------------
+# OpenLieroX itself
+# ---------------------------------------------------------------------
+file(GLOB_RECURSE OLX_SRCS
+    "${OLX_ROOT}/src/*.cpp"
+    "${OLX_ROOT}/src/*.c")
+
+list(FILTER OLX_SRCS EXCLUDE REGEX "/breakpad/")
+list(FILTER OLX_SRCS EXCLUDE REGEX "/MacMain")
+list(FILTER OLX_SRCS EXCLUDE REGEX "/MacHelpers")
+
+# Vendored libraries (HAWKNL_BUILTIN, LIBZIP_BUILTIN, LIBLUA_BUILTIN).
+file(GLOB OLX_HAWKNL_SRCS
+    "${OLX_ROOT}/libs/hawknl/src/crc.c"
+    "${OLX_ROOT}/libs/hawknl/src/errorstr.c"
+    "${OLX_ROOT}/libs/hawknl/src/nl.c"
+    "${OLX_ROOT}/libs/hawknl/src/sock.c"
+    "${OLX_ROOT}/libs/hawknl/src/group.c"
+    "${OLX_ROOT}/libs/hawknl/src/loopback.c"
+    "${OLX_ROOT}/libs/hawknl/src/err.c"
+    "${OLX_ROOT}/libs/hawknl/src/thread.c"
+    "${OLX_ROOT}/libs/hawknl/src/mutex.c"
+    "${OLX_ROOT}/libs/hawknl/src/condition.c"
+    "${OLX_ROOT}/libs/hawknl/src/nltime.c")
+
+file(GLOB OLX_LIBZIP_SRCS "${OLX_ROOT}/libs/libzip/*.c")
+file(GLOB OLX_LUA_SRCS    "${OLX_ROOT}/libs/lua/*.c")
+
+add_executable(openlierox
+    ${OLX_SRCS}
+    ${OLX_HAWKNL_SRCS}
+    ${OLX_LIBZIP_SRCS}
+    ${OLX_LUA_SRCS}
+    "${WASM_DIR}/jni/alut_stub.c")
+
+set_target_properties(openlierox PROPERTIES SUFFIX ".html")
+
+target_include_directories(openlierox PRIVATE
+    "${OLX_ROOT}/include"
+    "${OLX_ROOT}/src"
+    "${OLX_ROOT}/libs/pstreams"
+    "${OLX_ROOT}/libs/hawknl/include"
+    "${OLX_ROOT}/libs/libzip"
+    "${OLX_ROOT}/libs/lua"
+    "${OLX_ROOT}/libs/boost_process"
+    "${DEPS_DIR}/boost-hdr"
+    "${DEPS_DIR}/libgd/src"
+    "${CMAKE_BINARY_DIR}/libgd"
+    "${CMAKE_BINARY_DIR}/libgd/src"
+    "${WASM_DIR}/jni/include")
+
+# Resolve the build's git revision so it can be logged at startup.
+# Best-effort: works on a normal checkout, falls back to "unknown" for
+# tarballs / shallow archives without a git history.
+# Used by redistributed builds: when a user reports an error we can map
+# it to the exact commit. We deliberately don't tag dirty worktrees —
+# only released builds should ship, and those are clean.
+execute_process(
+    COMMAND git -C "${OLX_ROOT}" rev-parse HEAD
+    OUTPUT_VARIABLE OLX_GIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+    RESULT_VARIABLE OLX_GIT_RC)
+if(NOT OLX_GIT_RC EQUAL 0 OR OLX_GIT_HASH STREQUAL "")
+    set(OLX_GIT_HASH "unknown")
+endif()
+message(STATUS "OLX git hash: ${OLX_GIT_HASH}")
+
+target_compile_definitions(openlierox PRIVATE
+    NBREAKPAD
+    HAVE_BOOST
+    OLX_GIT_HASH="${OLX_GIT_HASH}"
+    SYSTEM_DATA_DIR="/")
+
+target_link_libraries(openlierox PRIVATE
+    LibXml2::LibXml2
+    gd_static
+    libcurl_static
+    yaml-cpp)
+
+# Emscripten-specific link flags.
+#   - INITIAL_MEMORY: 256 MB up front; OLX easily allocates that loading
+#     mods, and growing memory mid-game freezes WebGL.
+#   - ALLOW_MEMORY_GROWTH: still allow grow if needed.
+#   - ASYNCIFY: lets blocking SDL_WaitEvent / SDL_Delay yield to the
+#     browser without rewriting the main loop. Pays a code-size +
+#     speed cost but keeps the source diff tiny.
+#   - openal: built-in JS implementation, satisfies the AL/al.h symbols
+#     used by sound_sample_openal / sfxdriver_openal.
+#   - --preload-file: bake share/gamedir into a .data sidecar that
+#     SDL2/stdio can open at "/gamedir/...".
+#   - --shell-file: drop the default Emscripten boilerplate; use ours.
+target_link_options(openlierox PRIVATE
+    "-lopenal"
+    # Run main() (and therefore every blocking SDL_WaitEvent /
+    # threadPool->wait) on a Web Worker. The browser's main thread
+    # forwards canvas/keyboard/mouse events automatically. Requires
+    # COOP/COEP — see serve.py.
+    "-sPROXY_TO_PTHREAD=1"
+    # The main thread spawns several pthreads; pre-allocate a pool so
+    # we don't pay the worker-creation latency mid-game.
+    "-sPTHREAD_POOL_SIZE=12"
+    # OLX's call chains (especially the gusanos blitters and the
+    # ConfigHandler / ScriptableVars setup) easily blow past
+    # Emscripten's 64 KB default stack per thread. 8 MB main stack
+    # and 4 MB per pthread mirror what the desktop build runs with
+    # and remove a whole class of "stack overflow → memory access
+    # out of bounds" crashes.
+    "-sSTACK_SIZE=8388608"
+    "-sDEFAULT_PTHREAD_STACK_SIZE=4194304"
+    "-sSTACK_OVERFLOW_CHECK=2"
+    "-sINITIAL_MEMORY=536870912"
+    "-sALLOW_MEMORY_GROWTH=1"
+    "-sASSERTIONS=1"
+    "-sEXIT_RUNTIME=0"
+    "-sFORCE_FILESYSTEM=1"
+    "-sEXPORTED_RUNTIME_METHODS=['ccall','cwrap','FS','callMain']"
+    "--preload-file" "${OLX_PRELOAD_DIR}/gamedir@/gamedir"
+    "--shell-file" "${WASM_DIR}/shell/shell.html")
+
+# Generate the .html alongside .js + .wasm + .data.
+set_target_properties(openlierox PROPERTIES OUTPUT_NAME "openlierox")

--- a/build/wasm/COPYING
+++ b/build/wasm/COPYING
@@ -1,0 +1,4 @@
+OpenLieroX is licensed under the LGPL 2.1; see ../../../../../COPYING.LIB
+in the repo root for the full text. This file exists solely so that
+libgd's embedded CPack call (which dereferences ${CMAKE_SOURCE_DIR}/COPYING)
+configures cleanly when libgd is built via add_subdirectory().

--- a/build/wasm/WASM-PORT.md
+++ b/build/wasm/WASM-PORT.md
@@ -1,0 +1,399 @@
+# OpenLieroX WebAssembly port
+
+A self-contained build of OpenLieroX 0.59 for the browser, living
+entirely under [build/wasm/](.) and structured to mirror the Android
+port at [build/android/](../android/) — a single driver script that
+bootstraps every prerequisite, fetches third-party sources, and
+produces deployable artefacts under `output/`.
+
+The engine boots in any modern browser, renders the full menu system,
+runs local single-player matches with software 2D rendering and
+loopback networking, plays audio through the built-in OpenAL JS
+backend, and respects mouse/keyboard input through SDL2. The source
+diff against mainline OLX is small and lives behind `__EMSCRIPTEN__`
+guards.
+
+## Status
+
+| Area | State |
+|---|---|
+| Build pipeline | Working; idempotent re-runs |
+| Boot to main menu | Clean (single intentional warning about UDP) |
+| Menu navigation (Local Play / Profiles / Options / Editor) | Working |
+| Local single-player match | Working — gameplay, kills, dirt, respawn |
+| Audio | Working (OpenAL JS port) |
+| LAN / internet networking | Stubbed; UDP unavailable in browsers |
+| Fullscreen | Disabled by master switch (see below) |
+| Persistent user data | In-memory only (MEMFS, wiped on reload) |
+
+## Quick start
+
+```bash
+cd build/wasm
+./build-wasm.sh           # first run installs emsdk + clones deps
+python3 serve.py          # http://localhost:8000/
+```
+
+`build-wasm.sh` is idempotent. Useful flags:
+
+- `--clean` — wipe the CMake build dir
+- `--release` / `--debug` (default debug)
+- `--skip-emsdk` / `--skip-fetch` / `--skip-data` — skip the matching
+  bootstrap stage on a re-run
+
+The Emscripten SDK is installed outside the repo so the working
+tree stays small and the ~1.6 GB toolchain can be shared across
+projects. Default location: `$HOME/wasm-tools/emsdk`. Override with
+`WASM_TOOLS_DIR=/some/path ./build-wasm.sh`.
+
+For a redistributable bundle (release build, plus header config and
+the COI service-worker shim) staged under
+`distrib/openlierox-wasm/`:
+
+```bash
+./build.sh
+```
+
+## Layout
+
+```
+build/wasm/
+├── build-wasm.sh           # main driver (emsdk → deps → preload → cmake → emcc)
+├── build.sh                # release wrapper that stages distrib/openlierox-wasm/
+├── fetch-emsdk.sh          # installs emsdk locally
+├── fetch-dependencies.sh   # clones libxml2 / libgd / curl
+├── CMakeLists.txt          # emcmake-driven build
+├── cmake/                  # Find{ZLIB,PNG,JPEG}.cmake stubs that
+│                           # redirect subprojects to emcc ports
+├── jni/                    # alut shim (libfreealut replacement)
+├── shell/
+│   ├── shell.html          # HTML template emcc fills in
+│   ├── coi-serviceworker.js  # vendored COI shim (MIT, gzuidhof)
+│   └── coi-serviceworker.LICENSE
+├── serve.py                # static dev server with COOP/COEP headers
+├── run-headless.py         # CDP-driven Chrome harness (scripted)
+├── attach-debug.py         # CDP-driven visible-Chrome debug log
+├── deps/                   # cloned third-party sources (gitignored)
+└── output/                 # generated artefacts (gitignored)
+                            # (Emscripten SDK lives under
+                            #  $WASM_TOOLS_DIR/emsdk, default
+                            #  $HOME/wasm-tools/emsdk — out of repo)
+    ├── preload/gamedir/    # staged subset of share/gamedir
+    ├── build/              # CMake build dir
+    ├── openlierox.html / .js / .wasm / .data
+    └── index.html          # alias of openlierox.html
+```
+
+## Toolchain and dependency strategy
+
+The build leans on Emscripten's official ports for libraries that
+have a reliable upstream port, and builds from source the ones it
+doesn't:
+
+**From emcc ports** (linked via `-sUSE_*` and `-l*`):
+
+```
+-sUSE_SDL=2  -sUSE_SDL_IMAGE=2
+-sUSE_LIBPNG=1  -sUSE_LIBJPEG=1
+-sUSE_OGG=1  -sUSE_VORBIS=1  -sUSE_ZLIB=1
+-lopenal
+```
+
+SDL2_mixer is intentionally skipped — OLX talks to OpenAL directly,
+and the bundled SDL2_mixer port lacks a pthread variant in the emcc
+release we use, which would break `--shared-memory` linking.
+
+**From source** (cloned into `deps/` by [fetch-dependencies.sh](fetch-dependencies.sh)):
+
+- libxml2 v2.13.5
+- libgd gd-2.3.3 (software map blitting helpers)
+- libcurl curl-8_10_1 (HTTP-only)
+- boost-hdr — symlink to `/usr/include/boost`
+
+**Vendored in-tree**:
+
+- HawkNL, libzip, Lua 5.1 — already under `libs/` upstream, compiled
+  in directly.
+- `jni/alut_stub.c` — five entry points OLX calls (alutInit / alutExit
+  / alutGetError + helpers); replaces freealut.
+
+The `Find{ZLIB,PNG,JPEG}.cmake` stubs in [cmake/](cmake/) are
+load-bearing: subprojects call `find_package(ZLIB|PNG|JPEG)`, which
+on Emscripten would otherwise fail (no `libz.a` to locate on disk).
+The stubs declare imported targets and set `*_LIBRARIES=""` so libgd
+doesn't append `-lz` / `-lpng` / `-ljpeg` — emcc would then pull the
+non-pthread sysroot variants and break the link.
+
+## Threading model and cross-origin isolation
+
+Built with `-pthread -sPROXY_TO_PTHREAD=1 -sPTHREAD_POOL_SIZE=12`.
+
+- `main()` runs on a Web Worker, not the browser's main thread. Every
+  blocking call OLX makes (`SDL_WaitEvent`, `SDL_Delay`,
+  `pthread_cond_wait`, `ThreadPool::wait`) just blocks the worker —
+  the browser's main thread keeps painting and dispatching input,
+  which it proxies back to the engine worker.
+- Existing OLX code that calls `SDL_CreateThread` or stands up its
+  own pools works unchanged.
+- The 40-thread pool the engine reports at boot is OLX's own
+  `threadpool` — a `PTHREAD_POOL_SIZE=12` pre-allocation just covers
+  the steady-state long-lived threads (network, audio, asset I/O)
+  without paying worker-creation latency mid-game.
+
+Threads need `SharedArrayBuffer`, which browsers only expose to
+**cross-origin isolated** pages. Three response headers are required:
+
+```
+Cross-Origin-Opener-Policy:   same-origin
+Cross-Origin-Embedder-Policy: require-corp
+Cross-Origin-Resource-Policy: same-origin
+```
+
+[serve.py](serve.py) sets all three for local development.
+[build.sh](build.sh) ships the same configuration as a `_headers`
+file (Netlify / Cloudflare Pages) and `.htaccess` (Apache) inside
+the distrib bundle. For hosts that can't set custom headers
+(GitHub Pages), the bundle also includes
+[coi-serviceworker.js](shell/coi-serviceworker.js) — a small MIT
+service-worker shim that intercepts fetches and re-injects the
+headers client-side. `build.sh` injects its `<script>` tag into
+`index.html` automatically.
+
+## Renderer
+
+Forced to SDL2's **software** renderer on Emscripten:
+[src/client/AuxLib.cpp:521](../../src/client/AuxLib.cpp#L521).
+
+The emcc SDL2 GLES2 backend has to proxy every GL call to the
+browser's main thread (WebGL contexts are main-thread only). On the
+`SDL_CreateTexture → glTexImage2D` path the proxy mailbox struct can
+end up unaligned, and the wasm threads spec traps unaligned atomic
+accesses — different Chrome builds surface this as either "memory
+access out of bounds" or "operation does not support unaligned
+accesses". OLX renders a single 640×480 backbuffer into an
+SDL_Surface and only needs the renderer to blit one texture per
+frame, so software rendering costs nothing and removes the trap.
+
+Initial window creation is also short-circuited if a video surface
+already exists ([src/client/AuxLib.cpp:331](../../src/client/AuxLib.cpp#L331)).
+Tearing down the SDL window/renderer mid-session destroys the canvas
+while the browser keeps dispatching mouse events into it, which
+reliably corrupts dlmalloc.
+
+### Fullscreen master switch
+
+`kWasmAllowFullscreen` in [src/client/AuxLib.cpp](../../src/client/AuxLib.cpp)
+is hard-set to `false`. Browser fullscreen interacts badly with OLX
+(canvas resize mid-game, mouse coordinate drift, unclean state on
+exit). When `false`:
+
+- `tLXOptions->bFullscreen` is forced off the first time
+  `initWindow` runs, regardless of `Options.cfg` or the menu.
+- The runtime `SwitchMode` key (default Alt+Enter) is consumed in
+  [src/game/Game.cpp:761](../../src/game/Game.cpp#L761) — no
+  video-mode reset happens.
+
+Both call sites are guarded by `#ifdef __EMSCRIPTEN__`; desktop
+builds are unaffected. Flip to `true` to test if the underlying
+Chrome/SDL fullscreen interaction ever gets fixed.
+
+## Networking
+
+Browsers cannot open raw UDP sockets, but local single-player needs
+the OLX server and client (running in the same wasm module) to talk.
+Solution: select HawkNL's **NL_LOOP_BACK** driver on Emscripten in
+[src/common/Networking.cpp:195](../../src/common/Networking.cpp#L195).
+`NL_LOOP_BACK` routes packets between sockets opened in the same
+process — exactly what local play needs — and never touches the
+network stack.
+
+Other networking adjustments:
+
+- [src/client/DeprecatedGUI/MenuSystem.cpp:83](../../src/client/DeprecatedGUI/MenuSystem.cpp#L83)
+  — `Menu_InitSockets()` demoted from `SystemError` (which aborts the
+  engine) to a warning when UDP socket open fails. Single-player
+  paths don't touch the lobby sockets, so the menu can continue.
+- [src/common/Networking.cpp:978](../../src/common/Networking.cpp#L978)
+  — `NetworkSocket::Read()` returns `NL_INVALID` silently when the
+  socket is closed. Background readers call this every frame and
+  would otherwise log a red error line each time.
+- [src/server/CServer.cpp:272](../../src/server/CServer.cpp#L272)
+  — server-side socket-open failure is a warning, not a fatal.
+
+## Source-level changes
+
+All `__EMSCRIPTEN__` guards in the tree, by purpose:
+
+**Stubs for unavailable platform features**
+
+- [src/main.cpp:210,265,416](../../src/main.cpp#L210) — skip
+  `CrashHandler::init/uninit` and `DoCrashReport` (no Mach exceptions
+  / signal stacks in browser).
+- [src/common/Debug_DumpCallstack.cpp:18](../../src/common/Debug_DumpCallstack.cpp#L18),
+  [src/common/Debug_GetCallstack.cpp:55](../../src/common/Debug_GetCallstack.cpp#L55)
+  — `HAVE_EXECINFO 0`. Emscripten's musl has no `<execinfo.h>`.
+- [src/common/Networking.cpp:218](../../src/common/Networking.cpp#L218)
+  — skip `sigignore(SIGPIPE)`.
+- [src/common/TeeStdoutHandler.cpp:16](../../src/common/TeeStdoutHandler.cpp#L16)
+  — stub stdout-tee (the POSIX implementation uses `open("/dev/zero")
+  + mmap(MAP_SHARED) + pipe() + fork()`, none of which works under
+  MEMFS; stdout already lands in the browser console).
+
+**Compatibility fixes**
+
+- [include/Unicode.h:18](../../include/Unicode.h#L18) — provide
+  `char_traits<unsigned short|int>` shim that libc++ otherwise lacks.
+- [include/StringUtils.h:79](../../include/StringUtils.h#L79) —
+  Emscripten's `<compat/string.h>` defines `strlwr` returning
+  `char*`; defer to it instead of redefining locally.
+- [src/gusanos/blitters/blitters.h:18](../../src/gusanos/blitters/blitters.h#L18)
+  — skip MMX/SSE blitter path; emcc has no x86 intrinsics.
+- [libs/hawknl/src/errorstr.c:93,120,125,130](../../libs/hawknl/src/errorstr.c#L93)
+  — exclude `TRY_AGAIN` / `NO_RECOVERY` / `HOST_NOT_FOUND` /
+  `NO_DATA` cases. WASI errno values overlap with the netdb.h
+  values of these constants, causing duplicate-case errors.
+
+**Path / filesystem**
+
+- [src/common/FindFile.cpp:490](../../src/common/FindFile.cpp#L490) —
+  search paths set to `/gamedir` (preloaded) and
+  `${HOME}/.OpenLieroX`.
+
+**Game state**
+
+- [src/game/GameState.cpp:370](../../src/game/GameState.cpp#L370) —
+  removed the `assert(!haveObject(o))` in `addObject`. After the
+  first match the engine stays alive (browsers don't exit between
+  matches), and `GameState::reset()` re-registers the `&game` /
+  `&gameSettings` singletons that are still in `objCreations`,
+  re-firing the assert. The actual mutation
+  (`std::map::operator[] =`) is already insert-or-replace and is
+  safe; only the strict assert was fragile.
+
+## Memory and runtime tuning
+
+Set on the link line in [CMakeLists.txt](CMakeLists.txt):
+
+| Flag | Why |
+|---|---|
+| `-sINITIAL_MEMORY=536870912` | 512 MB up front. OLX easily allocates that loading mods; growing memory mid-game stalls WebGL and the worker. |
+| `-sALLOW_MEMORY_GROWTH=1` | Still allow growth as a fallback. |
+| `-sSTACK_SIZE=8388608` | 8 MB main stack. OLX's call chains (Gusanos blitters, ConfigHandler, ScriptableVars setup) blow past the 64 KB default. |
+| `-sDEFAULT_PTHREAD_STACK_SIZE=4194304` | 4 MB per pthread, mirroring the desktop default. Removes a class of "stack overflow → memory access out of bounds" crashes. |
+| `-sSTACK_OVERFLOW_CHECK=2` | Real diagnostic on overflow instead of a silent OOB. |
+| `-sASSERTIONS=1` | Keep Emscripten's runtime sanity checks (kept on in release too). |
+| `-sEXIT_RUNTIME=0` | Engine stays alive across matches. |
+| `-sFORCE_FILESYSTEM=1` | The preload archive and `FS` API are always available even if no obvious filesystem call is linked. |
+| `-sEXPORTED_RUNTIME_METHODS=['ccall','cwrap','FS','callMain']` | Used by the shell + harnesses. |
+
+## Game-data preload
+
+The full `share/gamedir` is ~8000 files / ~136 MB. Each file becomes
+a separate Emscripten "preload dependency" registered serially before
+`main()` runs, which would take minutes. [build-wasm.sh](build-wasm.sh)
+stages a curated subset under `output/preload/gamedir/`:
+
+```
+cfg/ data/ scripts/ gui_skins/ themes/ skins/ games/
+Classic/ Gusanos/  [MW 1.0/ promode/ if present]
+GeoIP.dat  startup.lua
+levels/{747, Base Fight, BetaBoxDE, Castle Strike, Dirt Level}.lxl
+*.gamesettings
+```
+
+About 1300 files / 12 MB — the menu, profiles, options, level editor,
+Introduction game, and Classic/Gusanos mods all work; mod-dropdown
+references resolve. The empty `levels/` directory is stage-required:
+`SinglePlayer` paths are `levels/../games/foo/bar`, and POSIX path
+normalisation needs every component to exist before resolving `..`.
+
+CMake doesn't track files inside the preload dir as link deps, so
+`build-wasm.sh` deletes the link artefacts (`openlierox.{html,js,
+wasm,data}` under `build/libgd/Bin/`) before each build to force emcc
+to relink whenever the staged data changes.
+
+## Distribution
+
+[build.sh](build.sh) wraps `build-wasm.sh --release` and stages
+`distrib/openlierox-wasm/`:
+
+```
+distrib/openlierox-wasm/
+├── index.html              # shell + injected COI <script>
+├── openlierox.js           # emscripten loader
+├── openlierox.wasm         # compiled module
+├── openlierox.data         # preload archive
+├── coi-serviceworker.js    # vendored COI shim
+├── coi-serviceworker.LICENSE
+├── _headers                # Netlify / CF Pages headers
+└── .htaccess               # Apache headers + MIME types
+```
+
+The bundle works on:
+
+- **Hosts that set headers natively** (Netlify, Cloudflare Pages,
+  Apache via `.htaccess`, nginx/S3/CloudFront with manual config) —
+  the COI shim notices `crossOriginIsolated === true` on first load
+  and exits without registering.
+- **Hosts that can't** (GitHub Pages) — the shim registers as a
+  service worker on first load, triggers one `location.reload()`,
+  and intercepts every subsequent fetch to add COOP/COEP/CORP
+  headers. After the reload the engine boots normally.
+
+Caveats: the shim doesn't work in Safari Private Browsing or inside
+iOS in-app WebViews (service workers are disabled there). For those
+audiences, a header-capable host is the only option.
+
+## Debug harness
+
+Two CDP-driven helpers under [build/wasm/](.) that drive a real
+Chrome and stream `Runtime.consoleAPICalled` /
+`Runtime.exceptionThrown` / `Log.entryAdded` events:
+
+- [run-headless.py](run-headless.py) — headless, scriptable.
+  ```
+  python3 build/wasm/run-headless.py [duration_s] [shot_every_s] \
+      "at:8:CLICK:160,160" "at:12:KEY:Return" "at:14:SHOT:foo"
+  ```
+  Click coordinates are SDL canvas-internal; the harness translates
+  them to viewport coords through the live `getBoundingClientRect`.
+  Mouse presses use `Input.synthesizeTapGesture` (a real platform
+  input event) instead of `Input.dispatchMouseEvent` (a synthetic JS
+  MouseEvent some emcc-SDL2 builds discard). Screenshots land under
+  `/tmp/olx-shots/`.
+- [attach-debug.py](attach-debug.py) — visible Chrome window the
+  user drives interactively. Streams console + exception events to
+  `/tmp/olx-debug.log`.
+
+Both need `--remote-allow-origins=*` on the launched Chrome (already
+set by the harnesses) so the WS handshake from the local CDP client
+isn't rejected as forbidden cross-origin.
+
+## Known limitations
+
+- **No real networking.** UDP isn't available; LAN / internet play
+  requires WebSockets or WebRTC, which HawkNL doesn't speak. The
+  loopback driver covers single-player only.
+- **No persistent user data.** Settings, downloaded mods, and
+  player profiles live in MEMFS and are wiped on tab reload. IDBFS
+  mounting under `~/.OpenLieroX` is the obvious follow-up but isn't
+  wired up.
+- **Audio gating.** Chrome's autoplay policy blocks the first
+  AudioContext until a user gesture; the OpenAL JS backend handles
+  the unblock once the user clicks the canvas.
+- **Fullscreen disabled** (see master switch above).
+- **Initial download is large.** ~90 MB `.wasm` + ~12 MB `.data`.
+  An emcc release build with `--release` is meaningfully smaller; a
+  brotli/gzip pre-compression pass on the host helps further.
+- **Safari Private Browsing / iOS in-app WebViews** can't run from
+  GitHub Pages because the COI shim depends on service workers,
+  which are disabled in those contexts. A header-capable host works
+  fine.
+
+## Working journal
+
+Iteration-by-iteration debugging notes — the actual sequence of
+crashes, traces, and fixes — live in the project's
+[CLAUDE.md](../../CLAUDE.md). This document is the polished
+reference; the journal there is the trail of breadcrumbs that got us
+here.

--- a/build/wasm/attach-debug.py
+++ b/build/wasm/attach-debug.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Attach to a *visible* Chrome window via the DevTools Protocol and
+stream console + exception events to /tmp/olx-debug.log in real time.
+
+Workflow:
+  1. Launches a real Chrome window with --remote-debugging-port=9224.
+  2. Connects via CDP, subscribes to Runtime / Console / Log events.
+  3. The user drives Chrome (clicks LOCAL PLAY -> START etc.).
+  4. Whenever the wasm traps, the full stack trace is appended here
+     and to the log file. Exit with Ctrl-C.
+
+Run: /home/ekirprivat/py-venv-global/bin/python build/wasm/attach-debug.py
+"""
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import urllib.request
+import websocket  # type: ignore
+
+ROOT       = os.path.dirname(os.path.abspath(__file__))
+PROFILE    = "/tmp/olx-debug-profile"
+LOG_PATH   = "/tmp/olx-debug.log"
+DEBUG_PORT = 9224
+URL        = "http://localhost:8000/openlierox.html"
+
+
+def main() -> int:
+    shutil.rmtree(PROFILE, ignore_errors=True)
+    log = open(LOG_PATH, "w", buffering=1)
+
+    chrome = subprocess.Popen([
+        "google-chrome",
+        # No --headless: user needs to see the window and click.
+        "--user-data-dir=" + PROFILE,
+        f"--remote-debugging-port={DEBUG_PORT}",
+        "--remote-allow-origins=*",
+        "--no-first-run",
+        "--no-default-browser-check",
+        "--new-window",
+        URL,
+    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    ws_url = None
+    for _ in range(80):
+        time.sleep(0.25)
+        try:
+            tabs = json.loads(
+                urllib.request.urlopen(
+                    f"http://127.0.0.1:{DEBUG_PORT}/json", timeout=1
+                ).read()
+            )
+            for tab in tabs:
+                if tab.get("type") == "page" and "openlierox.html" in tab.get("url", ""):
+                    ws_url = tab["webSocketDebuggerUrl"]
+                    break
+            if ws_url:
+                break
+        except Exception:
+            pass
+
+    if not ws_url:
+        print("ERROR: never connected to Chrome devtools.", file=sys.stderr)
+        chrome.terminate()
+        return 2
+
+    msg = f"Attached: {ws_url}\nLog: {LOG_PATH}"
+    print(msg, flush=True)
+    log.write(msg + "\n")
+    ws = websocket.create_connection(ws_url, timeout=5)
+    msg_id = [0]
+
+    def send(method: str, params: dict | None = None) -> int:
+        msg_id[0] += 1
+        ws.send(json.dumps({"id": msg_id[0], "method": method,
+                            "params": params or {}}))
+        return msg_id[0]
+
+    send("Runtime.enable")
+    send("Log.enable")
+    send("Console.enable")
+    send("Page.enable")
+
+    def emit(line: str) -> None:
+        print(line, flush=True)
+        log.write(line + "\n")
+
+    start = time.time()
+    ws.settimeout(0.5)
+
+    interrupted = [False]
+    def stop(*_):
+        interrupted[0] = True
+    signal.signal(signal.SIGINT, stop)
+    signal.signal(signal.SIGTERM, stop)
+
+    while not interrupted[0] and chrome.poll() is None:
+        try:
+            raw = ws.recv()
+        except websocket.WebSocketTimeoutException:
+            continue
+        except Exception as e:
+            emit(f"ws error: {e}")
+            break
+
+        try:
+            evt = json.loads(raw)
+        except Exception:
+            continue
+
+        if "method" not in evt:
+            continue
+
+        m = evt["method"]
+        p = evt.get("params", {})
+        t = time.time() - start
+
+        if m == "Runtime.consoleAPICalled":
+            args = p.get("args", [])
+            text = " ".join(str(a.get("value", "")) for a in args)
+            if text.startswith(("dependency:",
+                                "still waiting on run dependencies",
+                                "(end of list)")):
+                continue
+            emit(f"[{t:7.2f}] {p.get('type','log'):>5}: {text}")
+
+        elif m == "Runtime.exceptionThrown":
+            ed = p.get("exceptionDetails", {})
+            emit(f"[{t:7.2f}] EXCEPTION: {ed.get('text')}")
+            ex = ed.get("exception", {}) or {}
+            desc = ex.get("description") or ed.get("text") or ""
+            for line in desc.splitlines():
+                emit(f"           {line}")
+            st = ed.get("stackTrace", {}) or {}
+            for frame in st.get("callFrames", []) or []:
+                fname = frame.get("functionName") or "(anonymous)"
+                url = frame.get("url") or ""
+                emit(f"           at {fname} ({url}:{frame.get('lineNumber')}:{frame.get('columnNumber')})")
+
+        elif m == "Log.entryAdded":
+            e = p.get("entry", {})
+            level = e.get("level", "")
+            if level in ("warning", "error"):
+                emit(f"[{t:7.2f}] {level.upper()}: {e.get('text','')}")
+                for frame in (e.get("stackTrace", {}) or {}).get("callFrames", []) or []:
+                    fname = frame.get("functionName") or "(anonymous)"
+                    url = frame.get("url") or ""
+                    emit(f"           at {fname} ({url}:{frame.get('lineNumber')})")
+
+    log.close()
+    try:
+        ws.close()
+    except Exception:
+        pass
+    print("Detached.", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/wasm/build-wasm.sh
+++ b/build/wasm/build-wasm.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# build-wasm.sh — build OpenLieroX as a WebAssembly module.
+#
+# Produces output/openlierox.html + .js + .wasm + .data, ready to serve
+# from any HTTP server with COOP/COEP headers (see serve.py).
+#
+# Usage: ./build-wasm.sh [--clean] [--release] [--skip-emsdk] [--skip-fetch] [--skip-data]
+
+set -euo pipefail
+
+WASM_DIR="$(cd "$(dirname "$0")" && pwd)"
+OLX_ROOT="$(cd "$WASM_DIR/../.." && pwd)"
+WASM_TOOLS_DIR="${WASM_TOOLS_DIR:-$HOME/wasm-tools}"
+export WASM_TOOLS_DIR
+
+BUILD_TYPE="Debug"
+DO_CLEAN=0
+SKIP_EMSDK=0
+SKIP_FETCH=0
+SKIP_DATA=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --release)     BUILD_TYPE="Release" ;;
+        --debug)       BUILD_TYPE="Debug" ;;
+        --clean)       DO_CLEAN=1 ;;
+        --skip-emsdk)  SKIP_EMSDK=1 ;;
+        --skip-fetch)  SKIP_FETCH=1 ;;
+        --skip-data)   SKIP_DATA=1 ;;
+        -h|--help)
+            sed -n '2,12p' "$0" | sed 's/^# \?//'
+            exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+# ---------- emsdk ----------------------------------------------------------
+
+if [ "$SKIP_EMSDK" -eq 0 ]; then
+    "$WASM_DIR/fetch-emsdk.sh"
+fi
+
+# Source the activated env so emcc/emcmake are on PATH.
+EMSDK_ENV="$WASM_TOOLS_DIR/emsdk/emsdk_env.sh"
+if [ ! -f "$EMSDK_ENV" ]; then
+    echo "ERROR: $EMSDK_ENV missing — run without --skip-emsdk first." >&2
+    echo "       (looked under WASM_TOOLS_DIR=$WASM_TOOLS_DIR)" >&2
+    exit 1
+fi
+# shellcheck disable=SC1090
+source "$EMSDK_ENV" >/dev/null
+
+echo "Using emcc: $(command -v emcc) ($(emcc --version | head -1))"
+
+# Pre-build the Emscripten port sysroot for our exact flag set.
+# Without this, the first parallel compile fights over cache locks
+# while emcc lazily builds libSDL2.a / libpng / etc.
+echo "Warming Emscripten port cache..."
+PREBUILD_TMP="$(mktemp -d)"
+trap 'rm -rf "$PREBUILD_TMP"' EXIT
+cat > "$PREBUILD_TMP/empty.c" <<'EOF'
+#include <SDL.h>
+#include <SDL_image.h>
+#include <png.h>
+#include <jpeglib.h>
+#include <ogg/ogg.h>
+#include <vorbis/vorbisfile.h>
+#include <zlib.h>
+#include <AL/al.h>
+int main(void) { return 0; }
+EOF
+emcc -pthread \
+    -sUSE_SDL=2 -sUSE_SDL_IMAGE=2 \
+    -sUSE_LIBPNG=1 -sUSE_LIBJPEG=1 -sUSE_OGG=1 -sUSE_VORBIS=1 -sUSE_ZLIB=1 \
+    -sSDL2_IMAGE_FORMATS='["bmp","gif","jpg","png","tga"]' \
+    -lopenal \
+    "$PREBUILD_TMP/empty.c" \
+    -o "$PREBUILD_TMP/empty.js" 2>&1 | tail -3
+echo "Cache warmed."
+
+# ---------- third-party deps ----------------------------------------------
+
+if [ "$SKIP_FETCH" -eq 0 ]; then
+    "$WASM_DIR/fetch-dependencies.sh"
+fi
+
+# ---------- stage game data ------------------------------------------------
+
+DATA_STAGE="$WASM_DIR/output/preload"
+if [ "$SKIP_DATA" -eq 0 ]; then
+    # CMake doesn't track files inside the preload dir as link deps,
+    # so a stale .data sidecar would otherwise stick around even when
+    # we add/remove staged files. Wipe the output's link artefacts to
+    # force a fresh emcc link each time data changes.
+    rm -f "$WASM_DIR/output/build/libgd/Bin/openlierox.html" \
+          "$WASM_DIR/output/build/libgd/Bin/openlierox.js" \
+          "$WASM_DIR/output/build/libgd/Bin/openlierox.wasm" \
+          "$WASM_DIR/output/build/libgd/Bin/openlierox.data"
+    echo "Staging slim game data into $DATA_STAGE/gamedir..."
+    # Bundling all of share/gamedir would package ~8000 files (136MB).
+    # Each file becomes a preload-file dependency and the runtime
+    # registers them serially, which takes minutes before main() can
+    # run. Stage only the bits the menu needs to boot, plus a single
+    # mod (Classic) so weapon-restrictions / map listing aren't empty.
+    rm -rf "$DATA_STAGE"
+    mkdir -p "$DATA_STAGE/gamedir"
+    GD="$OLX_ROOT/share/gamedir"
+    SD="$DATA_STAGE/gamedir"
+    cp -a "$GD/cfg"           "$SD/cfg"
+    cp -a "$GD/data"          "$SD/data"
+    cp -a "$GD/scripts"       "$SD/scripts"
+    cp -a "$GD/themes"        "$SD/themes"
+    cp -a "$GD/skins"         "$SD/skins"
+    cp -a "$GD/games"         "$SD/games"
+    cp -a "$GD/Classic"       "$SD/Classic"
+    cp -a "$GD/Gusanos"       "$SD/Gusanos"
+    # Touchscreen on-screen control layouts (+ button artwork). The web
+    # build enables touch controls by default (like Android), so the
+    # selected layout YAML and its images must be present.
+    [ -d "$GD/touchscreen" ] && cp -a "$GD/touchscreen" "$SD/touchscreen"
+    # The bundled Introduction game references "MW 1.0" and "promode"
+    # in its later levels; stage them too so the menu's mod dropdown
+    # has them and the Introduction's intro2/3 actually load.
+    [ -d "$GD/MW 1.0"  ] && cp -a "$GD/MW 1.0"  "$SD/MW 1.0"
+    [ -d "$GD/promode" ] && cp -a "$GD/promode" "$SD/promode"
+    cp -f "$GD/GeoIP.dat"     "$SD/GeoIP.dat"
+    cp -f "$GD/startup.lua"   "$SD/startup.lua"
+    # SinglePlayer paths look like "levels/../games/foo/bar". POSIX
+    # path normalization needs every directory component to exist
+    # before it can resolve `..`, so stage at least a few sample
+    # levels (and the empty `levels/` dir) for the introduction
+    # game's level lookup to succeed.
+    mkdir -p "$SD/levels"
+    for lvl in "747.lxl" "Base Fight.lxl" "BetaBoxDE.lxl" "Castle Strike.lxl" \
+               "Dirt Level.lxl"; do
+        if [ -f "$GD/levels/$lvl" ]; then
+            cp -f "$GD/levels/$lvl" "$SD/levels/$lvl"
+        fi
+    done
+    # gamesettings presets at the gamedir root
+    cp -f "$GD"/*.gamesettings "$SD/" 2>/dev/null || true
+    echo "Staged $(find "$SD" -type f | wc -l) files ($(du -sh "$SD" | cut -f1))"
+fi
+
+# ---------- cmake configure + build ---------------------------------------
+
+BUILD_DIR="$WASM_DIR/output/build"
+if [ "$DO_CLEAN" -eq 1 ]; then
+    rm -rf "$BUILD_DIR"
+fi
+mkdir -p "$BUILD_DIR"
+
+emcmake cmake -S "$WASM_DIR" -B "$BUILD_DIR" \
+    -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
+    -DOLX_ROOT="$OLX_ROOT" \
+    -DOLX_PRELOAD_DIR="$DATA_STAGE"
+
+cmake --build "$BUILD_DIR" -j"$(nproc)"
+
+# ---------- output -------------------------------------------------------
+
+OUT_DIR="$WASM_DIR/output"
+# libgd's CMakeLists sets a global EXECUTABLE_OUTPUT_PATH, redirecting
+# our binary into libgd/Bin/. Look there too.
+for ext in html js wasm data worker.js; do
+    for src in "$BUILD_DIR/openlierox.$ext" \
+               "$BUILD_DIR/libgd/Bin/openlierox.$ext"; do
+        if [ -f "$src" ]; then
+            cp -f "$src" "$OUT_DIR/"
+            break
+        fi
+    done
+done
+
+# Make openlierox.html accessible as index.html so plain `python -m
+# http.server` can serve it without a path argument.
+if [ -f "$OUT_DIR/openlierox.html" ]; then
+    cp -f "$OUT_DIR/openlierox.html" "$OUT_DIR/index.html"
+fi
+
+echo
+echo "Wasm artefacts ready under $OUT_DIR:"
+ls -lh "$OUT_DIR"/openlierox.* "$OUT_DIR/index.html" 2>/dev/null || true
+echo
+echo "Serve with:  python3 $WASM_DIR/serve.py"

--- a/build/wasm/build.sh
+++ b/build/wasm/build.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# build.sh — produce a redistributable OpenLieroX Wasm bundle.
+#
+# Wraps build-wasm.sh (release build by default) and stages the
+# resulting artefacts into <repo>/distrib/openlierox-wasm/, ready to
+# upload to a static web host.
+#
+# The bundle requires the host to send COOP/COEP headers (the wasm
+# build uses -pthread / SharedArrayBuffer). Three flavours of config
+# ship in the bundle:
+#   _headers              — Netlify / Cloudflare Pages
+#   .htaccess             — Apache
+#   coi-serviceworker.js  — fallback for hosts that can't set headers
+#                           (notably GitHub Pages); registers a
+#                           service worker that re-injects the
+#                           Cross-Origin-* headers client-side.
+# Other hosts (nginx, S3+CloudFront, ...) should set the same three
+# headers natively if possible.
+#
+# Usage: ./build.sh [--debug] [extra args forwarded to build-wasm.sh]
+
+set -euo pipefail
+
+WASM_DIR="$(cd "$(dirname "$0")" && pwd)"
+OLX_ROOT="$(cd "$WASM_DIR/../.." && pwd)"
+DIST_DIR="$OLX_ROOT/distrib/openlierox-wasm"
+
+BUILD_FLAVOR="--release"
+FORWARD_ARGS=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --debug)    BUILD_FLAVOR="--debug" ;;
+        --release)  BUILD_FLAVOR="--release" ;;
+        -h|--help)
+            sed -n '2,20p' "$0" | sed 's/^# \?//'
+            exit 0 ;;
+        *)          FORWARD_ARGS+=("$1") ;;
+    esac
+    shift
+done
+
+# ---------- build ---------------------------------------------------------
+
+"$WASM_DIR/build-wasm.sh" "$BUILD_FLAVOR" "${FORWARD_ARGS[@]}"
+
+OUT_DIR="$WASM_DIR/output"
+for f in index.html openlierox.js openlierox.wasm openlierox.data; do
+    if [ ! -f "$OUT_DIR/$f" ]; then
+        echo "ERROR: expected artefact missing: $OUT_DIR/$f" >&2
+        exit 1
+    fi
+done
+
+# ---------- stage ---------------------------------------------------------
+
+echo "Staging redistributable bundle into $DIST_DIR..."
+rm -rf "$DIST_DIR"
+mkdir -p "$DIST_DIR"
+
+cp -f "$OUT_DIR/index.html"      "$DIST_DIR/index.html"
+cp -f "$OUT_DIR/openlierox.js"   "$DIST_DIR/openlierox.js"
+cp -f "$OUT_DIR/openlierox.wasm" "$DIST_DIR/openlierox.wasm"
+cp -f "$OUT_DIR/openlierox.data" "$DIST_DIR/openlierox.data"
+
+# Cross-origin-isolation service-worker shim. Required for hosts
+# that can't set COOP/COEP response headers (GitHub Pages). Harmless
+# on hosts that do set the headers — the shim notices
+# `crossOriginIsolated === true` and exits without registering.
+SHIM_SRC="$WASM_DIR/shell/coi-serviceworker.js"
+if [ ! -f "$SHIM_SRC" ]; then
+    echo "ERROR: coi-serviceworker shim missing at $SHIM_SRC" >&2
+    exit 1
+fi
+cp -f "$SHIM_SRC" "$DIST_DIR/coi-serviceworker.js"
+[ -f "$WASM_DIR/shell/coi-serviceworker.LICENSE" ] && \
+    cp -f "$WASM_DIR/shell/coi-serviceworker.LICENSE" \
+          "$DIST_DIR/coi-serviceworker.LICENSE"
+
+# Inject the shim's <script> into the staged index.html, immediately
+# before </head>, so it registers before the emscripten loader runs.
+# The shim must be loaded as a regular script (no defer / async /
+# type=module) because it relies on document.currentScript.src to
+# self-register as the service worker.
+python3 - "$DIST_DIR/index.html" <<'PY'
+import sys, pathlib
+p = pathlib.Path(sys.argv[1])
+html = p.read_text()
+tag = '  <script src="coi-serviceworker.js"></script>\n'
+if tag.strip() in html:
+    sys.exit(0)
+needle = "</head>"
+i = html.find(needle)
+if i == -1:
+    sys.stderr.write(f"ERROR: no </head> in {p}\n")
+    sys.exit(1)
+p.write_text(html[:i] + tag + html[i:])
+PY
+
+# Netlify / Cloudflare Pages headers config.
+cat > "$DIST_DIR/_headers" <<'EOF'
+/*
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: require-corp
+  Cross-Origin-Resource-Policy: same-origin
+EOF
+
+# Apache headers + correct MIME types.
+cat > "$DIST_DIR/.htaccess" <<'EOF'
+<IfModule mod_headers.c>
+    Header set Cross-Origin-Opener-Policy   "same-origin"
+    Header set Cross-Origin-Embedder-Policy "require-corp"
+    Header set Cross-Origin-Resource-Policy "same-origin"
+</IfModule>
+
+AddType application/wasm         .wasm
+AddType application/octet-stream .data
+AddType application/javascript   .js
+EOF
+
+# ---------- summary -------------------------------------------------------
+
+echo
+echo "Bundle ready: $DIST_DIR"
+ls -lh "$DIST_DIR"
+TOTAL=$(du -sh "$DIST_DIR" | cut -f1)
+echo
+echo "Total size: $TOTAL"
+echo "Upload the contents of $DIST_DIR to your web host."
+echo
+echo "Cross-origin isolation (required for SharedArrayBuffer/pthread):"
+echo "  - Hosts with header config: covered by _headers (Netlify / CF Pages)"
+echo "    and .htaccess (Apache); set the same headers natively elsewhere:"
+echo "      Cross-Origin-Opener-Policy:   same-origin"
+echo "      Cross-Origin-Embedder-Policy: require-corp"
+echo "      Cross-Origin-Resource-Policy: same-origin"
+echo "  - Hosts without header config (GitHub Pages): coi-serviceworker.js"
+echo "    is wired into index.html and provides the headers client-side."
+echo "    First load triggers a one-time reload to activate the worker."

--- a/build/wasm/cmake/FindJPEG.cmake
+++ b/build/wasm/cmake/FindJPEG.cmake
@@ -1,0 +1,16 @@
+# Stub FindJPEG.cmake — Emscripten provides libjpeg via -sUSE_LIBJPEG=1.
+
+if(NOT TARGET JPEG::JPEG)
+    add_library(JPEG::JPEG INTERFACE IMPORTED)
+    target_compile_options(JPEG::JPEG INTERFACE "-sUSE_LIBJPEG=1")
+    target_link_options(JPEG::JPEG INTERFACE "-sUSE_LIBJPEG=1")
+endif()
+
+set(JPEG_FOUND       TRUE)
+# Empty — actual jpeg comes from -sUSE_LIBJPEG=1 in our global link
+# options. See note in FindZLIB.cmake.
+set(JPEG_LIBRARY     "")
+set(JPEG_LIBRARIES   "")
+set(JPEG_INCLUDE_DIR "${CMAKE_BINARY_DIR}")
+set(JPEG_INCLUDE_DIRS "${CMAKE_BINARY_DIR}")
+set(JPEG_VERSION     "8.0.0")

--- a/build/wasm/cmake/FindPNG.cmake
+++ b/build/wasm/cmake/FindPNG.cmake
@@ -1,0 +1,17 @@
+# Stub FindPNG.cmake — Emscripten provides libpng via -sUSE_LIBPNG=1.
+
+if(NOT TARGET PNG::PNG)
+    add_library(PNG::PNG INTERFACE IMPORTED)
+    target_compile_options(PNG::PNG INTERFACE "-sUSE_LIBPNG=1")
+    target_link_options(PNG::PNG INTERFACE "-sUSE_LIBPNG=1")
+endif()
+
+set(PNG_FOUND       TRUE)
+# Empty — actual png comes from -sUSE_LIBPNG=1 in our global link
+# options. See note in FindZLIB.cmake.
+set(PNG_LIBRARY     "")
+set(PNG_LIBRARIES   "")
+set(PNG_INCLUDE_DIR "${CMAKE_BINARY_DIR}")
+set(PNG_INCLUDE_DIRS "${CMAKE_BINARY_DIR}")
+set(PNG_PNG_INCLUDE_DIR "${CMAKE_BINARY_DIR}")
+set(PNG_VERSION_STRING "1.6.43")

--- a/build/wasm/cmake/FindZLIB.cmake
+++ b/build/wasm/cmake/FindZLIB.cmake
@@ -1,0 +1,29 @@
+# Stub FindZLIB.cmake for the OpenLieroX Wasm build.
+#
+# The actual symbols come from -sUSE_ZLIB=1 added globally in our top-
+# level CMakeLists. Subprojects (libxml2, libpng, libcurl, libgd) call
+# find_package(ZLIB) and expect:
+#   - ZLIB::ZLIB imported target (libxml2/libgd link via that)
+#   - ZLIB_LIBRARIES populated as a plain string (curl validates that
+#     the entries don't look like target names like "::")
+# So we expose both: the imported target carries the flags for cmake
+# consumers, and ZLIB_LIBRARIES is the plain link spec "z" — which
+# emcc resolves through its zlib port at link time.
+
+if(NOT TARGET ZLIB::ZLIB)
+    add_library(ZLIB::ZLIB INTERFACE IMPORTED)
+    target_compile_options(ZLIB::ZLIB INTERFACE "-sUSE_ZLIB=1")
+    target_link_options(ZLIB::ZLIB INTERFACE "-sUSE_ZLIB=1")
+endif()
+
+set(ZLIB_FOUND        TRUE)
+set(ZLIB_INCLUDE_DIR  "${CMAKE_BINARY_DIR}")
+set(ZLIB_INCLUDE_DIRS "${CMAKE_BINARY_DIR}")
+# Empty so subprojects don't add `-lz` directly — the actual zlib
+# symbols come from `-sUSE_ZLIB=1` (already in our global link
+# options), which under `-pthread` resolves to libz-mt.a. Adding `-lz`
+# would also pull in the non-mt libz.a, breaking --shared-memory.
+set(ZLIB_LIBRARY      "")
+set(ZLIB_LIBRARIES    "")
+set(ZLIB_VERSION_STRING "1.3.1")
+set(ZLIB_VERSION       "1.3.1")

--- a/build/wasm/fetch-dependencies.sh
+++ b/build/wasm/fetch-dependencies.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Fetch third-party native dependencies the Wasm build needs to compile
+# from source. SDL2/SDL_image/SDL_mixer/libpng/libjpeg/libogg/libvorbis/
+# zlib all come from Emscripten's built-in ports, so we only clone what
+# Emscripten doesn't ship.
+#
+# Clones land under build/wasm/deps/<name> at pinned tags. The directory
+# is .gitignored.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPS_DIR="$SCRIPT_DIR/deps"
+mkdir -p "$DEPS_DIR"
+cd "$DEPS_DIR"
+
+DEPS=(
+    "libxml2|https://github.com/GNOME/libxml2.git|v2.13.5"
+    "libgd|https://github.com/libgd/libgd.git|gd-2.3.3"
+    "curl|https://github.com/curl/curl.git|curl-8_10_1"
+    # 0.59's TouchControls parses share/gamedir/touchscreen/*.yaml at
+    # runtime. Same dep + pin as the Android port.
+    "yaml-cpp|https://github.com/jbeder/yaml-cpp.git|0.8.0"
+)
+
+clone_dep() {
+    local name="$1"
+    local url="$2"
+    local tag="$3"
+
+    if [ -d "$name/.git" ]; then
+        local current
+        current=$(git -C "$name" describe --tags --always 2>/dev/null || echo "")
+        if [ "$current" = "$tag" ]; then
+            echo "$name @ $tag (already present)"
+            return
+        fi
+        echo "$name: updating to $tag"
+        git -C "$name" fetch --tags --depth 1 origin "$tag" 2>/dev/null || \
+            git -C "$name" fetch --tags origin
+        git -C "$name" checkout "$tag"
+        return
+    fi
+
+    echo "Cloning $name @ $tag"
+    git clone --depth 1 --branch "$tag" --recurse-submodules --shallow-submodules \
+        "$url" "$name" 2>&1 | tail -5
+}
+
+for entry in "${DEPS[@]}"; do
+    IFS='|' read -r name url tag <<< "$entry"
+    clone_dep "$name" "$url" "$tag"
+done
+
+# Patch libgd's gdkanji.c so its iconv stubs don't fight any system
+# <iconv.h>. Same patch as the Android port; emcc's musl sysroot also
+# defines iconv_t.
+if [ -f libgd/src/gdkanji.c ] && ! grep -q "OLX Wasm iconv guard" libgd/src/gdkanji.c; then
+    python3 - <<'PYEOF'
+import pathlib
+p = pathlib.Path("libgd/src/gdkanji.c")
+src = p.read_text()
+src = src.replace(
+    "#if defined(HAVE_ICONV_H)\n#include <iconv.h>\n#endif",
+    "/* OLX Wasm iconv guard */\n"
+    "#if defined(HAVE_ICONV_H) && !defined(__EMSCRIPTEN__)\n"
+    "#include <iconv.h>\n"
+    "#endif")
+src = src.replace(
+    "#ifndef HAVE_ICONV_T_DEF\ntypedef void *iconv_t;\n#endif",
+    "#if !defined(HAVE_ICONV_T_DEF) && !defined(__EMSCRIPTEN__)\n"
+    "typedef void *iconv_t;\n"
+    "#elif defined(__EMSCRIPTEN__)\n"
+    "typedef void *iconv_t;\n"
+    "#endif")
+p.write_text(src)
+PYEOF
+fi
+
+# boost-hdr: symlink to whatever boost headers the host system has.
+if [ ! -e boost-hdr/boost ]; then
+    mkdir -p boost-hdr
+    if [ -d /usr/include/boost ]; then
+        ln -sfn /usr/include/boost boost-hdr/boost
+        echo "boost-hdr -> /usr/include/boost"
+    else
+        echo "WARNING: /usr/include/boost not found. Install libboost-dev." >&2
+    fi
+fi
+
+echo "All dependencies are in place under $DEPS_DIR"

--- a/build/wasm/fetch-emsdk.sh
+++ b/build/wasm/fetch-emsdk.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# fetch-emsdk.sh — install Emscripten SDK under $WASM_TOOLS_DIR/emsdk.
+#
+# The SDK is a generic toolchain (not OLX-specific), so it lives
+# outside the repo to keep the working tree small and to share a
+# single ~1.6 GB install across projects.
+#
+# Default location: $HOME/wasm-tools/emsdk
+# Override with:   WASM_TOOLS_DIR=/some/path ./fetch-emsdk.sh
+#
+# build-wasm.sh sources emsdk_env.sh from this checkout to bring
+# emcc/emcmake/emmake into PATH. Pinned to a known-working release so
+# the Wasm build is reproducible. Re-running is idempotent.
+
+set -euo pipefail
+
+WASM_TOOLS_DIR="${WASM_TOOLS_DIR:-$HOME/wasm-tools}"
+EMSDK_DIR="$WASM_TOOLS_DIR/emsdk"
+EMSDK_VERSION="3.1.74"
+
+mkdir -p "$WASM_TOOLS_DIR"
+
+if [ ! -d "$EMSDK_DIR/.git" ]; then
+    echo "Cloning emsdk into $EMSDK_DIR..."
+    git clone --depth 1 https://github.com/emscripten-core/emsdk.git "$EMSDK_DIR"
+fi
+
+cd "$EMSDK_DIR"
+"$EMSDK_DIR/emsdk" install "$EMSDK_VERSION"
+"$EMSDK_DIR/emsdk" activate "$EMSDK_VERSION"
+
+echo "Emscripten $EMSDK_VERSION ready under $EMSDK_DIR"

--- a/build/wasm/jni/COPYING.stub
+++ b/build/wasm/jni/COPYING.stub
@@ -1,0 +1,4 @@
+OpenLieroX is licensed under the LGPL 2.1; see ../../../../../COPYING.LIB
+in the repo root for the full text. This file exists solely so that
+libgd's embedded CPack call (which dereferences ${CMAKE_SOURCE_DIR}/COPYING)
+configures cleanly when libgd is built via add_subdirectory().

--- a/build/wasm/jni/alut_stub.c
+++ b/build/wasm/jni/alut_stub.c
@@ -1,0 +1,51 @@
+// Minimal stand-in for the freealut entry points OpenLieroX uses on
+// Android. freealut's CMake build is broken on modern CMake, and we
+// only need a tiny slice of its API: alutInit/alutExit are bypassed
+// by initialising OpenAL Soft directly, and the error helpers return
+// neutral values.
+
+#include <AL/al.h>
+#include <AL/alc.h>
+
+static ALCdevice*  g_device  = 0;
+static ALCcontext* g_context = 0;
+
+ALboolean alutInit(int* argcp, char** argv) {
+    (void)argcp; (void)argv;
+    if (g_context) return AL_TRUE;
+    g_device = alcOpenDevice(0);
+    if (!g_device) return AL_FALSE;
+    g_context = alcCreateContext(g_device, 0);
+    if (!g_context) { alcCloseDevice(g_device); g_device = 0; return AL_FALSE; }
+    if (!alcMakeContextCurrent(g_context)) {
+        alcDestroyContext(g_context); g_context = 0;
+        alcCloseDevice(g_device); g_device = 0;
+        return AL_FALSE;
+    }
+    return AL_TRUE;
+}
+
+ALboolean alutExit(void) {
+    if (g_context) {
+        alcMakeContextCurrent(0);
+        alcDestroyContext(g_context);
+        g_context = 0;
+    }
+    if (g_device) {
+        alcCloseDevice(g_device);
+        g_device = 0;
+    }
+    return AL_TRUE;
+}
+
+ALenum alutGetError(void) { return 0; }
+
+const char* alutGetErrorString(ALenum err) {
+    (void)err;
+    return "alut not available";
+}
+
+ALuint alutCreateBufferFromFile(const char* filename) {
+    (void)filename;
+    return 0;  // 0 = no buffer (caller must check)
+}

--- a/build/wasm/jni/include/AL/alut.h
+++ b/build/wasm/jni/include/AL/alut.h
@@ -1,0 +1,29 @@
+/* Minimal <AL/alut.h> shim for the OpenLieroX Android port.
+ *
+ * The real freealut library doesn't build cleanly on modern CMake;
+ * this header pairs with build/android/app/src/main/jni/alut_stub.c,
+ * which implements the four entry points OpenLieroX actually calls.
+ * alutCreateBufferFromFile returns 0 (no buffer) so sample loading
+ * fails gracefully. */
+
+#ifndef OLX_ALUT_H
+#define OLX_ALUT_H
+
+#include <AL/al.h>
+#include <AL/alc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ALboolean   alutInit(int* argcp, char** argv);
+ALboolean   alutExit(void);
+ALenum      alutGetError(void);
+const char* alutGetErrorString(ALenum err);
+ALuint      alutCreateBufferFromFile(const char* filename);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/build/wasm/run-headless.py
+++ b/build/wasm/run-headless.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Drive the Wasm build under headless Chrome via the Chrome DevTools
+Protocol. Tails console + page errors in real time and saves periodic
+screenshots, so we can see exactly where the runtime gets stuck.
+
+Usage: run-headless.py [seconds=120] [screenshot_every=5]
+"""
+import base64
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import urllib.request
+import websocket  # type: ignore
+
+ROOT       = os.path.dirname(os.path.abspath(__file__))
+PROFILE    = "/tmp/olx-cdp-profile"
+SHOTS_DIR  = "/tmp/olx-shots"
+DEBUG_PORT = 9223
+URL        = "http://localhost:8000/openlierox.html"
+
+DURATION   = int(sys.argv[1]) if len(sys.argv) > 1 else 120
+SHOT_EVERY = int(sys.argv[2]) if len(sys.argv) > 2 else 5
+
+# Optional: list of "TIMESTAMP CLICK x y" or "TIMESTAMP KEY name" actions.
+# Parsed from sys.argv[3:] as triples ("at:CLICK:300,400", "at:25:KEY:Down", ...).
+SCRIPT = []
+for tok in sys.argv[3:]:
+    parts = tok.split(":")
+    if len(parts) >= 3 and parts[0] == "at":
+        SCRIPT.append((float(parts[1]), parts[2], ":".join(parts[3:])))
+
+
+def main() -> int:
+    shutil.rmtree(PROFILE,   ignore_errors=True)
+    shutil.rmtree(SHOTS_DIR, ignore_errors=True)
+    os.makedirs(SHOTS_DIR, exist_ok=True)
+
+    chrome = subprocess.Popen([
+        "google-chrome",
+        "--headless=new",
+        # Keep GPU on — disabling it falls back to a software path
+        # that hides issues real Chrome users hit (e.g. WebGL-related
+        # wasm traps). Use ANGLE+SwiftShader so we don't need a GPU.
+        "--use-gl=angle",
+        "--use-angle=swiftshader",
+        "--no-sandbox",
+        "--disable-dev-shm-usage",
+        "--user-data-dir=" + PROFILE,
+        f"--remote-debugging-port={DEBUG_PORT}",
+        "--remote-allow-origins=*",
+        "--window-size=1024,768",
+        URL,
+    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    ws_url = None
+    for _ in range(40):
+        time.sleep(0.25)
+        try:
+            tabs = json.loads(
+                urllib.request.urlopen(
+                    f"http://127.0.0.1:{DEBUG_PORT}/json", timeout=1
+                ).read()
+            )
+            for tab in tabs:
+                if tab.get("type") == "page" and tab.get("url"):
+                    ws_url = tab["webSocketDebuggerUrl"]
+                    break
+            if ws_url:
+                break
+        except Exception:
+            pass
+
+    if not ws_url:
+        print("ERROR: never connected to Chrome devtools.", file=sys.stderr)
+        chrome.terminate()
+        return 2
+
+    print(f"Connected to {ws_url}", flush=True)
+    ws = websocket.create_connection(ws_url, timeout=5)
+    msg_id = [0]
+
+    def send(method: str, params: dict | None = None) -> int:
+        msg_id[0] += 1
+        ws.send(json.dumps({"id": msg_id[0], "method": method,
+                            "params": params or {}}))
+        return msg_id[0]
+
+    send("Runtime.enable")
+    send("Log.enable")
+    send("Console.enable")
+    send("Page.enable")
+
+    def cdp_call(method: str, params: dict) -> None:
+        """Send a CDP request and drain pending events until the reply
+        matching this id arrives. Used for synchronous calls like
+        screenshots / input dispatch."""
+        msg_id[0] += 1
+        my = msg_id[0]
+        ws.send(json.dumps({"id": my, "method": method, "params": params}))
+        prev_to = ws.gettimeout()
+        ws.settimeout(5)
+        t0 = time.time()
+        result = None
+        try:
+            while time.time() - t0 < 5:
+                try:
+                    r = ws.recv()
+                except websocket.WebSocketTimeoutException:
+                    break
+                obj = json.loads(r)
+                if obj.get("id") == my:
+                    result = obj.get("result")
+                    break
+        finally:
+            ws.settimeout(prev_to)
+        return result
+
+    def take_shot(label: str) -> None:
+        r = cdp_call("Page.captureScreenshot", {"format": "png"})
+        if r and r.get("data"):
+            path = os.path.join(SHOTS_DIR, label)
+            with open(path, "wb") as f:
+                f.write(base64.b64decode(r["data"]))
+            print(f"           saved {path}", flush=True)
+
+    def canvas_rect():
+        """Return the canvas DOM bounding rect (left, top, width, height)
+        in CSS pixels — we'll add a viewport offset of (left, top) to
+        convert canvas-internal click coords to absolute mouse coords."""
+        r = cdp_call("Runtime.evaluate", {
+            "expression": "JSON.stringify((() => { "
+                          "const c = document.getElementById('canvas');"
+                          "const r = c.getBoundingClientRect();"
+                          "return { l: r.left, t: r.top, w: r.width, "
+                          "         h: r.height, iw: c.width, ih: c.height };"
+                          "})())",
+            "returnByValue": True})
+        if not r:
+            return None
+        try:
+            return json.loads(r["result"]["value"])
+        except Exception:
+            return None
+
+    def click(x: int, y: int) -> None:
+        """x/y are canvas-internal (i.e. CSS-pixel) coords. SDL's
+        SDL_RenderSetLogicalSize then scales these to OLX-logical
+        (640x480) under the hood."""
+        rect = canvas_rect()
+        if rect:
+            sx = rect["l"] + (x / rect["iw"]) * rect["w"]
+            sy = rect["t"] + (y / rect["ih"]) * rect["h"]
+            print(f"           canvas_rect={rect}", flush=True)
+        else:
+            sx, sy = x, y
+        sx, sy = int(sx), int(sy)
+        # Move first so any hover-tracking widgets see us inside.
+        cdp_call("Input.dispatchMouseEvent",
+                 {"type": "mouseMoved", "x": sx, "y": sy, "button": "left"})
+        time.sleep(0.05)
+        # Use synthesizeTapGesture instead of dispatchMouseEvent —
+        # the latter generates a synthetic JS MouseEvent that some SDL
+        # builds don't treat as a real user click; the former goes
+        # through the platform layer and looks like a real tap to the
+        # browser, which OLX's CButton handler then sees as a proper
+        # press+release with the gesture duration as hold time.
+        cdp_call("Input.synthesizeTapGesture",
+                 {"x": sx, "y": sy, "duration": 120,
+                  "tapCount": 1, "gestureSourceType": "mouse"})
+        print(f"           click(canvas={x},{y} -> viewport={sx},{sy})", flush=True)
+
+    def press_key(name: str) -> None:
+        cdp_call("Input.dispatchKeyEvent",
+                 {"type": "keyDown", "key": name, "code": name})
+        cdp_call("Input.dispatchKeyEvent",
+                 {"type": "keyUp",   "key": name, "code": name})
+        print(f"           key({name})", flush=True)
+
+    start = time.time()
+    last_shot = 0.0
+    deadline = start + DURATION
+    pending_actions = list(SCRIPT)
+    ws.settimeout(0.25)
+
+    while time.time() < deadline:
+        try:
+            raw = ws.recv()
+        except websocket.WebSocketTimeoutException:
+            raw = None
+
+        if raw:
+            try:
+                evt = json.loads(raw)
+            except Exception:
+                evt = None
+
+            if evt and "method" in evt:
+                m = evt["method"]
+                p = evt.get("params", {})
+
+                if m == "Runtime.consoleAPICalled":
+                    args = p.get("args", [])
+                    text = " ".join(str(a.get("value", "")) for a in args)
+                    if not text.startswith(("dependency:",
+                                            "still waiting on run dependencies",
+                                            "(end of list)")):
+                        print(f"[{time.time()-start:6.1f}] {p.get('type','log'):>5}: {text}",
+                              flush=True)
+
+                elif m == "Runtime.exceptionThrown":
+                    ed = p.get("exceptionDetails", {})
+                    print(f"[{time.time()-start:6.1f}] EXC: {ed.get('text')} @ {ed.get('url')}:{ed.get('lineNumber')}",
+                          flush=True)
+                    exception = ed.get("exception", {})
+                    if exception.get("description"):
+                        for line in exception["description"].splitlines()[:20]:
+                            print(f"            {line}", flush=True)
+
+                elif m == "Log.entryAdded":
+                    e = p.get("entry", {})
+                    if e.get("level") in ("warning", "error"):
+                        print(f"[{time.time()-start:6.1f}] {e['level'].upper()}: {e.get('text','')}",
+                              flush=True)
+
+        now = time.time() - start
+
+        # Fire any scripted actions whose time has come.
+        while pending_actions and pending_actions[0][0] <= now:
+            _, action, arg = pending_actions.pop(0)
+            print(f"[{now:6.1f}] action: {action} {arg}", flush=True)
+            try:
+                if action == "CLICK":
+                    x, y = (int(v) for v in arg.split(","))
+                    click(x, y)
+                elif action == "KEY":
+                    press_key(arg)
+                elif action == "SHOT":
+                    take_shot(arg)
+            except Exception as e:
+                print(f"action error: {e}", flush=True)
+
+        # Periodic screenshot
+        if now - last_shot >= SHOT_EVERY:
+            last_shot = now
+            try:
+                take_shot(f"shot-{int(now):04d}s.png")
+            except Exception as e:
+                print(f"screenshot error: {e}", flush=True)
+
+    print("--- DONE ---", flush=True)
+    ws.close()
+    chrome.send_signal(signal.SIGTERM)
+    try:
+        chrome.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        chrome.kill()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/wasm/serve.py
+++ b/build/wasm/serve.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Tiny static server for the OpenLieroX Wasm build.
+
+Serves build/wasm/output/ on http://localhost:8000 with:
+- Correct MIME types for .wasm / .data / .js
+- Cross-Origin-Opener-Policy / Cross-Origin-Embedder-Policy headers,
+  required by the -pthread build (SharedArrayBuffer).
+
+Optional TLS, for testing on a phone over the LAN: SharedArrayBuffer
+needs a *secure context*, which over a LAN IP means HTTPS (localhost is
+exempt, a bare LAN IP is not). Set CERTFILE (and optionally KEYFILE) to
+serve https:// instead. Example:
+
+    CERTFILE=/tmp/olx-tls/cert.pem KEYFILE=/tmp/olx-tls/key.pem \\
+        PORT=8443 python3 serve.py
+"""
+import http.server
+import os
+import ssl
+import sys
+
+ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "output")
+PORT = int(os.environ.get("PORT", "8000"))
+CERTFILE = os.environ.get("CERTFILE")
+KEYFILE = os.environ.get("KEYFILE")  # may be None if cert.pem also holds the key
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    extensions_map = dict(http.server.SimpleHTTPRequestHandler.extensions_map)
+    extensions_map.update({
+        ".wasm": "application/wasm",
+        ".data": "application/octet-stream",
+        ".js":   "application/javascript",
+        ".html": "text/html",
+    })
+
+    def end_headers(self):
+        self.send_header("Cross-Origin-Opener-Policy",   "same-origin")
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        self.send_header("Cross-Origin-Resource-Policy", "same-origin")
+        # Aggressive no-cache so phones don't keep serving a stale build while
+        # iterating. no-store alone isn't always honoured by mobile browsers;
+        # pair it with no-cache/must-revalidate + the legacy Pragma/Expires.
+        self.send_header("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Expires", "0")
+        super().end_headers()
+
+
+def main():
+    os.chdir(ROOT)
+    httpd = http.server.ThreadingHTTPServer(("", PORT), Handler)
+    scheme = "http"
+    if CERTFILE:
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ctx.load_cert_chain(certfile=CERTFILE, keyfile=KEYFILE)
+        httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
+        scheme = "https"
+    print(f"Serving {ROOT} on {scheme}://localhost:{PORT}/")
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\nStopping.")
+        sys.exit(0)

--- a/build/wasm/shell/coi-serviceworker.LICENSE
+++ b/build/wasm/shell/coi-serviceworker.LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Guido Zuidhof
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/build/wasm/shell/coi-serviceworker.js
+++ b/build/wasm/shell/coi-serviceworker.js
@@ -1,0 +1,146 @@
+/*! coi-serviceworker v0.1.7 - Guido Zuidhof and contributors, licensed under MIT */
+let coepCredentialless = false;
+if (typeof window === 'undefined') {
+    self.addEventListener("install", () => self.skipWaiting());
+    self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()));
+
+    self.addEventListener("message", (ev) => {
+        if (!ev.data) {
+            return;
+        } else if (ev.data.type === "deregister") {
+            self.registration
+                .unregister()
+                .then(() => {
+                    return self.clients.matchAll();
+                })
+                .then(clients => {
+                    clients.forEach((client) => client.navigate(client.url));
+                });
+        } else if (ev.data.type === "coepCredentialless") {
+            coepCredentialless = ev.data.value;
+        }
+    });
+
+    self.addEventListener("fetch", function (event) {
+        const r = event.request;
+        if (r.cache === "only-if-cached" && r.mode !== "same-origin") {
+            return;
+        }
+
+        const request = (coepCredentialless && r.mode === "no-cors")
+            ? new Request(r, {
+                credentials: "omit",
+            })
+            : r;
+        event.respondWith(
+            fetch(request)
+                .then((response) => {
+                    if (response.status === 0) {
+                        return response;
+                    }
+
+                    const newHeaders = new Headers(response.headers);
+                    newHeaders.set("Cross-Origin-Embedder-Policy",
+                        coepCredentialless ? "credentialless" : "require-corp"
+                    );
+                    if (!coepCredentialless) {
+                        newHeaders.set("Cross-Origin-Resource-Policy", "cross-origin");
+                    }
+                    newHeaders.set("Cross-Origin-Opener-Policy", "same-origin");
+
+                    return new Response(response.body, {
+                        status: response.status,
+                        statusText: response.statusText,
+                        headers: newHeaders,
+                    });
+                })
+                .catch((e) => console.error(e))
+        );
+    });
+
+} else {
+    (() => {
+        const reloadedBySelf = window.sessionStorage.getItem("coiReloadedBySelf");
+        window.sessionStorage.removeItem("coiReloadedBySelf");
+        const coepDegrading = (reloadedBySelf == "coepdegrade");
+
+        // You can customize the behavior of this script through a global `coi` variable.
+        const coi = {
+            shouldRegister: () => !reloadedBySelf,
+            shouldDeregister: () => false,
+            coepCredentialless: () => true,
+            coepDegrade: () => true,
+            doReload: () => window.location.reload(),
+            quiet: false,
+            ...window.coi
+        };
+
+        const n = navigator;
+        const controlling = n.serviceWorker && n.serviceWorker.controller;
+
+        // Record the failure if the page is served by serviceWorker.
+        if (controlling && !window.crossOriginIsolated) {
+            window.sessionStorage.setItem("coiCoepHasFailed", "true");
+        }
+        const coepHasFailed = window.sessionStorage.getItem("coiCoepHasFailed");
+
+        if (controlling) {
+            // Reload only on the first failure.
+            const reloadToDegrade = coi.coepDegrade() && !(
+                coepDegrading || window.crossOriginIsolated
+            );
+            n.serviceWorker.controller.postMessage({
+                type: "coepCredentialless",
+                value: (reloadToDegrade || coepHasFailed && coi.coepDegrade())
+                    ? false
+                    : coi.coepCredentialless(),
+            });
+            if (reloadToDegrade) {
+                !coi.quiet && console.log("Reloading page to degrade COEP.");
+                window.sessionStorage.setItem("coiReloadedBySelf", "coepdegrade");
+                coi.doReload("coepdegrade");
+            }
+
+            if (coi.shouldDeregister()) {
+                n.serviceWorker.controller.postMessage({ type: "deregister" });
+            }
+        }
+
+        // If we're already coi: do nothing. Perhaps it's due to this script doing its job, or COOP/COEP are
+        // already set from the origin server. Also if the browser has no notion of crossOriginIsolated, just give up here.
+        if (window.crossOriginIsolated !== false || !coi.shouldRegister()) return;
+
+        if (!window.isSecureContext) {
+            !coi.quiet && console.log("COOP/COEP Service Worker not registered, a secure context is required.");
+            return;
+        }
+
+        // In some environments (e.g. Firefox private mode) this won't be available
+        if (!n.serviceWorker) {
+            !coi.quiet && console.error("COOP/COEP Service Worker not registered, perhaps due to private mode.");
+            return;
+        }
+
+        n.serviceWorker.register(window.document.currentScript.src).then(
+            (registration) => {
+                !coi.quiet && console.log("COOP/COEP Service Worker registered", registration.scope);
+
+                registration.addEventListener("updatefound", () => {
+                    !coi.quiet && console.log("Reloading page to make use of updated COOP/COEP Service Worker.");
+                    window.sessionStorage.setItem("coiReloadedBySelf", "updatefound");
+                    coi.doReload();
+                });
+
+                // If the registration is active, but it's not controlling the page
+                if (registration.active && !n.serviceWorker.controller) {
+                    !coi.quiet && console.log("Reloading page to make use of COOP/COEP Service Worker.");
+                    window.sessionStorage.setItem("coiReloadedBySelf", "notcontrolling");
+                    coi.doReload();
+                }
+            },
+            (err) => {
+                !coi.quiet && console.error("COOP/COEP Service Worker failed to register:", err);
+            }
+        );
+    })();
+}

--- a/build/wasm/shell/shell.html
+++ b/build/wasm/shell/shell.html
@@ -1,0 +1,259 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>OpenLieroX (WebAssembly)</title>
+  <!-- Empty data: URL stops the browser from fetching /favicon.ico
+       and logging a noisy 404 on first load. -->
+  <link rel="icon" href="data:,">
+
+  <style>
+    html, body { margin: 0; padding: 0; height: 100%; background: #111; color: #ddd;
+                 font-family: system-ui, sans-serif; overflow: hidden; }
+    #wrapper   { display: flex; flex-direction: column; height: 100%;
+                 align-items: center; }
+    /* Loading/status text overlaid centred ON TOP of the canvas. It lives
+     * inside #fs-area (which is what goes fullscreen), so it stays visible over
+     * the game even in fullscreen — the browser's fullscreen top layer hides
+     * anything outside the fullscreen element. Hidden by JS once loading is
+     * done. pointer-events:none so it never intercepts input for the canvas. */
+    #status    { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+                 z-index: 10000; pointer-events: none; text-align: center; max-width: 90%;
+                 padding: 10px 16px; border-radius: 6px; background: rgba(0, 0, 0, 0.75);
+                 color: #ddd; font: 14px/1.4 monospace; }
+    #status.err { background: #803030; color: #fff; }
+    #toolbar   { padding: 4px 0; }
+    #toolbar button { background: #2a2a2a; color: #ddd; border: 1px solid #444;
+                      padding: 4px 10px; font: 12px system-ui, sans-serif;
+                      cursor: pointer; border-radius: 3px; }
+    #toolbar button:hover { background: #3a3a3a; }
+    /* Lock the canvas to OLX's native resolution. Letting it stretch
+     * makes mouse coordinates ambiguous (DOM vs SDL pixel space) and
+     * also softens the pixel-art assets. */
+    #canvas    { width: 640px; height: 480px; display: block;
+                 background: #000; outline: none; image-rendering: pixelated; }
+    /* The canvas + the status overlay live in #fs-area, and IT is what goes
+     * fullscreen (not the canvas directly) so the overlay can sit on top in the
+     * browser's fullscreen top layer. Windowed: it just hugs the 640x480
+     * canvas. Fullscreen: fill the screen, centre the canvas scaled to the
+     * largest 4:3 box, and paint the side/top bars black. */
+    #fs-area   { position: relative; width: 640px; height: 480px; }
+    #fs-area:fullscreen { width: 100vw; height: 100vh; display: flex;
+                          align-items: center; justify-content: center; background: #000; }
+    #fs-area:fullscreen #canvas { width: min(100vw, 100vh * 4 / 3);
+                                  height: min(100vh, 100vw * 3 / 4); }
+    #log       { max-height: 25vh; overflow: auto; padding: 4px 10px;
+                 background: #181818; font: 12px/1.3 monospace; white-space: pre-wrap;
+                 align-self: stretch; }
+    #log.err   { color: #f99; }
+  </style>
+</head>
+<body>
+  <div id="wrapper">
+    <div id="toolbar">
+      <button id="fs-toggle" type="button">Enter fullscreen</button>
+    </div>
+    <!-- #fs-area is the element that goes fullscreen — it holds both the
+         canvas and the status overlay so the overlay stays visible (in the
+         fullscreen top layer) while the game is still loading. -->
+    <div id="fs-area">
+      <!-- width/height attributes set the internal pixel buffer size.
+           Without them Emscripten/SDL2 inherit the default 800x600,
+           which means SDL_RenderSetLogicalSize(640,480) ends up scaling
+           all mouse events and the canvas is then resized inconsistently
+           on the first SDL window create. Lock to OLX's native res. -->
+      <canvas id="canvas" width="640" height="480"
+              tabindex="-1" oncontextmenu="event.preventDefault()"></canvas>
+      <div id="status">Loading OpenLieroX…</div>
+    </div>
+    <pre id="log"></pre>
+  </div>
+
+  <script>
+    const statusEl = document.getElementById("status");
+    const logEl    = document.getElementById("log");
+
+    function appendLog(text, isErr) {
+      logEl.textContent += text + "\n";
+      logEl.scrollTop = logEl.scrollHeight;
+      if (isErr) logEl.classList.add("err");
+    }
+
+    // Latch: once the data download is complete we show "Starting OpenLieroX…"
+    // and ignore further loading-status churn until the engine is ready.
+    let loadingDone = false;
+    function showStarting() {
+      if (loadingDone) return;
+      loadingDone = true;
+      statusEl.style.display = "";
+      statusEl.classList.remove("err");
+      statusEl.textContent = "Starting OpenLieroX…";
+    }
+
+    function exitFullscreenIfActive() {
+      if (document.fullscreenElement) {
+        document.exitFullscreen().catch(() => {});
+      }
+    }
+
+    // The engine calls this from Game::onStateUpdate (src/game/Game.cpp,
+    // under __EMSCRIPTEN__) only when the application actually quits
+    // (transition into S_Quit) — e.g. "Quit OpenLieroX" from the main
+    // menu. Returning to the menu after a match keeps fullscreen, since
+    // that usually means the player wants to start another game.
+    window.olxOnEngineExit = (_state) => exitFullscreenIfActive();
+
+    // The engine calls this from Menu_MainFrame (src/.../Menu_Main.cpp, under
+    // __EMSCRIPTEN__) the first time the main menu renders — i.e. it's finished
+    // the few-second boot that follows the data download. Hide the loading /
+    // "Starting OpenLieroX…" overlay at that point. (Hide directly — setStatus
+    // ignores updates once the "Starting…" latch is set.)
+    window.olxOnEngineReady = () => { statusEl.style.display = "none"; };
+
+    var Module = {
+      canvas: (() => {
+        const c = document.getElementById("canvas");
+        c.addEventListener("webglcontextlost", (e) => {
+          alert("WebGL context lost — please reload."); e.preventDefault();
+        }, false);
+        return c;
+      })(),
+      print:    (text) => {
+        if (Module.printAccept && !Module.printAccept(text)) return;
+        console.log(text);
+        appendLog(text, false);
+      },
+      printErr: (text) => {
+        if (Module.printAccept && !Module.printAccept(text)) return;
+        console.warn(text);
+        appendLog(text, true);
+      },
+      setStatus: (text) => {
+        text = text || "";
+        // Errors/aborts always win and are shown verbatim.
+        if (/error|abort|exception/i.test(text)) {
+          statusEl.style.display = "";
+          statusEl.textContent = text;
+          statusEl.classList.add("err");
+          return;
+        }
+        // Once we've switched to "Starting OpenLieroX…" stay there (ignore the
+        // run-dependency churn that follows) until olxOnEngineReady() hides it.
+        if (loadingDone) return;
+        // Emscripten reports the .data download as "Downloading data... (x/y)"
+        // in bytes. The instant the DOWNLOAD completes (x == y), switch to
+        // "Starting OpenLieroX…" — the engine still needs a few seconds to boot
+        // to the menu. (Previously we waited for all run dependencies, incl. the
+        // wasm, to resolve, which showed the switch too late.)
+        const dl = /^Downloading data\.\.\. \((\d+)\/(\d+)\)$/.exec(text);
+        if (dl && dl[1] === dl[2]) { showStarting(); return; }
+        statusEl.style.display = text ? "" : "none";
+        statusEl.textContent = text;
+        statusEl.classList.remove("err");
+      },
+      monitorRunDependencies: (left) => {
+        // Backstop for the cached case where the byte counter may not emit a
+        // final x == y: once everything's resolved, show "Starting…".
+        if (left === 0) showStarting();
+      },
+      // Don't stream every "dependency: fp /xxx" or "(end of list)" line
+      // into the on-page log; with thousands of preload files the spam
+      // dwarfs the actual runtime output. Filter at print time.
+      printAccept: (text) =>
+        !/^(dependency:|still waiting on run dependencies|\(end of list\))/.test(text),
+      onAbort: (what) => {
+        exitFullscreenIfActive();
+        Module.setStatus("Aborted: " + what);
+      },
+      onExit: () => exitFullscreenIfActive(),
+    };
+
+    Module.setStatus("Downloading…");
+    window.onerror = (msg) => Module.setStatus("Exception: " + msg);
+
+    // --- Pointer-coordinate safety net for a letterboxed canvas.
+    // Emscripten maps mouse/touch coordinates from the canvas element's
+    // getBoundingClientRect() (its FULL box). If the canvas box were ever a
+    // different aspect than its 640x480 buffer, the bars would skew edge
+    // clicks. We size the canvas to an exact 4:3 box in CSS (windowed and
+    // fullscreen), so this override is normally a no-op — but if a box is ever
+    // letterboxed, it reports the rect of the actually-rendered 4:3 content so
+    // Emscripten's mapping (canvas.width / rect.width + rect.left) stays right.
+    (() => {
+      const c = Module.canvas;
+      const realRect = c.getBoundingClientRect.bind(c);
+      c.getBoundingClientRect = function () {
+        const r = realRect();
+        const bw = this.width, bh = this.height; // 640x480 backing buffer
+        if (!r.width || !r.height || !bw || !bh) return r;
+        const bufAspect = bw / bh;
+        const boxAspect = r.width / r.height;
+        if (Math.abs(boxAspect - bufAspect) < 1e-3) return r; // no letterbox
+        let cw, ch;
+        if (boxAspect > bufAspect) { ch = r.height; cw = ch * bufAspect; } // pillarbox (wide screen)
+        else                       { cw = r.width;  ch = cw / bufAspect; } // letterbox (tall screen)
+        return new DOMRect(r.left + (r.width - cw) / 2,
+                           r.top  + (r.height - ch) / 2, cw, ch);
+      };
+    })();
+
+    // Suppress browser shortcuts that overlap OLX gameplay bindings.
+    // preventDefault only stops the browser's default action — SDL2's
+    // own keyboard listener still receives the event, so the engine
+    // sees the press normally. Captured at the window level so we run
+    // before SDL2's handler. Skipped for form inputs in case any are
+    // ever added to the shell.
+    window.addEventListener("keydown", (e) => {
+      const t = e.target;
+      if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" ||
+                t.isContentEditable))
+        return;
+
+      // Modifier+arrow combos: Alt+Left/Right is browser back/forward,
+      // Ctrl+arrows are word-skip / scroll on some platforms.
+      if ((e.altKey || e.ctrlKey || e.metaKey) &&
+          (e.code === "ArrowLeft"  || e.code === "ArrowRight" ||
+           e.code === "ArrowUp"    || e.code === "ArrowDown")) {
+        e.preventDefault();
+        return;
+      }
+
+      // Bare keys that scroll or navigate the page.
+      switch (e.code) {
+        case "ArrowLeft": case "ArrowRight":
+        case "ArrowUp":   case "ArrowDown":
+        case "Space":     case "Tab":
+        case "Backspace": case "F1":
+          e.preventDefault();
+          break;
+      }
+      // Intentionally NOT swallowed: F5/Ctrl+R (reload), F11 (browser
+      // fullscreen escape hatch), F12 (devtools), Esc.
+    }, true);
+
+    // Web Fullscreen toggle. We fullscreen #fs-area (the canvas + the status
+    // overlay), NOT the canvas itself, so the loading/status text stays visible
+    // on top while the game loads (the fullscreen top layer hides anything
+    // outside the fullscreen element). This is independent of SDL/OLX
+    // fullscreen (kWasmAllowFullscreen in AuxLib.cpp), which is disabled. The
+    // canvas keeps its 640x480 buffer; CSS scales it to the screen.
+    (() => {
+      const fsArea = document.getElementById("fs-area");
+      const btn    = document.getElementById("fs-toggle");
+      btn.addEventListener("click", () => {
+        if (document.fullscreenElement) {
+          document.exitFullscreen();
+        } else {
+          fsArea.requestFullscreen().catch((e) =>
+            appendLog("Fullscreen request failed: " + e, true));
+        }
+      });
+      document.addEventListener("fullscreenchange", () => {
+        btn.textContent = document.fullscreenElement
+          ? "Exit fullscreen" : "Enter fullscreen";
+      });
+    })();
+  </script>
+  {{{ SCRIPT }}}
+</body>
+</html>

--- a/include/InputEvents.h
+++ b/include/InputEvents.h
@@ -108,6 +108,10 @@ mouse_t		*GetMouse();
 SDL_Event	*GetEvent();
 ModifiersState *GetCurrentModstate();
 
+// True while the player is using a mouse rather than touch (web build only;
+// always false elsewhere). Used to show the software cursor in-game.
+bool		InputUsingMouse();
+
 bool		WasKeyboardEventHappening(SDL_Keycode key, bool down = true);
 
 // Inject a synthetic keyboard event into the same pipeline real key events go

--- a/include/StringUtils.h
+++ b/include/StringUtils.h
@@ -76,6 +76,11 @@
 #	define stricmp _stricmp
 #	define fcloseall _fcloseall
 #	define strcasecmp	stricmp
+#elif defined(__EMSCRIPTEN__)
+// Emscripten ships <compat/string.h> with `extern char* strlwr(char*)`,
+// which clashes with the void-returning helper below. Use the system one
+// (it's a thin wrapper around tolower() too) and discard the return.
+#include <compat/string.h>
 #else
 INLINE void strlwr(char* string) {
 	if(string)

--- a/include/TouchControls.h
+++ b/include/TouchControls.h
@@ -54,6 +54,12 @@ void Update();
 // controls in the way. The next SDL_FINGERDOWN re-enables the UI.
 void NotifyExternalInput();
 
+// Called by the input layer when a genuine (non-synthetic) touch event
+// arrives. The "auto" value of Game.TouchscreenControls turns the touch
+// controls on once this has happened — i.e. a touchscreen is actually in
+// use — with no per-platform assumptions.
+void NotifyRealTouch();
+
 // If the active touch layout specifies a minimap position, write it
 // to outX/outY (top-left in logical 640x480 coords) and return true.
 // Callers (the HUD draw path) use this to reposition the minimap so it

--- a/include/Unicode.h
+++ b/include/Unicode.h
@@ -15,13 +15,14 @@
 #include <string>
 #include "CodeAttributes.h"
 
-#ifdef __ANDROID__
-// Android's libc++ only provides std::char_traits specialisations for
-// char, wchar_t, char8_t, char16_t, char32_t. OpenLieroX instantiates
-// std::basic_string with Uint16/Uint32 (unsigned short / unsigned int);
-// add minimal specialisations for those here so the typedefs below
-// compile. We only use these strings as buffers, so locale-aware bits
-// are intentionally not implemented.
+#if defined(__ANDROID__) || defined(__EMSCRIPTEN__)
+// Both Bionic libc++ (Android) and Emscripten's libc++ only provide
+// std::char_traits specialisations for char, wchar_t, char8_t,
+// char16_t, char32_t. OpenLieroX instantiates std::basic_string with
+// Uint16/Uint32 (unsigned short / unsigned int); add minimal
+// specialisations for those here so the typedefs below compile. We
+// only use these strings as buffers, so locale-aware bits are
+// intentionally not implemented.
 #include <cstring>
 namespace std {
 template<typename T>
@@ -59,7 +60,7 @@ struct __olx_int_char_traits {
 template<> struct char_traits<unsigned short> : __olx_int_char_traits<unsigned short> {};
 template<> struct char_traits<unsigned int>   : __olx_int_char_traits<unsigned int>   {};
 }
-#endif // __ANDROID__
+#endif // __ANDROID__ || __EMSCRIPTEN__
 
 typedef Uint32 UnicodeChar;
 typedef std::basic_string<UnicodeChar> Unicode32String;

--- a/libs/hawknl/src/errorstr.c
+++ b/libs/hawknl/src/errorstr.c
@@ -89,11 +89,12 @@ NL_EXP const /*@observer@*/  NLchar* NL_APIENTRY nlGetSystemErrorStr(NLint err)
     case EINTR:
         lpszRetStr=(NLchar *)TEXT("Interrupted function call.");
         break;
-#if defined(NO_DATA)       
+/* Emscripten/WASI: NO_DATA collides with EADDRNOTAVAIL (both = 4). */
+#if defined(NO_DATA) && !defined(__EMSCRIPTEN__)
     case NO_DATA:
         lpszRetStr=(NLchar *)TEXT("Valid name, no data record for type.");
         break;
-#endif        
+#endif
 #else
     case NO_DATA:
         lpszRetStr=(NLchar *)TEXT("Interrupted function call or no data record for type.");
@@ -111,21 +112,26 @@ NL_EXP const /*@observer@*/  NLchar* NL_APIENTRY nlGetSystemErrorStr(NLint err)
     case EINVAL:
         lpszRetStr=(NLchar *)TEXT("App version not supported by DLL.");
         break;
-#if defined(TRY_AGAIN)        
+/* On Emscripten/WASI, h_errno values (TRY_AGAIN=2, NO_RECOVERY=3,
+ * HOST_NOT_FOUND=4) collide with errno values (EACCES=2, EADDRINUSE=3,
+ * EADDRNOTAVAIL=4) — both come from the same number space. Skip the
+ * h_errno cases there; the errno cases below are the ones HawkNL
+ * actually reports. */
+#if defined(TRY_AGAIN) && !defined(__EMSCRIPTEN__)
     case TRY_AGAIN:
         lpszRetStr=(NLchar *)TEXT("Non-authoritive: host not found or server failure.");
         break;
-#endif        
-#if defined(NO_RECOVERY)
+#endif
+#if defined(NO_RECOVERY) && !defined(__EMSCRIPTEN__)
     case NO_RECOVERY:
         lpszRetStr=(NLchar *)TEXT("Non-recoverable: refused or not implemented.");
         break;
 #endif
-#if defined(HOST_NOT_FOUND)        
+#if defined(HOST_NOT_FOUND) && !defined(__EMSCRIPTEN__)
     case HOST_NOT_FOUND:
         lpszRetStr=(NLchar *)TEXT("Authoritive: Host not found.");
         break;
-#endif        
+#endif
     case EACCES:
         lpszRetStr=(NLchar *)TEXT("Permission to access socket denied.");
         break;

--- a/libs/hawknl/src/loopback.c
+++ b/libs/hawknl/src/loopback.c
@@ -480,8 +480,14 @@ NLint loopback_Read(NLsocket socket, NLvoid *buffer, NLint nbytes)
     }
     /* check for broken connection */
     else if((len == -1) || (sock->connected == NL_TRUE && sock->ext->consock == NL_INVALID)
-        || (sock->connected == NL_FALSE && sock->type != NL_BROADCAST))
+        || (sock->connected == NL_FALSE && sock->type != NL_BROADCAST
+            && sock->type != NL_UNRELIABLE))
     {
+        /* Unconnected NL_UNRELIABLE (UDP) is the normal pattern OLX
+         * uses: bind a port, sendto/recvfrom by address. The original
+         * driver treated "no data" on such sockets as DISCONNECT,
+         * which made every OLX read fail. Treat it the same as
+         * NL_BROADCAST and return len (== 0). */
         nlSetError(NL_SOCK_DISCONNECT);
         return NL_INVALID;
     }
@@ -615,19 +621,30 @@ NLint loopback_Write(NLsocket socket, const NLvoid *buffer, NLint nbytes)
                 return NL_INVALID;
             }
             /* unconnected UDP emulation */
-            count = nbytes;
-            (void)nlGroupGetSockets(loopgroup, (NLsocket *)s, &number);
-            for(i=0;i<number;i++)
             {
-                if(nlIsValidSocket(s[i]) == NL_TRUE)
+                /* OLX uses nlSetRemoteAddr() which only fills in
+                 * sock->addressout. The original loopback driver only
+                 * matched against sock->remoteport, which Open never
+                 * sets for unconnected UDP — so the destination port
+                 * was always 0 and packets went nowhere. Fall back to
+                 * the addressout port when remoteport is unset. */
+                NLushort dport = sock->remoteport;
+                if(dport == 0)
+                    dport = loopback_GetPortFromAddr(&sock->addressout);
+                count = nbytes;
+                (void)nlGroupGetSockets(loopgroup, (NLsocket *)s, &number);
+                for(i=0;i<number;i++)
                 {
-                    othersock = nlSockets[s[i]];
-
-                    if(sock->remoteport == othersock->localport &&
-                        othersock->connected == NL_FALSE &&
-                        sock->type == othersock->type)
+                    if(nlIsValidSocket(s[i]) == NL_TRUE)
                     {
-                        (void)loopback_WritePacket(s[i], buffer, nbytes, sock->localport);
+                        othersock = nlSockets[s[i]];
+
+                        if(dport == othersock->localport &&
+                            othersock->connected == NL_FALSE &&
+                            sock->type == othersock->type)
+                        {
+                            (void)loopback_WritePacket(s[i], buffer, nbytes, sock->localport);
+                        }
                     }
                 }
             }

--- a/src/client/AuxLib.cpp
+++ b/src/client/AuxLib.cpp
@@ -29,6 +29,9 @@
 #undef Font
 #include <cstdlib>
 #include <sstream>
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 #include <cstring>
 
 #if defined(__APPLE__)
@@ -250,6 +253,16 @@ void *GetWindowHandle()
 
 
 void CapFPS() {
+#ifdef __EMSCRIPTEN__
+	// Don't sleep on wasm. The browser's compositor already paces
+	// presentation at vsync (~60 Hz), so the game-thread sleeping here
+	// only adds keyboard-input latency without saving any visible work:
+	// any SDL_KEYDOWN that arrives in the OLX mainQueue while the thread
+	// is mid-SDL_Delay has to wait for the sleep to end before
+	// ProcessEvents picks it up next frame. Gamepad input doesn't suffer
+	// because it's polled directly during simulation.
+	return;
+#else
 	const TimeDiff fMaxFrameTime = TimeDiff( (tLXOptions->nMaxFPS > 0) ? (1.0f / (float)tLXOptions->nMaxFPS) : 0.0f );
 	const AbsTime currentTime = GetTime();
 	// tLX->currentTime is old time
@@ -260,6 +273,7 @@ void CapFPS() {
 	else
 		// do at least one small break, else it's possible that we never receive signals from our OS
 		SDL_Delay(1);
+#endif
 }
 
 
@@ -317,7 +331,7 @@ bool VideoPostProcessor::initWindow() {
 	assert(isMainThread());
 
 	bool resetting = false;
-	
+
 	// Check if already running
 	if (m_videoSurface.get())  {
 		resetting = true;
@@ -325,7 +339,22 @@ bool VideoPostProcessor::initWindow() {
 	} else {
 		notes << "setting video mode" << endl;
 	}
-	
+
+#if defined(__EMSCRIPTEN__)
+	// SDL2 + Emscripten doesn't support tearing down and recreating
+	// the window / renderer cleanly: doing so destroys the canvas
+	// element while the browser's main thread may still be dispatching
+	// mouse events into the old context, which trips a heap-corruption
+	// trap inside the malloc-on-mouse-event path. The 640x480 surface
+	// never changes between menu and gameplay, so just keep the
+	// existing window+renderer the first time around and short-circuit
+	// any later "reset" calls.
+	if (resetting) {
+		notes << "  (Emscripten: reusing existing window+renderer)" << endl;
+		return true;
+	}
+#endif
+
 	// uninit first to ensure that the video thread is not running
 	VideoPostProcessor::uninit();
 	
@@ -345,6 +374,21 @@ bool VideoPostProcessor::initWindow() {
 	// BlueBeret's addition (2007): OpenGL support
 	bool opengl = tLXOptions->bOpenGL;
 	
+#if defined(__EMSCRIPTEN__)
+	// === Wasm fullscreen master switch ============================
+	// Browser fullscreen + OpenLieroX is currently buggy: the canvas
+	// resizes mid-game, mouse coordinates drift, and exiting fullscreen
+	// leaves SDL in a bad state. Flip this to `true` if you want to
+	// re-enable it after fixing those issues; for now we force it off
+	// regardless of what the user picked in Options. See CLAUDE.md.
+	static const bool kWasmAllowFullscreen = false;
+	if(!kWasmAllowFullscreen && tLXOptions->bFullscreen) {
+		notes << "Wasm: ignoring requested fullscreen "
+		         "(disabled via kWasmAllowFullscreen)" << endl;
+		tLXOptions->bFullscreen = false;
+	}
+#endif
+
 	// Initialize the video
 	if(tLXOptions->bFullscreen)  {
 		vidflags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
@@ -424,8 +468,12 @@ setvideomode:
 		return false;
 	}
 	
+	// Hide the operating-system / browser cursor. OpenLieroX draws its own
+	// software cursor where one is wanted (menus), and that should be the only
+	// cursor the player ever sees — on the web too (SDL maps this to
+	// `canvas { cursor: none }`).
 	SDL_ShowCursor(SDL_DISABLE);
-	
+
 #ifdef WIN32
 	// Hint: Reset the mouse state - this should avoid the mouse staying pressed
 	GetMouse()->Button = 0;
@@ -486,7 +534,18 @@ static void dumpRenderInfo(SDL_Renderer* renderer) {
 }
 
 bool VideoPostProcessor::resetVideo() {
+#if defined(__EMSCRIPTEN__)
+	// On Emscripten + pthreads, SDL's GLES2 backend posts every GL
+	// call (glTexImage2D etc.) to the main thread via a proxy queue
+	// whose atomics-on-mailbox path trips wasm's alignment trap. The
+	// software renderer doesn't touch WebGL at all and is plenty
+	// fast for 640x480 — pin to it.
+	SDL_SetHint(SDL_HINT_RENDER_DRIVER, "software");
+	m_renderer = SDL_CreateRenderer(m_window.get(), -1,
+	                                SDL_RENDERER_SOFTWARE);
+#else
 	m_renderer = SDL_CreateRenderer(m_window.get(), -1, 0);
+#endif
 	if(!m_renderer.get()) {
 		errors << "failed to init renderer: " << SDL_GetError() << endl;
 		return false;
@@ -565,10 +624,30 @@ void VideoPostProcessor::render() {
 	//DrawLoadingAni(psScreen, 320, 260, 10, 10, Color(255,0,0), Color(0,255,0), LAT_CAKE);
 	
 	if(!get()->m_renderer.get()) return;
-	
+
 	SDL_RenderClear(get()->m_renderer.get());
 	SDL_RenderCopy(get()->m_renderer.get(), get()->m_videoTexture.get(), NULL, NULL);
 	SDL_RenderPresent(get()->m_renderer.get());
+
+#ifdef __EMSCRIPTEN__
+	// The very first presented frame means the wasm app is actually up on
+	// screen — tell the JS shell so it drops the "Starting OpenLieroX…" overlay.
+	// (Doing this here rather than when the main menu renders hides the overlay
+	// the instant the engine shows anything, not a moment later.)
+	// PROXY_TO_PTHREAD runs this on a worker; route to the browser main thread.
+	{
+		static bool reportedReady = false;
+		if(!reportedReady) {
+			reportedReady = true;
+			MAIN_THREAD_ASYNC_EM_ASM({
+				if (typeof window !== 'undefined' &&
+				    typeof window.olxOnEngineReady === 'function') {
+					window.olxOnEngineReady();
+				}
+			});
+		}
+	}
+#endif
 }
 
 void VideoPostProcessor::cloneBuffer() {
@@ -941,9 +1020,17 @@ void EnableSystemMouseCursor(bool enable)
 		EnableMouseCursor(bool b): Enable(b) {};
 		Result handle()
 		{
+#ifdef __EMSCRIPTEN__
+			// Web build: never show the operating-system / browser cursor.
+			// OpenLieroX's own software cursor is the only cursor the player
+			// should ever see, so ignore requests to show the OS one.
+			(void)Enable;
+			SDL_ShowCursor(SDL_DISABLE);
+#else
 			SDL_ShowCursor(Enable ? SDL_ENABLE : SDL_DISABLE ); // Should be called from main thread, or you'll get race condition with libX11
+#endif
 			return true;
-		} 
+		}
 	};
 	doActionInMainThread( new EnableMouseCursor(enable) );
 };

--- a/src/client/CClient_Draw.cpp
+++ b/src/client/CClient_Draw.cpp
@@ -841,6 +841,15 @@ void CClient::Draw(const SmartPointer<SDL_Surface>& bmpDest)
 	// Touchscreen on-screen controls (no-op when option is disabled)
 	TouchControls::Render(bmpDest.get());
 
+	// When the touch controls are up but the player is driving them with a
+	// mouse (web build), draw the software cursor so they can see where they're
+	// pointing. InputUsingMouse() flips to false on real touch, so a finger
+	// user never sees a cursor. (No-op off the web build — always false there.)
+	if(TouchControls::IsActive() && InputUsingMouse()) {
+		SetGameCursor(CURSOR_ARROW);
+		DrawCursor(bmpDest.get());
+	}
+
 	// We currently just set it always to true because it paints on the video surface
 	// and expects that it will always stay there. This is of course wrong for double buffering
 	// or also our video post processor.

--- a/src/client/CInput.cpp
+++ b/src/client/CInput.cpp
@@ -669,11 +669,15 @@ bool CInput::Binding::setup(const std::string& string)
 			JoystickIndex = padIndex;
 			Data = 0;
 
-			// Pad not connected — leave the binding unusable (Data stays 0).
-			if(SDL_NumJoysticks() <= padIndex) return false;
-
-			// Open the controller if it hasn't been already opened
-			initController(padIndex, false);
+			// Open the pad now if it's already connected. If it isn't yet —
+			// e.g. a browser only exposes a gamepad to the page after its first
+			// button press — don't bail out: the hotplug path
+			// (OnControllerAdded) opens it the moment it appears. We still
+			// resolve the binding's action below regardless, so it works as
+			// soon as the pad is initialised, with no trip through the controls
+			// menu needed to "wake" it.
+			if(SDL_NumJoysticks() > padIndex)
+				initController(padIndex, false);
 
 			std::string suffix = remaining.substr(digitsEnd + 1);
 			for(uint32_t n=0; n<sizeof(Joysticks) / sizeof(joystick_t); n++) {
@@ -791,6 +795,40 @@ bool CInput::Binding::isDown() const
 
 		// Keyboard
 		case INP_KEYBOARD:
+#ifdef __EMSCRIPTEN__
+			// On the wasm port we poll keyboard state directly each
+			// frame, the same model gamepad uses (CInput::INP_JOYSTICK*
+			// → checkControllerState). The event-driven path still
+			// updates bDown via HandleCInputs_KeyEvent, but events have
+			// to traverse browser → SDL → wasm-worker → OLX mainQueue
+			// → game-thread; polling skips that whole chain so a held
+			// key shows up the same frame the simulation runs.
+			if(Data > 0) {
+				SDL_Scancode sc = SDL_GetScancodeFromKey(Data);
+				if(sc != SDL_SCANCODE_UNKNOWN) {
+					const Uint8* state = SDL_GetKeyboardState(NULL);
+					if(state && state[sc]) {
+						// If the binding requires modifiers, enforce
+						// an exact match; otherwise fire regardless.
+						if(m_modifiers.bAlt || m_modifiers.bCtrl ||
+						   m_modifiers.bShift || m_modifiers.bGui) {
+							SDL_Keymod mod = SDL_GetModState();
+							const bool alt   = (mod & KMOD_ALT)   != 0;
+							const bool ctrl  = (mod & KMOD_CTRL)  != 0;
+							const bool shift = (mod & KMOD_SHIFT) != 0;
+							const bool gui   = (mod & KMOD_GUI)   != 0;
+							if(m_modifiers.bAlt   == alt &&
+							   m_modifiers.bCtrl  == ctrl &&
+							   m_modifiers.bShift == shift &&
+							   m_modifiers.bGui   == gui)
+								return true;
+						} else {
+							return true;
+						}
+					}
+				}
+			}
+#endif
 			if(wasDown()) return true; // in this case, we want to return true here to get it recognised at least once
 			return bDown;
 
@@ -962,8 +1000,18 @@ void CInput::handleKeyEvent(const KeyboardEvent& ev) {
 // Update down-once state for non-keyboard bindings (polled each frame)
 void CInput::updateDownOnceForNonKeyboard() {
 	for(std::vector<Binding>::iterator b = m_bindings.begin(); b != m_bindings.end(); ++b) {
+#ifdef __EMSCRIPTEN__
+		// On wasm keyboard bindings are also polled each frame via
+		// Binding::isDown (see the SDL_GetKeyboardState branch there), so
+		// they ride the same edge-derivation logic the gamepad uses. This
+		// is what makes held keys register the same frame the simulation
+		// runs, without the OLX mainQueue round-trip.
+		if(!b->isUsed())
+			continue;
+#else
 		if(!b->isUsed() || b->isKeyboard())
 			continue;
+#endif
 
 		// HINT: It is possible that wasUp() and !Down (a case which is not covered in further code)
 		if(b->wasUp() && !b->bDown) {
@@ -1003,8 +1051,15 @@ void CInput::updateDownOnceForNonKeyboard() {
 // Update up state for non-keyboard bindings (polled each frame)
 void CInput::updateUpForNonKeyboard() {
 	for(std::vector<Binding>::iterator b = m_bindings.begin(); b != m_bindings.end(); ++b) {
+#ifdef __EMSCRIPTEN__
+		// See updateDownOnceForNonKeyboard: keyboard bindings are polled
+		// each frame on wasm, so don't skip them here.
+		if(!b->isUsed())
+			continue;
+#else
 		if(!b->isUsed() || b->isKeyboard())
 			continue;
+#endif
 		if(b->isDown() && !b->bDown)
 			b->nUp++;
 	}

--- a/src/client/DeprecatedGUI/MenuSystem.cpp
+++ b/src/client/DeprecatedGUI/MenuSystem.cpp
@@ -80,8 +80,18 @@ static bool Menu_InitSockets() {
 	tMenu->tSocket[SCK_NET]->OpenUnreliable(0);	
 	
 	if(!tMenu->tSocket[SCK_LAN]->isOpen() || !tMenu->tSocket[SCK_NET]->isOpen()) {
+#if defined(__EMSCRIPTEN__)
+		// Browsers can't open raw UDP sockets — sockets() returns
+		// SOCK_DGRAM = -1 in Emscripten. The single-player menu still
+		// works without them; just skip the abort and continue with
+		// closed sockets. The server browser / master server query
+		// paths will be no-ops at runtime.
+		warnings << "Menu_InitSockets: UDP sockets unavailable on Emscripten — "
+		            "continuing without networking" << endl;
+#else
 		SystemError("Error: Failed to open a socket for networking");
 		return false;
+#endif
 	}
 
 	// Send some random data to some random IP

--- a/src/client/DeprecatedGUI/Menu_Main.cpp
+++ b/src/client/DeprecatedGUI/Menu_Main.cpp
@@ -31,6 +31,9 @@
 #include "DeprecatedGUI/CTextButton.h"
 #include "sound/SoundsBase.h"
 #include "game/ServerList.h"
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 
 
 namespace DeprecatedGUI {
@@ -182,6 +185,20 @@ void Menu_MainFrame()
 
 					MessageBoxReturnType answer = Menu_MessageBox(GetGameName(), "Quit OpenLieroX?", LMB_YESNO);
 					if( answer == MBR_YES || answer == MBR_INVALID ) {
+#ifdef __EMSCRIPTEN__
+						// Tell the JS shell to drop browser fullscreen the
+						// instant the user confirms Quit, before any teardown
+						// runs. Game::onStateUpdate's parallel hook does not
+						// reliably fire on the Inactive→Quit transition for
+						// reasons we haven't pinned down, so this is the
+						// authoritative quit signal for the wasm port.
+						MAIN_THREAD_ASYNC_EM_ASM({
+							if (typeof window !== 'undefined' &&
+							    typeof window.olxOnEngineExit === 'function') {
+								window.olxOnEngineExit(0);
+							}
+						});
+#endif
 						game.state = Game::S_Quit;
 					    Menu_MainShutdown();
 				    } else {

--- a/src/client/DeprecatedGUI/Menu_Options.cpp
+++ b/src/client/DeprecatedGUI/Menu_Options.cpp
@@ -61,10 +61,12 @@ enum {
 int ControlsSubTab = ct_Player1;
 static const char* ControlsTabNames[ct__Count] = { "Player 1", "Player 2", "General", "Touchscreen" };
 
-// True if the given tab should appear in the tab bar. The touch-screen
-// tab is hidden on devices without a touch input.
-static bool IsControlsTabVisible(int t) {
-	return t != ct_Touchscreen || TouchControls::IsTouchDeviceAvailable();
+// True if the given tab should appear in the tab bar. All control tabs,
+// including Touchscreen, are always available — the touch layout can be
+// inspected/picked anywhere, which is useful for debugging or authoring a
+// new layout even on a machine without a touch device.
+static bool IsControlsTabVisible(int /*t*/) {
+	return true;
 }
 // Tab header hit-boxes, filled in when drawn (see Menu_OptionsDrawControlsTabs).
 static SDL_Rect ControlsTabRects[ct__Count];
@@ -76,6 +78,24 @@ static SDL_Rect ResetBtnRect;
 // plus the per-tile hit-boxes filled in by Menu_OptionsDrawTouchTiles.
 static std::vector<TouchControls::LayoutInfo> gTouchLayoutInfos;
 static std::vector<SDL_Rect>                  gTouchLayoutTileRects;
+
+// The On / Off / Auto selector for Game.TouchscreenControls, shown on the top
+// row of the Touchscreen sub-tab (above the layout tiles). The labels map to
+// the tri-state option value; hit-boxes are filled in when drawn.
+static const struct { const char* label; const char* value; } kTouchModeChoices[] = {
+	{ "Auto-detect", "auto" }, { "Always on", "true" }, { "Always off", "false" },
+};
+static const int kTouchModeCount = (int)(sizeof(kTouchModeChoices) / sizeof(kTouchModeChoices[0]));
+static SDL_Rect gTouchModeRects[kTouchModeCount];
+
+// Which choice the current option value corresponds to (for highlighting).
+static int Menu_CurrentTouchMode() {
+	const std::string& v = tLXOptions->sTouchscreenControls;
+	// Index must match kTouchModeChoices order: 0=Auto-detect, 1=Always on, 2=Always off.
+	if(stringcaseequal(v, "true")  || stringcaseequal(v, "yes") || stringcaseequal(v, "on")  || v == "1") return 1;
+	if(stringcaseequal(v, "false") || stringcaseequal(v, "no")  || stringcaseequal(v, "off") || v == "0") return 2;
+	return 0; // "auto" or anything unrecognised
+}
 CButton		TopButtons[3];
 
 // Control id's
@@ -640,6 +660,42 @@ static void Menu_OptionsRefreshTouchTiles()
 }
 
 ///////////////////
+// Draw the "Touch controls: On / Off / Auto" selector on the top row of the
+// Touchscreen sub-tab (above the layout tiles). Records each choice's hit-box
+// in gTouchModeRects for click handling in Menu_OptionsFrame.
+static void Menu_OptionsDrawTouchMode(SDL_Surface* dest)
+{
+	mouse_t* Mouse = GetMouse();
+	// Sit roughly midway between the sub-tab bar (y=150) and the tiles (now
+	// y=235), with generous padding above and below so the row isn't crowded.
+	const int y = 190;
+	const int h = tLX->cFont.GetHeight();
+
+	const std::string label = "Use touchscreen controls:";
+	tLX->cFont.Draw(dest, kControlLabelX, y, tLX->clNormalLabel, label);
+
+	const int current = Menu_CurrentTouchMode();
+	int x = kControlLabelX + tLX->cFont.GetWidth(label) + 16;
+	for(int i = 0; i < kTouchModeCount; i++) {
+		const std::string text = kTouchModeChoices[i].label;
+		const int w = tLX->cFont.GetWidth(text);
+
+		SDL_Rect r{(Sint16)x, (Sint16)y, (Uint16)w, (Uint16)h};
+		gTouchModeRects[i] = r;
+
+		const bool selected = (i == current);
+		const bool hover = (Mouse->X >= x && Mouse->X <= x + w &&
+		                    Mouse->Y >= y && Mouse->Y <= y + h);
+		Color col = selected ? tLX->clHeading : (hover ? tLX->clHeading : tLX->clNormalLabel);
+		tLX->cFont.Draw(dest, x, y, col, text);
+		// Underline the selected choice so the active value is obvious.
+		if(selected)
+			DrawRectFill(dest, x, y + h, x + w, y + h + 1, tLX->clHeading);
+
+		x += w + 24;
+	}
+}
+
 // Draw the row of layout tiles on the "Touchscreen" sub-tab. Each tile
 // shows the layout's preview PNG (or a "No preview" placeholder), the
 // `name:` field below, and a thicker border around the currently-selected
@@ -650,14 +706,14 @@ static void Menu_OptionsDrawTouchTiles(SDL_Surface* dest)
 	const int n = (int)gTouchLayoutInfos.size();
 	if(n == 0) {
 		const std::string msg = "No layouts found in share/gamedir/touchscreen/";
-		tLX->cFont.Draw(dest, kControlLabelX, 220, tLX->clNormalLabel, msg);
+		tLX->cFont.Draw(dest, kControlLabelX, 250, tLX->clNormalLabel, msg);
 		return;
 	}
 
 	const int tileW = 200;
 	const int tileH = 150;
 	const int gap   = 20;
-	const int topY  = 200;
+	const int topY  = 235; // leave padding below the "Use touchscreen controls:" row
 	const int totalW = n * tileW + (n - 1) * gap;
 	int x = (640 - totalW) / 2;
 	if(x < 20) x = 20;  // many tiles — fall back to a left margin
@@ -855,6 +911,23 @@ void Menu_OptionsFrame()
 		ctrlLayout.Draw(VideoPostProcessor::videoSurface().get());
 
 		if(ControlsSubTab == ct_Touchscreen) {
+			// Top row: On / Off / Auto selector for Game.TouchscreenControls.
+			Menu_OptionsDrawTouchMode(VideoPostProcessor::videoSurface().get());
+			if(!bSpeedTest && Mouse->Up) {
+				for(int i = 0; i < kTouchModeCount; i++) {
+					const SDL_Rect& r = gTouchModeRects[i];
+					if(Mouse->X >= r.x && Mouse->X <= r.x + r.w &&
+					   Mouse->Y >= r.y && Mouse->Y <= r.y + r.h) {
+						const std::string val = kTouchModeChoices[i].value;
+						if(!stringcaseequal(tLXOptions->sTouchscreenControls, val)) {
+							tLXOptions->sTouchscreenControls = val;
+							TouchControls::ReloadLayout();
+							PlaySoundSample(sfxGeneral.smpClick);
+						}
+						break;
+					}
+				}
+			}
 			// Layout tiles + click handling. No "Reset defaults" here — the
 			// touch-screen tab has nothing to reset.
 			Menu_OptionsDrawTouchTiles(VideoPostProcessor::videoSurface().get());

--- a/src/client/InputEvents.cpp
+++ b/src/client/InputEvents.cpp
@@ -32,6 +32,10 @@
 #include <Windows.h>
 #endif
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten/html5.h> // emscripten_sample_gamepad_data()
+#endif
+
 
 // Keyboard, Mouse, & Event
 static keyboard_t	Keyboard;
@@ -249,12 +253,13 @@ void InjectSyntheticKey(SDL_Keycode sym, bool down) {
 }
 
 static void EvHndl_KeyDownUp(SDL_Event* ev) {
-	// User pressed a key that's bound to one of player 1's actions —
-	// hide the on-screen touch controls until they touch the screen
-	// again. Player 2's keys and general controls (chat/score/...) don't
-	// trigger the hide, so split-screen player 2 typing on the keyboard
-	// doesn't dismiss player 1's touch UI.
-	if(ev->type == SDL_KEYDOWN && isPlayer1KeyBinding(ev->key.keysym.sym))
+	// Any key press hides the on-screen touch controls until the screen is
+	// touched again — the player has switched to the keyboard. This mirrors
+	// the gamepad behaviour (see EvHndl_ControllerButton/Axis, which call
+	// NotifyExternalInput on player-1 input). We hide on any key, not just
+	// keys bound to player 1, so a keyboard player isn't left with the touch
+	// overlay covering the game.
+	if(ev->type == SDL_KEYDOWN)
 		TouchControls::NotifyExternalInput();
 
 	// Check the characters
@@ -340,15 +345,85 @@ static void EvHndl_TextInput(SDL_Event* _ev) {
 
 static int mouseX, mouseY;
 
+// Drive the on-screen touch controls with the mouse, so a player without a
+// touchscreen can still use them (any platform). We synthesise a single-finger
+// touch from the left mouse button; TouchControls::HandleFingerEvent only acts
+// on it when the touch controls are actually enabled (the TouchscreenControls
+// option / touch detection), so this is a harmless no-op otherwise.
+//
+// Avoiding double-presses on a real touchscreen: a tap there can also produce a
+// "compatibility" mouse event (mousedown/up). SDL tags the mouse events it
+// synthesises from touch with SDL_TOUCH_MOUSEID, which we skip; we also ignore
+// mouse input for a short window after any real touch (ghost-click suppression)
+// and only ever start a synthetic touch on a genuine mouse-down.
+static const Uint32 kRealTouchGuardMs = 800;
+static Uint32 gLastRealTouchTicks = 0;
+static bool recentRealTouch() {
+	return gLastRealTouchTicks != 0 && (SDL_GetTicks() - gLastRealTouchTicks) < kRealTouchGuardMs;
+}
+
+static bool gSynthFingerDown = false;
+
+// True while the player is driving the game with a mouse rather than touch.
+// Flipped true by genuine mouse input and false by real finger input
+// (post-touch compatibility mouse events are filtered via recentRealTouch()).
+// Drives the in-game software cursor — see InputUsingMouse().
+static bool gInputIsMouse = false;
+
+static void synthFingerFromMouse(Uint32 fingerType, int x, int y) {
+	SDL_TouchFingerEvent t = {};
+	t.type     = fingerType;
+	t.touchId  = 0;
+	t.fingerId = 0; // single synthetic pointer; mouse can't multi-touch
+	// HandleFingerEvent maps normalised x/y back onto the 640x480 surface,
+	// which is the logical space SDL reports mouse coords in too.
+	t.x = (float)x / 640.0f;
+	t.y = (float)y / 480.0f;
+	t.pressure = 1.0f;
+	TouchControls::HandleFingerEvent(t);
+}
+
+// True while the player is using a mouse (not touch). Drives the in-game
+// software-cursor visibility (CClient_Draw).
+bool InputUsingMouse() {
+	return gInputIsMouse;
+}
+
 static void EvHndl_MouseMotion(SDL_Event* ev) {
 /*	mouseX = CLAMP(mouseX, 0, VideoPostProcessor::get()->screenWidth());
 	mouseY = CLAMP(mouseY, 0, VideoPostProcessor::get()->screenHeight());*/
 	mouseX = ev->motion.x;
 	mouseY = ev->motion.y;
+	// Genuine mouse movement (not a compatibility event trailing a real tap)
+	// means the player is on the mouse — show the software cursor.
+	if(ev->motion.which != SDL_TOUCH_MOUSEID && !recentRealTouch())
+		gInputIsMouse = true;
+	if(gSynthFingerDown && ev->motion.which != SDL_TOUCH_MOUSEID)
+		synthFingerFromMouse(SDL_FINGERMOTION, ev->motion.x, ev->motion.y);
 }
 
-static void EvHndl_MouseButtonDown(SDL_Event* ev) {}
-static void EvHndl_MouseButtonUp(SDL_Event* ev) {}
+static void EvHndl_MouseButtonDown(SDL_Event* ev) {
+	// Genuine mouse click → the player is on the mouse (show the cursor).
+	if(!recentRealTouch() && ev->button.which != SDL_TOUCH_MOUSEID)
+		gInputIsMouse = true;
+	// Only START a synthetic touch on a genuine mouse-down: skip a compatibility
+	// mouse-down that trails a real tap (recentRealTouch()).
+	if(!recentRealTouch()
+	   && ev->button.button == SDL_BUTTON_LEFT && ev->button.which != SDL_TOUCH_MOUSEID) {
+		gSynthFingerDown = true;
+		synthFingerFromMouse(SDL_FINGERDOWN, ev->button.x, ev->button.y);
+	}
+}
+static void EvHndl_MouseButtonUp(SDL_Event* ev) {
+	// Release only if we actually started a synthetic touch — this avoids a
+	// stray FINGERUP from a touch's compatibility mouse-up and guarantees a
+	// genuine mouse release always ends the press (no stuck finger).
+	if(gSynthFingerDown
+	   && ev->button.button == SDL_BUTTON_LEFT && ev->button.which != SDL_TOUCH_MOUSEID) {
+		gSynthFingerDown = false;
+		synthFingerFromMouse(SDL_FINGERUP, ev->button.x, ev->button.y);
+	}
+}
 
 // Two unrelated jobs on the same event:
 //  1) Gamepad activity on player 1's controller hides the touch UI.
@@ -390,6 +465,15 @@ static void EvHndl_Quit(SDL_Event*) {
 }
 
 static void EvHndl_FingerEvent(SDL_Event* ev) {
+	// A real touch event (any platform). Record it so:
+	//  - the "auto" TouchscreenControls mode knows a touchscreen is in use,
+	//  - the mouse-emulation path can ignore the compatibility mouse events
+	//    that trail a tap (recentRealTouch),
+	//  - the in-game cursor switches off.
+	// Synthetic touches from the mouse don't come through here.
+	gLastRealTouchTicks = SDL_GetTicks();
+	gInputIsMouse = false;
+	TouchControls::NotifyRealTouch();
 	TouchControls::HandleFingerEvent(ev->tfinger);
 }
 
@@ -592,7 +676,33 @@ void ProcessEvents()
 		HandleMouseState();
 #ifndef DEDICATED_ONLY
 		if(bJoystickSupport)  {
+#ifdef __EMSCRIPTEN__
+			// Browser build: feed the Gamepad API into SDL. A browser only
+			// exposes a pad to the page after its first button press, and the
+			// sampled gamepad state must be refreshed every frame or it goes
+			// stale (so detection silently stops). Re-sample here, before SDL
+			// polls — SDL then raises the very same SDL_CONTROLLERDEVICEADDED /
+			// *REMOVED events the desktop hotplug path uses, so the engine's
+			// existing controller handling (CInput::OnControllerAdded etc.)
+			// picks pads up with no browser-specific logic of its own.
+			emscripten_sample_gamepad_data();
+#endif
 			SDL_GameControllerUpdate();
+#ifdef __EMSCRIPTEN__
+			// Open a just-appeared pad THIS frame instead of waiting for the
+			// queued SDL_CONTROLLERDEVICEADDED event (which lands a frame or two
+			// later). A browser reveals a gamepad only in response to its first
+			// button press, so opening it immediately gives the best chance of
+			// reading that very press before it's released. OnControllerAdded
+			// skips pads it has already opened, so the later event is a no-op.
+			{
+				static int lastNumJoysticks = 0;
+				const int n = SDL_NumJoysticks();
+				for(int i = lastNumJoysticks; i < n; ++i)
+					CInput::OnControllerAdded(i);
+				lastNumJoysticks = n;
+			}
+#endif
 			updateAxisStates();
 		}
 #endif

--- a/src/client/TouchControls.cpp
+++ b/src/client/TouchControls.cpp
@@ -694,14 +694,16 @@ void Shutdown() {
 	gInited = false;
 }
 
-// Internal predicate — would touch be allowed if the player were using
-// it? Used by HandleFingerEvent so a finger-down can re-enable the UI
-// even when IsActive() is currently false because of auto-hide.
-// Resolve the tri-state Game.TouchscreenControls option to an effective
-// bool. "true"/"yes"/"on"/"1" → force on (use this on the Linux client
-// to capture layout previews). "false"/"no"/"off"/"0" → force off.
-// Anything else (including the default "auto") → platform default:
-// Android = on, everything else = off.
+// Set true the first time a real (non-synthetic) touch event arrives, so the
+// "auto" mode can decide based on whether a touchscreen is actually in use —
+// no per-platform assumptions. Set via NotifyRealTouch() from the input layer.
+static bool gHaveSeenRealTouch = false;
+
+// Resolve the tri-state Game.TouchscreenControls option to an effective bool:
+//   "true"/"yes"/"on"/"1"   → always on (the mouse can drive the controls too)
+//   "false"/"no"/"off"/"0"  → always off
+//   anything else ("auto")  → on only once real touch input has been seen.
+// Used by isTouchAllowed/HandleFingerEvent.
 static bool resolveTouchscreenEnabled(const std::string& setting) {
 	if(stringcaseequal(setting, "true")  || stringcaseequal(setting, "yes")
 	|| stringcaseequal(setting, "on")    || setting == "1")
@@ -709,11 +711,7 @@ static bool resolveTouchscreenEnabled(const std::string& setting) {
 	if(stringcaseequal(setting, "false") || stringcaseequal(setting, "no")
 	|| stringcaseequal(setting, "off")   || setting == "0")
 		return false;
-#ifdef __ANDROID__
-	return true;
-#else
-	return false;
-#endif
+	return gHaveSeenRealTouch; // "auto": purely input-driven, no platform checks
 }
 
 static bool isTouchAllowed() {
@@ -728,6 +726,13 @@ static bool isTouchAllowed() {
 
 bool IsActive() {
 	return isTouchAllowed() && gUIActive;
+}
+
+// Called from the input layer when a genuine (non-synthetic) touch event
+// arrives. Lets the "auto" TouchscreenControls mode enable itself once a
+// touchscreen is actually used, with no per-platform assumptions.
+void NotifyRealTouch() {
+	gHaveSeenRealTouch = true;
 }
 
 void NotifyExternalInput() {

--- a/src/common/Debug_DumpCallstack.cpp
+++ b/src/common/Debug_DumpCallstack.cpp
@@ -15,8 +15,8 @@
 #include <cstdlib>
 
 #ifndef HAVE_EXECINFO
-#	if defined(__ANDROID__)
-		// Bionic libc has no <execinfo.h> / backtrace().
+#	if defined(__ANDROID__) || defined(__EMSCRIPTEN__)
+		// Bionic libc / Emscripten musl have no <execinfo.h> / backtrace().
 #		define HAVE_EXECINFO 0
 #	elif defined(__linux__)
 #		define HAVE_EXECINFO 1

--- a/src/common/Debug_GetCallstack.cpp
+++ b/src/common/Debug_GetCallstack.cpp
@@ -52,8 +52,8 @@
 
 
 #ifndef HAVE_EXECINFO
-#	if defined(__ANDROID__)
-		// Bionic libc has no <execinfo.h> / backtrace().
+#	if defined(__ANDROID__) || defined(__EMSCRIPTEN__)
+		// Bionic libc / Emscripten musl have no <execinfo.h> / backtrace().
 #		define HAVE_EXECINFO 0
 #	elif defined(__linux__)
 #		define HAVE_EXECINFO 1

--- a/src/common/FindFile.cpp
+++ b/src/common/FindFile.cpp
@@ -487,6 +487,12 @@ void InitBaseSearchPaths() {
 	if (const char* external = SDL_AndroidGetExternalStoragePath()) {
 		AddToFileList(&basesearchpaths, std::string(external) + "/OpenLieroX");
 	}
+#elif defined(__EMSCRIPTEN__)
+	// The build script preloads share/gamedir at /gamedir on the
+	// virtual MEMFS, and we chdir to / in main(). Persistent user data
+	// is mounted on IDBFS at /home/web_user (Emscripten's musl HOME).
+	AddToFileList(&basesearchpaths, "/gamedir");
+	AddToFileList(&basesearchpaths, "${HOME}/.OpenLieroX");
 #elif defined(__APPLE__)
 	AddToFileList(&basesearchpaths, "${HOME}/Library/Application Support/OpenLieroX");
 	AddToFileList(&basesearchpaths, ".");

--- a/src/common/Networking.cpp
+++ b/src/common/Networking.cpp
@@ -295,11 +295,24 @@ bool InitNetworkSystem() {
     	return false;
     }
 
+#if defined(__EMSCRIPTEN__)
+    // Browsers can't open raw UDP sockets, so NL_IP fails immediately.
+    // HawkNL ships an in-process NL_LOOP_BACK driver that routes
+    // packets between sockets opened in the same process — perfect
+    // for local client+server gameplay, which is the only mode the
+    // wasm build supports.
+    if(!nlSelectNetwork(NL_LOOP_BACK)) {
+        SystemError("could not select loopback network");
+        nlSystemUseChangeLock.endWriteAccess();
+        return false;
+    }
+#else
     if(!nlSelectNetwork(NL_IP)) {
         SystemError("could not select IP-based network");
 		nlSystemUseChangeLock.endWriteAccess();
 		return false;
     }
+#endif
 
 	bNetworkInited = true;
 	

--- a/src/common/TeeStdoutHandler.cpp
+++ b/src/common/TeeStdoutHandler.cpp
@@ -13,7 +13,18 @@
 #include "Debug.h"
 #include "client/StdinCLISupport.h"
 
-#ifndef WIN32
+#if defined(__EMSCRIPTEN__)
+
+// On Emscripten, stdout already lands in the browser console via the
+// emcc runtime — we don't need a tee, and the fork/mmap/pipe machinery
+// the POSIX path uses isn't available. Provide stub entry points.
+
+const char* GetLogFilename() { return ""; }
+void teeStdoutInit() {}
+void teeStdoutFile(const std::string&) {}
+void teeStdoutQuit(bool) {}
+
+#elif !defined(WIN32)
 
 #include <sys/types.h>
 #include <sys/mman.h>

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -37,6 +37,9 @@
 #include "game/SinglePlayer.h"
 #include "game/SettingsPreset.h"
 #include "CGameScript.h"
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 #include "WeaponDesc.h"
 #include "ProfileSystem.h"
 #include "Attr.h"
@@ -270,6 +273,25 @@ static void stateUpdate_leaveNetState() {
 void Game::onStateUpdate(BaseObject* oPt, const AttrDesc* attrDesc, ScriptVar_t oldValue) {
 	assert(oPt == &game);
 	assert(attrDesc == game.state.attrDesc());
+
+#ifdef __EMSCRIPTEN__
+	// Tell the JS shell when the engine fully QUITS (transition into
+	// S_Quit), so it can drop browser fullscreen. We deliberately do NOT
+	// signal on a return to the menu after a match (active state ->
+	// S_Inactive): "Quit game" there usually means the player wants to
+	// start another match, so staying in fullscreen is the expected
+	// behaviour — only leaving the whole application exits fullscreen.
+	// PROXY_TO_PTHREAD puts main() on a worker; route through the main
+	// browser thread so `window` is reachable.
+	if(game.state == Game::S_Quit && (int)oldValue != Game::S_Quit) {
+		MAIN_THREAD_ASYNC_EM_ASM({
+			if (typeof window !== 'undefined' &&
+			    typeof window.olxOnEngineExit === 'function') {
+				window.olxOnEngineExit($0);
+			}
+		}, (int)game.state);
+	}
+#endif
 
 	if((int)oldValue >= Game::S_Preparing && game.state <= Game::S_Lobby)
 		game.cleanupAfterGameloopEnd();
@@ -757,13 +779,21 @@ void Game::frameInner()
 	// respond for >30secs and the user presses cSwitchMode in the meantime, the mainlock-detector
 	// would switch to window and here we would switch again to fullscreen which is stupid.
 	if( tLX->cSwitchMode.isUp() && tLX && tLX->fRealDeltaTime < 1.0f )  {
+#if defined(__EMSCRIPTEN__)
+		// Wasm fullscreen toggle is gated by the same master switch as
+		// the initial mode in AuxLib.cpp. Eat the keypress quietly so a
+		// stray Alt+Enter doesn't ruin a session while the feature is
+		// off.
+		tLX->cSwitchMode.reset();
+#else
 		// Set to fullscreen
 		tLXOptions->bFullscreen = !tLXOptions->bFullscreen;
-		
+
 		// Set the new video mode
 		doSetVideoModeInMainThread();
-		
+
 		tLX->cSwitchMode.reset();
+#endif
 	}
 	
 #ifdef WITH_G15

--- a/src/game/GameState.cpp
+++ b/src/game/GameState.cpp
@@ -368,7 +368,16 @@ void GameState::updateToCurrent() {
 }
 
 void GameState::addObject(ObjRef o) {
-	assert(!haveObject(o));
+	// The fresh GameState() registers &game and &gameSettings as
+	// singletons. After a first match, gameStateUpdates->objCreations
+	// can also contain those refs (or any other object whose pointer
+	// gets reused across game restarts), and updateToCurrent() then
+	// re-adds them on top of the singletons. The actual store
+	// (operator[] = ...) is fine with that — it just replaces — so
+	// drop the strict assertion that only fired on the harmless
+	// re-add path. Keeping the data write means the second match
+	// starts with a coherent state instead of aborting in
+	// VALIDATE_BUILD code paths.
 	objs[o] = ObjectState(o);
 }
 

--- a/src/gusanos/blitters/blitters.h
+++ b/src/gusanos/blitters/blitters.h
@@ -15,7 +15,7 @@
 // Android NDK's clang uses LLVM's integrated assembler, which rejects
 // the GAS-style MMX register macros in mmx.h. Force the non-SIMD path
 // on Android so the build does not depend on a separate `as`.
-#if !defined(WIN32) && !defined(__ANDROID__) && (SDL_BYTEORDER == SDL_LIL_ENDIAN) && (defined(__i386__) || defined(__x86_64__))
+#if !defined(WIN32) && !defined(__ANDROID__) && !defined(__EMSCRIPTEN__) && (SDL_BYTEORDER == SDL_LIL_ENDIAN) && (defined(__i386__) || defined(__x86_64__))
 #define HAS_MMX (cpu_capabilities & CPU_MMX)
 #define HAS_SSE (cpu_capabilities & CPU_SSE)
 #define HAS_MMXSSE (cpu_capabilities & CPU_MMXPLUS)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -206,7 +206,7 @@ int main(int argc, char *argv[]) {
 // Main entry point
 int real_main(int argc, char *argv[])
 {
-#ifndef __ANDROID__
+#if !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)
 	if(DoCrashReport(argc, argv)) return 0;
 #endif
 
@@ -226,6 +226,9 @@ int real_main(int argc, char *argv[])
 	hints << GetFullGameName() << " is starting ..." << endl;
 #ifdef DEBUG
 	hints << "This is a DEBUG build." << endl;
+#endif
+#ifdef OLX_GIT_HASH
+	hints << "Built from git hash: " << OLX_GIT_HASH << endl;
 #endif
 #ifdef DEDICATED_ONLY
 	hints << "This is a DEDICATED_ONLY build." << endl;
@@ -261,7 +264,7 @@ startpoint:
 
 	teeStdoutFile(GetWriteFullFileName("logs/OpenLieroX - " + GetDateTimeFilename() + ".txt", true));
 	activateStdinCLIHistory();
-#ifndef __ANDROID__
+#if !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)
 	CrashHandler::init();
 #endif
 
@@ -412,7 +415,7 @@ startpoint:
 	
 	notes << "Good Bye and enjoy your day..." << endl;
 
-#ifndef __ANDROID__
+#if !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)
 	// Uninit the crash handler after all other code
 	CrashHandler::uninit();
 #endif

--- a/src/server/CServer.cpp
+++ b/src/server/CServer.cpp
@@ -265,9 +265,18 @@ int GameServer::StartServer()
 }
 
 void GameServer::ObtainExternalIP()
-{	
+{
 	if (sExternalIP.size())
 		return;
+
+#if defined(__EMSCRIPTEN__)
+	// External IP is meaningless in the browser (no inbound socket to
+	// reach), and curl on Emscripten translates connect() into a
+	// WebSocket open against ws://www.openlierox.net which then fails
+	// noisily in the dev console. Skip the fetch for local games.
+	if (game.isLocalGame())
+		return;
+#endif
 
 	// TODO: use a config
 	tHttp2.RequestData("http://www.openlierox.net/external_ip.php", tLXOptions->sHttpProxy);


### PR DESCRIPTION
So you can run OpenLieroX in the browser. This would make OpenLieroX available on any platform where we don't have a native build such as Linux-arm, Linux-risc-v, FreeBSD or other less common platforms

It would also make it possible to try the game from the OpenLieroX website

This build can be tried out in the browser here:
https://openlierox.github.io/play-on-web/

<img width="1341" height="893" alt="Screenshot from 2026-05-05 20-39-02" src="https://github.com/user-attachments/assets/27d504d1-6e7a-4222-8a2c-262f513d1c92" />
