### PR TITLE
Add gamepad hotplugging support

### DIFF
--- a/include/CInput.h
+++ b/include/CInput.h
@@ -28,8 +28,7 @@
 #define		INP_NOTUSED			-1
 #define		INP_KEYBOARD		0
 #define		INP_MOUSE			1
-#define		INP_JOYSTICK1		2
-#define		INP_JOYSTICK2		3
+#define		INP_JOYSTICK		2
 
 
 // Joystick data
@@ -64,6 +63,7 @@ private:
 	int		Type; // keyboard, mouse or joystick
 	int		Data;
 	int		SdlIndex;
+	int		JoystickIndex; // 0-based pad index for INP_JOYSTICK
 	std::string m_EventName;
 	ModifiersState m_modifiers; // required modifier keys for keyboard bindings
 	bool	resetEachFrame;
@@ -95,7 +95,7 @@ public:
 	bool	isUsed() { return Type >= 0; }
 	int		getData() { return Data; }
 	int		getType() { return Type; }
-	bool	isJoystick() { return Type == INP_JOYSTICK1 || Type == INP_JOYSTICK2; }
+	bool	isJoystick() { return Type == INP_JOYSTICK; }
 	bool	isKeyboard() { return Type == INP_KEYBOARD; }
 	void	setResetEachFrame(bool r)	{ resetEachFrame = r; }
 	bool	getResetEachFrame()			{ return resetEachFrame; }

--- a/include/CInput.h
+++ b/include/CInput.h
@@ -84,6 +84,13 @@ public:
 	int		Setup(const std::string& text);
 	static void InitJoysticksTemp(); // call this if CInput::Wait shall recognise joystick events
 	static void UnInitJoysticksTemp();
+	// SDL_CONTROLLERDEVICEADDED / SDL_CONTROLLERDEVICEREMOVED hotplug
+	// handlers. Without these, controllers plugged in after startup
+	// (or surfaced late by the platform — e.g. browser Gamepad API
+	// only exposing pads after the user's first button press) are
+	// invisible to the engine.
+	static void OnControllerAdded(int deviceIndex);
+	static void OnControllerRemoved(int instanceId);
 	static int Wait(std::string& strText); // TODO: change this name. this function doesn't realy wait, it just checks the event-state
 	bool	isUsed() { return Type >= 0; }
 	int		getData() { return Data; }

--- a/src/client/AuxLib.cpp
+++ b/src/client/AuxLib.cpp
@@ -129,14 +129,12 @@ bool InitializeAuxLib()
 		return false;
 	}
 
-#ifndef DISABLE_JOYSTICK
 	if(bJoystickSupport) {
 		if(SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) != 0) {
 			warnings << "WARNING: couldn't init gamecontroller/joystick subystem: " << SDL_GetError() << endl;
 			bJoystickSupport = false;
 		}
 	}
-#endif
 
 	if(!bDedicated && !SetVideoMode())
 		return false;

--- a/src/client/CInput.cpp
+++ b/src/client/CInput.cpp
@@ -17,6 +17,7 @@
 // By Jason Boettcher
 
 #include <assert.h>
+#include <vector>
 
 
 #include "LieroX.h"
@@ -194,71 +195,65 @@ static const int JOY_DEADZONE = 8000;
 // Trigger threshold: triggers range 0..32767; fire at 75% travel
 static const int JOY_TRIGGER_THRESHOLD = 24576;
 
-// Binding table — maps config string to JOY_* flag and SDL constant (sdl_index).
+// Binding table — maps the per-pad suffix to JOY_* flag and SDL constant.
+// Config strings use the form "j<N>_<suffix>" where N is 1-based pad index
+// (e.g. "j1_button_south", "j5_lefty_up"). Pad count is unbounded; the N is
+// parsed at Setup() time and the suffix is matched against this table.
 // Text names use SDL's naming: SDL_GameControllerGetStringForButton/Axis
 // For axes:    sdl_index = SDL_GameControllerAxis
 // For buttons: sdl_index = SDL_GameControllerButton
 joystick_t Joysticks[] = {
-	{ "j1_lefty_up",      JOY_UP,             SDL_CONTROLLER_AXIS_LEFTY},
-	{ "j1_lefty_down",    JOY_DOWN,           SDL_CONTROLLER_AXIS_LEFTY},
-	{ "j1_leftx_left",    JOY_LEFT,           SDL_CONTROLLER_AXIS_LEFTX},
-	{ "j1_leftx_right",   JOY_RIGHT,          SDL_CONTROLLER_AXIS_LEFTX},
-	{ "j1_button_south",  JOY_BUTTON,         SDL_CONTROLLER_BUTTON_A},
-	{ "j1_button_east",   JOY_BUTTON,         SDL_CONTROLLER_BUTTON_B},
-	{ "j1_button_west",   JOY_BUTTON,         SDL_CONTROLLER_BUTTON_X},
-	{ "j1_button_north",  JOY_BUTTON,         SDL_CONTROLLER_BUTTON_Y},
-	{ "j1_back",          JOY_BUTTON,         SDL_CONTROLLER_BUTTON_BACK},
-	{ "j1_guide",         JOY_BUTTON,         SDL_CONTROLLER_BUTTON_GUIDE},
-	{ "j1_start",         JOY_BUTTON,         SDL_CONTROLLER_BUTTON_START},
-	{ "j1_leftstick",     JOY_BUTTON,         SDL_CONTROLLER_BUTTON_LEFTSTICK},
-	{ "j1_rightstick",    JOY_BUTTON,         SDL_CONTROLLER_BUTTON_RIGHTSTICK},
-	{ "j1_lshoulder",     JOY_BUTTON,         SDL_CONTROLLER_BUTTON_LEFTSHOULDER},
-	{ "j1_rshoulder",     JOY_BUTTON,         SDL_CONTROLLER_BUTTON_RIGHTSHOULDER},
-	{ "j1_rightx_left",   JOY_TURN_LEFT,      SDL_CONTROLLER_AXIS_RIGHTX},
-	{ "j1_rightx_right",  JOY_TURN_RIGHT,     SDL_CONTROLLER_AXIS_RIGHTX},
-	{ "j1_righty_up",     JOY_THROTTLE_LEFT,  SDL_CONTROLLER_AXIS_RIGHTY},
-	{ "j1_righty_down",   JOY_THROTTLE_RIGHT, SDL_CONTROLLER_AXIS_RIGHTY},
-	{ "j1_d_up",          JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_UP},
-	{ "j1_d_down",        JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_DOWN},
-	{ "j1_d_left",        JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_LEFT},
-	{ "j1_d_right",       JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_RIGHT},
-	{ "j1_triggerleft",   JOY_TRIGGER_LEFT,   SDL_CONTROLLER_AXIS_TRIGGERLEFT},
-	{ "j1_triggerright",  JOY_TRIGGER_RIGHT,  SDL_CONTROLLER_AXIS_TRIGGERRIGHT},
-	{ "j2_lefty_up",      JOY_UP,             SDL_CONTROLLER_AXIS_LEFTY},
-	{ "j2_lefty_down",    JOY_DOWN,           SDL_CONTROLLER_AXIS_LEFTY},
-	{ "j2_leftx_left",    JOY_LEFT,           SDL_CONTROLLER_AXIS_LEFTX},
-	{ "j2_leftx_right",   JOY_RIGHT,          SDL_CONTROLLER_AXIS_LEFTX},
-	{ "j2_button_south",  JOY_BUTTON,         SDL_CONTROLLER_BUTTON_A},
-	{ "j2_button_east",   JOY_BUTTON,         SDL_CONTROLLER_BUTTON_B},
-	{ "j2_button_west",   JOY_BUTTON,         SDL_CONTROLLER_BUTTON_X},
-	{ "j2_button_north",  JOY_BUTTON,         SDL_CONTROLLER_BUTTON_Y},
-	{ "j2_back",          JOY_BUTTON,         SDL_CONTROLLER_BUTTON_BACK},
-	{ "j2_guide",         JOY_BUTTON,         SDL_CONTROLLER_BUTTON_GUIDE},
-	{ "j2_start",         JOY_BUTTON,         SDL_CONTROLLER_BUTTON_START},
-	{ "j2_leftstick",     JOY_BUTTON,         SDL_CONTROLLER_BUTTON_LEFTSTICK},
-	{ "j2_rightstick",    JOY_BUTTON,         SDL_CONTROLLER_BUTTON_RIGHTSTICK},
-	{ "j2_lshoulder",     JOY_BUTTON,         SDL_CONTROLLER_BUTTON_LEFTSHOULDER},
-	{ "j2_rshoulder",     JOY_BUTTON,         SDL_CONTROLLER_BUTTON_RIGHTSHOULDER},
-	{ "j2_rightx_left",   JOY_TURN_LEFT,      SDL_CONTROLLER_AXIS_RIGHTX},
-	{ "j2_rightx_right",  JOY_TURN_RIGHT,     SDL_CONTROLLER_AXIS_RIGHTX},
-	{ "j2_righty_up",     JOY_THROTTLE_LEFT,  SDL_CONTROLLER_AXIS_RIGHTY},
-	{ "j2_righty_down",   JOY_THROTTLE_RIGHT, SDL_CONTROLLER_AXIS_RIGHTY},
-	{ "j2_d_up",          JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_UP},
-	{ "j2_d_down",        JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_DOWN},
-	{ "j2_d_left",        JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_LEFT},
-	{ "j2_d_right",       JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_RIGHT},
-	{ "j2_triggerleft",   JOY_TRIGGER_LEFT,   SDL_CONTROLLER_AXIS_TRIGGERLEFT},
-	{ "j2_triggerright",  JOY_TRIGGER_RIGHT,  SDL_CONTROLLER_AXIS_TRIGGERRIGHT},
+	{ "lefty_up",      JOY_UP,             SDL_CONTROLLER_AXIS_LEFTY},
+	{ "lefty_down",    JOY_DOWN,           SDL_CONTROLLER_AXIS_LEFTY},
+	{ "leftx_left",    JOY_LEFT,           SDL_CONTROLLER_AXIS_LEFTX},
+	{ "leftx_right",   JOY_RIGHT,          SDL_CONTROLLER_AXIS_LEFTX},
+	{ "button_south",  JOY_BUTTON,         SDL_CONTROLLER_BUTTON_A},
+	{ "button_east",   JOY_BUTTON,         SDL_CONTROLLER_BUTTON_B},
+	{ "button_west",   JOY_BUTTON,         SDL_CONTROLLER_BUTTON_X},
+	{ "button_north",  JOY_BUTTON,         SDL_CONTROLLER_BUTTON_Y},
+	{ "back",          JOY_BUTTON,         SDL_CONTROLLER_BUTTON_BACK},
+	{ "guide",         JOY_BUTTON,         SDL_CONTROLLER_BUTTON_GUIDE},
+	{ "start",         JOY_BUTTON,         SDL_CONTROLLER_BUTTON_START},
+	{ "leftstick",     JOY_BUTTON,         SDL_CONTROLLER_BUTTON_LEFTSTICK},
+	{ "rightstick",    JOY_BUTTON,         SDL_CONTROLLER_BUTTON_RIGHTSTICK},
+	{ "lshoulder",     JOY_BUTTON,         SDL_CONTROLLER_BUTTON_LEFTSHOULDER},
+	{ "rshoulder",     JOY_BUTTON,         SDL_CONTROLLER_BUTTON_RIGHTSHOULDER},
+	{ "rightx_left",   JOY_TURN_LEFT,      SDL_CONTROLLER_AXIS_RIGHTX},
+	{ "rightx_right",  JOY_TURN_RIGHT,     SDL_CONTROLLER_AXIS_RIGHTX},
+	{ "righty_up",     JOY_THROTTLE_LEFT,  SDL_CONTROLLER_AXIS_RIGHTY},
+	{ "righty_down",   JOY_THROTTLE_RIGHT, SDL_CONTROLLER_AXIS_RIGHTY},
+	{ "d_up",          JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_UP},
+	{ "d_down",        JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_DOWN},
+	{ "d_left",        JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_LEFT},
+	{ "d_right",       JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_RIGHT},
+	{ "triggerleft",   JOY_TRIGGER_LEFT,   SDL_CONTROLLER_AXIS_TRIGGERLEFT},
+	{ "triggerright",  JOY_TRIGGER_RIGHT,  SDL_CONTROLLER_AXIS_TRIGGERRIGHT},
 };
 
-static SDL_GameController* controllers[2] = {NULL, NULL};
+// Pad slots grow on demand; closed pads remain as NULL holes so existing
+// jN_* bindings keep referring to the same physical position.
+static std::vector<SDL_GameController*> controllers;
+static std::vector<bool> controllers_inited_temp;
+
+static SDL_GameController* getController(int idx) {
+	if(idx < 0 || (size_t)idx >= controllers.size()) return NULL;
+	return controllers[idx];
+}
+
+static void ensureControllerSlot(int idx) {
+	if(idx < 0) return;
+	if((size_t)idx >= controllers.size()) {
+		controllers.resize(idx + 1, NULL);
+		controllers_inited_temp.resize(idx + 1, false);
+	}
+}
 
 // Called each frame by the event loop — nothing to snapshot with the GameController API
 void updateAxisStates() {}
 
 static int getControllerValue(int flag, int sdl_index, int idx)
 {
-	SDL_GameController *gc = controllers[idx];
+	SDL_GameController *gc = getController(idx);
 	if(!gc) return 0;
 
 	switch(flag) {
@@ -285,7 +280,7 @@ static int getControllerValue(int flag, int sdl_index, int idx)
 static bool checkControllerState(int flag, int sdl_index, int idx)
 {
 	if(!bJoystickSupport) return false;
-	SDL_GameController *gc = controllers[idx];
+	SDL_GameController *gc = getController(idx);
 	if(!gc) return false;
 
 	switch(flag) {
@@ -311,11 +306,10 @@ static bool checkControllerState(int flag, int sdl_index, int idx)
 	return false;
 }
 
-static bool controllers_inited_temp[2] = {false, false};
-
 static void initController(int i, bool isTemp) {
-	assert(i == 0 || i == 1);
+	if(i < 0) return;
 	if(!bJoystickSupport) return;
+	ensureControllerSlot(i);
 	if(controllers[i] != NULL) return;
 	if(SDL_NumJoysticks() <= i) return;
 
@@ -347,13 +341,14 @@ static void initController(int i, bool isTemp) {
 
 void CInput::InitJoysticksTemp() {
 	if(!bJoystickSupport) return;
+	const int n = SDL_NumJoysticks();
 	notes << "Initing controllers temporary..." << endl;
-	notes << "Available joysticks: " << SDL_NumJoysticks() << endl;
-	initController(0, true);
-	initController(1, true);
+	notes << "Available joysticks: " << n << endl;
+	for(int i = 0; i < n; ++i) initController(i, true);
 }
 
 static void uninitTempController(int i) {
+	if(i < 0 || (size_t)i >= controllers.size()) return;
 	if(controllers_inited_temp[i]) {
 		notes << "Uninit temporary controller " << i << endl;
 		SDL_GameControllerClose(controllers[i]);
@@ -363,8 +358,7 @@ static void uninitTempController(int i) {
 }
 
 void CInput::UnInitJoysticksTemp() {
-	uninitTempController(0);
-	uninitTempController(1);
+	for(size_t i = 0; i < controllers.size(); ++i) uninitTempController((int)i);
 }
 
 void CInput::OnControllerAdded(int deviceIndex) {
@@ -376,43 +370,48 @@ void CInput::OnControllerAdded(int deviceIndex) {
 	// open the same physical pad and we'll bind it to two slots.
 	SDL_JoystickID newId = SDL_JoystickGetDeviceInstanceID(deviceIndex);
 	if(newId >= 0) {
-		for(int j = 0; j < 2; ++j) {
+		for(size_t j = 0; j < controllers.size(); ++j) {
 			if(!controllers[j]) continue;
 			SDL_Joystick* joy = SDL_GameControllerGetJoystick(controllers[j]);
 			if(joy && SDL_JoystickInstanceID(joy) == newId) return;
 		}
 	}
-	// Fill the first free slot. We only support up to two controllers.
-	for(int i = 0; i < 2; ++i) {
-		if(controllers[i] != NULL) continue;
-		const char* name = SDL_GameControllerNameForIndex(deviceIndex);
-		notes << "OnControllerAdded: opening device " << deviceIndex
-		      << " (\"" << (name ? name : "unknown") << "\") in slot " << i << endl;
-		if(!SDL_IsGameController(deviceIndex)) {
-			warnings << "  Device is not a recognised SDL GameController — skipping" << endl;
-			return;
-		}
-		controllers[i] = SDL_GameControllerOpen(deviceIndex);
-		if(!controllers[i]) {
-			warnings << "  Could not open game controller: " << SDL_GetError() << endl;
-			return;
-		}
-		SDL_Joystick* joy = SDL_GameControllerGetJoystick(controllers[i]);
-		notes << "  Axes: "    << SDL_JoystickNumAxes(joy)    << endl;
-		notes << "  Buttons: " << SDL_JoystickNumButtons(joy) << endl;
-		notes << "  Hats: "    << SDL_JoystickNumHats(joy)    << endl;
-		// Hot-plugged controllers persist past the menu's temp-init
-		// teardown — leave controllers_inited_temp[i] false.
-		SDL_GameControllerUpdate();
+	if(!SDL_IsGameController(deviceIndex)) {
+		warnings << "OnControllerAdded: device " << deviceIndex
+		         << " is not a recognised SDL GameController — skipping" << endl;
 		return;
 	}
-	notes << "OnControllerAdded: device " << deviceIndex
-	      << " ignored — both controller slots already in use" << endl;
+	// Fill the first free slot, or append a new one. Slots freed by
+	// OnControllerRemoved stay as NULL holes so existing bindings keep
+	// pointing at the same physical position.
+	int slot = -1;
+	for(size_t i = 0; i < controllers.size(); ++i) {
+		if(controllers[i] == NULL) { slot = (int)i; break; }
+	}
+	if(slot < 0) {
+		slot = (int)controllers.size();
+		ensureControllerSlot(slot);
+	}
+	const char* name = SDL_GameControllerNameForIndex(deviceIndex);
+	notes << "OnControllerAdded: opening device " << deviceIndex
+	      << " (\"" << (name ? name : "unknown") << "\") in slot " << slot << endl;
+	controllers[slot] = SDL_GameControllerOpen(deviceIndex);
+	if(!controllers[slot]) {
+		warnings << "  Could not open game controller: " << SDL_GetError() << endl;
+		return;
+	}
+	SDL_Joystick* joy = SDL_GameControllerGetJoystick(controllers[slot]);
+	notes << "  Axes: "    << SDL_JoystickNumAxes(joy)    << endl;
+	notes << "  Buttons: " << SDL_JoystickNumButtons(joy) << endl;
+	notes << "  Hats: "    << SDL_JoystickNumHats(joy)    << endl;
+	// Hot-plugged controllers persist past the menu's temp-init
+	// teardown — leave controllers_inited_temp[slot] false.
+	SDL_GameControllerUpdate();
 }
 
 void CInput::OnControllerRemoved(int instanceId) {
 	if(!bJoystickSupport) return;
-	for(int i = 0; i < 2; ++i) {
+	for(size_t i = 0; i < controllers.size(); ++i) {
 		if(!controllers[i]) continue;
 		SDL_Joystick* joy = SDL_GameControllerGetJoystick(controllers[i]);
 		if(!joy) continue;
@@ -437,6 +436,7 @@ CInput::CInput() {
 	Type = INP_NOTUSED;
 	Data = 0;
 	SdlIndex = 0;
+	JoystickIndex = 0;
 	resetEachFrame = true;
 	bDown = false;
 	reset();
@@ -524,14 +524,13 @@ int CInput::Wait(std::string& strText)
 	}
 
 #ifdef HAVE_JOYSTICK
-	// controller
-	// TODO: more controllers
-	for(uint n = 0; n < sizeof(Joysticks) / sizeof(joystick_t); n++) {
-		int i = Joysticks[n].text[1] - '1'; // at pos 1, there is the number ("j1_...")
-
-		if(controllers[i] != NULL && checkControllerState(Joysticks[n].value, Joysticks[n].sdl_index, i)) {
-			strText = Joysticks[n].text;
-			return true;
+	for(size_t idx = 0; idx < controllers.size(); ++idx) {
+		if(!controllers[idx]) continue;
+		for(uint n = 0; n < sizeof(Joysticks) / sizeof(joystick_t); n++) {
+			if(checkControllerState(Joysticks[n].value, Joysticks[n].sdl_index, (int)idx)) {
+				strText = "j" + itoa((int)idx + 1) + "_" + Joysticks[n].text;
+				return true;
+			}
 		}
 	}
 #endif
@@ -599,49 +598,31 @@ int CInput::Setup(const std::string& string)
 	}
 
 #ifdef HAVE_JOYSTICK
-	// Check if it's a joystick #1
-	// TODO: allow more joysticks
-	if(remaining.substr(0,3) == "j1_") {
-		Type = INP_JOYSTICK1;
-		Data = 0;
+	// Joystick binding: "j<N>_<suffix>" — N is the 1-based pad index, any N.
+	if(remaining.size() >= 3 && remaining[0] == 'j' && remaining[1] >= '1' && remaining[1] <= '9') {
+		size_t digitsEnd = 1;
+		while(digitsEnd < remaining.size() && remaining[digitsEnd] >= '0' && remaining[digitsEnd] <= '9')
+			++digitsEnd;
+		if(digitsEnd < remaining.size() && remaining[digitsEnd] == '_') {
+			int padNumber = atoi(remaining.substr(1, digitsEnd - 1).c_str());
+			int padIndex = padNumber - 1;
+			Type = INP_JOYSTICK;
+			JoystickIndex = padIndex;
+			Data = 0;
 
-		// Make sure there is a joystick present
-		if(SDL_NumJoysticks()<=0) {
-			SetError("Could not open joystick1");
-			return false;
-		}
+			// Pad not connected — leave the binding unusable (Data stays 0).
+			if(SDL_NumJoysticks() <= padIndex) return false;
 
-		// Open the controller if it hasn't been already opened
-		initController(0, false);
+			// Open the controller if it hasn't been already opened
+			initController(padIndex, false);
 
-		// Go through the joystick list
-		for(uint32_t n=0; n<sizeof(Joysticks) / sizeof(joystick_t); n++) {
-			if(strcasecmp(Joysticks[n].text, remaining.c_str()) == 0) {
-				Data = Joysticks[n].value;
-				SdlIndex = Joysticks[n].sdl_index;
-				return true;
-			}
-		}
-	}
-
-	// Check if it's a joystick #2
-	if(remaining.substr(0,3) == "j2_") {
-		Type = INP_JOYSTICK2;
-		Data = 0;
-
-		// Make sure there is a joystick present
-		if(SDL_NumJoysticks()<=1)
-			return false;
-
-		// Open the controller if it hasn't been already opened
-		initController(1, false);
-
-		// Go through the joystick list
-		for(uint32_t n=0; n < sizeof(Joysticks) / sizeof(joystick_t); n++) {
-			if(strcasecmp(Joysticks[n].text, remaining.c_str()) == 0) {
-				Data = Joysticks[n].value;
-				SdlIndex = Joysticks[n].sdl_index;
-				return true;
+			std::string suffix = remaining.substr(digitsEnd + 1);
+			for(uint32_t n=0; n<sizeof(Joysticks) / sizeof(joystick_t); n++) {
+				if(strcasecmp(Joysticks[n].text, suffix.c_str()) == 0) {
+					Data = Joysticks[n].value;
+					SdlIndex = Joysticks[n].sdl_index;
+					return true;
+				}
 			}
 		}
 	}
@@ -668,14 +649,8 @@ int CInput::Setup(const std::string& string)
 int CInput::getJoystickValue()
 {
 #ifdef HAVE_JOYSTICK
-	switch (Type)  {
-	case INP_JOYSTICK1:
-		return getControllerValue(Data, SdlIndex, 0);
-	case INP_JOYSTICK2:
-		return getControllerValue(Data, SdlIndex, 1);
-	default:
-		return 0;
-	}
+	if(Type == INP_JOYSTICK)
+		return getControllerValue(Data, SdlIndex, JoystickIndex);
 #endif
 	return 0;
 }
@@ -686,7 +661,7 @@ int CInput::getJoystickValue()
 bool CInput::isJoystickThrottle()
 {
 #ifdef HAVE_JOYSTICK
-	if (Type == INP_JOYSTICK1 || Type == INP_JOYSTICK2)
+	if (Type == INP_JOYSTICK)
 		return (Data == JOY_THROTTLE_LEFT) || (Data == JOY_THROTTLE_RIGHT);
 #endif
 	return false;
@@ -714,8 +689,7 @@ bool CInput::isUp()
 
 #ifdef HAVE_JOYSTICK
 		// Joystick
-		case INP_JOYSTICK1:
-		case INP_JOYSTICK2:
+		case INP_JOYSTICK:
 			return nUp > 0;
 #endif
 	}
@@ -743,10 +717,8 @@ bool CInput::isDown() const
 
 #ifdef HAVE_JOYSTICK
 		// Joystick
-		case INP_JOYSTICK1:
-			return checkControllerState(Data, SdlIndex, 0);
-		case INP_JOYSTICK2:
-			return checkControllerState(Data, SdlIndex, 1);
+		case INP_JOYSTICK:
+			return checkControllerState(Data, SdlIndex, JoystickIndex);
 #endif
 	}
 
@@ -780,8 +752,7 @@ int CInput::wasDown() const {
 		break;
 
 #ifdef HAVE_JOYSTICK
-	case INP_JOYSTICK1:
-	case INP_JOYSTICK2:
+	case INP_JOYSTICK:
 		counter = nDownOnce; // no other way at the moment
 		break;
 #endif
@@ -805,8 +776,7 @@ int CInput::wasUp() {
 		break;
 
 #ifdef HAVE_JOYSTICK
-	case INP_JOYSTICK1:
-	case INP_JOYSTICK2:
+	case INP_JOYSTICK:
 		counter = 0; // no other way at the moment
 		break;
 #endif

--- a/src/client/CInput.cpp
+++ b/src/client/CInput.cpp
@@ -182,6 +182,8 @@ int keys_t::keySymFromName(const std::string & name)
 void updateAxisStates() {}
 void CInput::InitJoysticksTemp() {}
 void CInput::UnInitJoysticksTemp() {}
+void CInput::OnControllerAdded(int) {}
+void CInput::OnControllerRemoved(int) {}
 
 #else
 
@@ -363,6 +365,65 @@ static void uninitTempController(int i) {
 void CInput::UnInitJoysticksTemp() {
 	uninitTempController(0);
 	uninitTempController(1);
+}
+
+void CInput::OnControllerAdded(int deviceIndex) {
+	if(!bJoystickSupport) return;
+	// SDL fires SDL_CONTROLLERDEVICEADDED for every controller present
+	// during SDL_INIT_GAMECONTROLLER (not only true hot-plug events).
+	// Skip if this device is already open in some slot — otherwise the
+	// boot-time scan in InitJoysticksTemp() and this handler will both
+	// open the same physical pad and we'll bind it to two slots.
+	SDL_JoystickID newId = SDL_JoystickGetDeviceInstanceID(deviceIndex);
+	if(newId >= 0) {
+		for(int j = 0; j < 2; ++j) {
+			if(!controllers[j]) continue;
+			SDL_Joystick* joy = SDL_GameControllerGetJoystick(controllers[j]);
+			if(joy && SDL_JoystickInstanceID(joy) == newId) return;
+		}
+	}
+	// Fill the first free slot. We only support up to two controllers.
+	for(int i = 0; i < 2; ++i) {
+		if(controllers[i] != NULL) continue;
+		const char* name = SDL_GameControllerNameForIndex(deviceIndex);
+		notes << "OnControllerAdded: opening device " << deviceIndex
+		      << " (\"" << (name ? name : "unknown") << "\") in slot " << i << endl;
+		if(!SDL_IsGameController(deviceIndex)) {
+			warnings << "  Device is not a recognised SDL GameController — skipping" << endl;
+			return;
+		}
+		controllers[i] = SDL_GameControllerOpen(deviceIndex);
+		if(!controllers[i]) {
+			warnings << "  Could not open game controller: " << SDL_GetError() << endl;
+			return;
+		}
+		SDL_Joystick* joy = SDL_GameControllerGetJoystick(controllers[i]);
+		notes << "  Axes: "    << SDL_JoystickNumAxes(joy)    << endl;
+		notes << "  Buttons: " << SDL_JoystickNumButtons(joy) << endl;
+		notes << "  Hats: "    << SDL_JoystickNumHats(joy)    << endl;
+		// Hot-plugged controllers persist past the menu's temp-init
+		// teardown — leave controllers_inited_temp[i] false.
+		SDL_GameControllerUpdate();
+		return;
+	}
+	notes << "OnControllerAdded: device " << deviceIndex
+	      << " ignored — both controller slots already in use" << endl;
+}
+
+void CInput::OnControllerRemoved(int instanceId) {
+	if(!bJoystickSupport) return;
+	for(int i = 0; i < 2; ++i) {
+		if(!controllers[i]) continue;
+		SDL_Joystick* joy = SDL_GameControllerGetJoystick(controllers[i]);
+		if(!joy) continue;
+		if(SDL_JoystickInstanceID(joy) != (SDL_JoystickID)instanceId) continue;
+		notes << "OnControllerRemoved: closing slot " << i
+		      << " (instance " << instanceId << ")" << endl;
+		SDL_GameControllerClose(controllers[i]);
+		controllers[i] = NULL;
+		controllers_inited_temp[i] = false;
+		return;
+	}
 }
 
 #endif // !DEDICATED_ONLY

--- a/src/client/CInput.cpp
+++ b/src/client/CInput.cpp
@@ -177,7 +177,7 @@ int keys_t::keySymFromName(const std::string & name)
 
 	
 	
-#if defined(DEDICATED_ONLY) || defined(DISABLE_JOYSTICK)
+#ifdef DEDICATED_ONLY
 
 void updateAxisStates() {}
 void CInput::InitJoysticksTemp() {}

--- a/src/client/InputEvents.cpp
+++ b/src/client/InputEvents.cpp
@@ -405,6 +405,18 @@ static void EvHndl_UserEvent(SDL_Event* ev) {
 	}
 }
 
+#ifndef DISABLE_JOYSTICK
+static void EvHndl_ControllerDeviceAdded(SDL_Event* ev) {
+	// ev->cdevice.which is the device index here (per SDL2 docs).
+	CInput::OnControllerAdded(ev->cdevice.which);
+}
+
+static void EvHndl_ControllerDeviceRemoved(SDL_Event* ev) {
+	// ev->cdevice.which is the joystick instance id here.
+	CInput::OnControllerRemoved(ev->cdevice.which);
+}
+#endif
+
 void InitEventSystem() {	
 	Mouse.Button = 0;
 	Mouse.Down = 0;
@@ -421,6 +433,10 @@ void InitEventSystem() {
 	sdlEvents[SDL_MOUSEWHEEL].handler() = getEventHandler(&EvHndl_MouseWheel);
 	sdlEvents[SDL_QUIT].handler() = getEventHandler(&EvHndl_Quit);
 	sdlEvents[SDL_USEREVENT].handler() = getEventHandler(&EvHndl_UserEvent);
+#ifndef DISABLE_JOYSTICK
+	sdlEvents[SDL_CONTROLLERDEVICEADDED  ].handler() = getEventHandler(&EvHndl_ControllerDeviceAdded);
+	sdlEvents[SDL_CONTROLLERDEVICEREMOVED].handler() = getEventHandler(&EvHndl_ControllerDeviceRemoved);
+#endif
 	// Note: SDL_SYSWMEVENT is handled directly on the main thread by handleSDLEvents().
 	
 	bEventSystemInited = true;

--- a/src/client/InputEvents.cpp
+++ b/src/client/InputEvents.cpp
@@ -405,7 +405,6 @@ static void EvHndl_UserEvent(SDL_Event* ev) {
 	}
 }
 
-#ifndef DISABLE_JOYSTICK
 static void EvHndl_ControllerDeviceAdded(SDL_Event* ev) {
 	// ev->cdevice.which is the device index here (per SDL2 docs).
 	CInput::OnControllerAdded(ev->cdevice.which);
@@ -415,7 +414,6 @@ static void EvHndl_ControllerDeviceRemoved(SDL_Event* ev) {
 	// ev->cdevice.which is the joystick instance id here.
 	CInput::OnControllerRemoved(ev->cdevice.which);
 }
-#endif
 
 void InitEventSystem() {	
 	Mouse.Button = 0;
@@ -433,10 +431,8 @@ void InitEventSystem() {
 	sdlEvents[SDL_MOUSEWHEEL].handler() = getEventHandler(&EvHndl_MouseWheel);
 	sdlEvents[SDL_QUIT].handler() = getEventHandler(&EvHndl_Quit);
 	sdlEvents[SDL_USEREVENT].handler() = getEventHandler(&EvHndl_UserEvent);
-#ifndef DISABLE_JOYSTICK
 	sdlEvents[SDL_CONTROLLERDEVICEADDED  ].handler() = getEventHandler(&EvHndl_ControllerDeviceAdded);
 	sdlEvents[SDL_CONTROLLERDEVICEREMOVED].handler() = getEventHandler(&EvHndl_ControllerDeviceRemoved);
-#endif
 	// Note: SDL_SYSWMEVENT is handled directly on the main thread by handleSDLEvents().
 	
 	bEventSystemInited = true;
@@ -591,12 +587,10 @@ void ProcessEvents()
 
 		HandleMouseState();
 #ifndef DEDICATED_ONLY
-#ifndef DISABLE_JOYSTICK
 		if(bJoystickSupport)  {
 			SDL_GameControllerUpdate();
 			updateAxisStates();
 		}
-#endif
 #endif
 		HandleCInputs_UpdateUpForNonKeyboard();
 		HandleCInputs_UpdateDownOnceForNonKeyboard();

--- a/src/common/MainGlobals.cpp
+++ b/src/common/MainGlobals.cpp
@@ -20,11 +20,7 @@ bool		bDedicated = true;
 bool		bJoystickSupport = false;
 #else //DEDICATED_ONLY
 bool		bDedicated = false;
-#ifdef DISABLE_JOYSTICK
-bool		bJoystickSupport = false;
-#else
 bool		bJoystickSupport = true;
-#endif
 #endif //DEDICATED_ONLY
 bool		bRestartGameAfterQuit = false;
 TStartFunction startFunction = NULL;


### PR DESCRIPTION
### Before this PR: 
All gamepads had to be connected BEFORE the game was started, and nothing about the gamepads could be added or removed while the game was running

### What this PR does:

This makes it possible to plug in controllers after the game has already started

Controllers can also be disconnected while the game is running, which is common for battery powered wireless gamepads when they run out of battery or the connection is weak. When this happen, they can now be reconnected while the game is running, without restarting the game

