### PR TITLE
Auto update server list

### DIFF
--- a/build/android/app/src/main/jni/CMakeLists.txt
+++ b/build/android/app/src/main/jni/CMakeLists.txt
@@ -214,7 +214,28 @@ add_subdirectory("${DEPS_DIR}/libgd"        "${CMAKE_BINARY_DIR}/libgd")
 unset(BUILD_SHARED_LIBS CACHE)
 
 # ---------------------------------------------------------------------
-# libcurl (HTTP only — no SSL/HTTPS for now)
+# mbedTLS — provides the HTTPS backend for libcurl below. Android has no
+# usable system curl, and curl's other TLS backends (OpenSSL, Schannel,
+# Secure Transport) aren't available here, so we link a small static
+# mbedTLS into the curl build.
+# ---------------------------------------------------------------------
+set(ENABLE_PROGRAMS OFF CACHE BOOL "")
+set(ENABLE_TESTING OFF CACHE BOOL "")
+set(USE_STATIC_MBEDTLS_LIBRARY ON CACHE BOOL "")
+set(USE_SHARED_MBEDTLS_LIBRARY OFF CACHE BOOL "")
+set(MBEDTLS_FATAL_WARNINGS OFF CACHE BOOL "")
+add_subdirectory("${DEPS_DIR}/mbedtls"      "${CMAKE_BINARY_DIR}/mbedtls")
+
+# Pre-fill the variables curl's FindMbedTLS.cmake looks up so it picks up
+# the in-tree subproject above instead of searching the NDK sysroot. The
+# library names resolve to the add_subdirectory targets at link time.
+set(MBEDTLS_INCLUDE_DIRS "${DEPS_DIR}/mbedtls/include" CACHE PATH    "" FORCE)
+set(MBEDTLS_LIBRARY      mbedtls            CACHE FILEPATH "" FORCE)
+set(MBEDX509_LIBRARY     mbedx509           CACHE FILEPATH "" FORCE)
+set(MBEDCRYPTO_LIBRARY   mbedcrypto         CACHE FILEPATH "" FORCE)
+
+# ---------------------------------------------------------------------
+# libcurl — HTTP + HTTPS via mbedTLS.
 # ---------------------------------------------------------------------
 set(BUILD_CURL_EXE OFF CACHE BOOL "")
 set(BUILD_LIBCURL_DOCS OFF CACHE BOOL "")
@@ -226,7 +247,13 @@ set(CURL_USE_LIBPSL OFF CACHE BOOL "")
 set(CURL_USE_LIBSSH2 OFF CACHE BOOL "")
 set(CURL_USE_OPENSSL OFF CACHE BOOL "")
 set(CURL_USE_GSSAPI OFF CACHE BOOL "")
-set(CURL_USE_MBEDTLS OFF CACHE BOOL "")
+set(CURL_USE_MBEDTLS ON CACHE BOOL "")
+# We embed libcurl as a subproject and never install it. Skipping the
+# CMake export target avoids "export() / install(EXPORT CURLTargets ...)
+# requires target mbedtls that is not in any export set" - mbedTLS'
+# subproject targets aren't in any export set, and we have no use for
+# the exported curl targets anyway.
+set(CURL_ENABLE_EXPORT_TARGET OFF CACHE BOOL "")
 set(CURL_DISABLE_LDAP ON CACHE BOOL "")
 set(CURL_DISABLE_LDAPS ON CACHE BOOL "")
 set(CURL_DISABLE_PROXY OFF CACHE BOOL "")

--- a/build/android/build-android.sh
+++ b/build/android/build-android.sh
@@ -95,6 +95,18 @@ if [ "$SKIP_DATA" -eq 0 ]; then
     rm -rf "$ANDROID_DIR/output/assets/gamedir"
     mkdir -p "$ANDROID_DIR/output/assets"
     cp -a "$OLX_ROOT/share/gamedir" "$ANDROID_DIR/output/assets/gamedir"
+    # Ship Mozilla's CA bundle next to the gamedir so libcurl's mbedTLS
+    # backend can verify HTTPS certificates (Android exposes no cert file
+    # in a format curl/mbedTLS can read). Fail loudly rather than silently
+    # producing an APK whose every https:// request rejects the peer.
+    if [ ! -f "$ANDROID_DIR/deps/cacert.pem" ]; then
+        echo "ERROR: $ANDROID_DIR/deps/cacert.pem is missing." >&2
+        echo "       HTTPS in the APK depends on it. Run" >&2
+        echo "       build/android/fetch-dependencies.sh (without --skip-fetch)" >&2
+        echo "       to download it from curl.se." >&2
+        exit 1
+    fi
+    cp "$ANDROID_DIR/deps/cacert.pem" "$ANDROID_DIR/output/assets/gamedir/cacert.pem"
     # Drop a marker so the runtime can check that the data was extracted.
     echo "$(cat "$OLX_ROOT/VERSION" 2>/dev/null || echo unknown)" \
         > "$ANDROID_DIR/output/assets/gamedir.version"

--- a/build/android/fetch-dependencies.sh
+++ b/build/android/fetch-dependencies.sh
@@ -27,6 +27,7 @@ DEPS=(
     "libvorbis|https://github.com/xiph/vorbis.git|v1.3.7"
     "openal-soft|https://github.com/kcat/openal-soft.git|1.23.1"
     "freealut|https://github.com/vancegroup/freealut.git|freealut_1_1_0"
+    "mbedtls|https://github.com/Mbed-TLS/mbedtls.git|mbedtls-3.6.2"
     "curl|https://github.com/curl/curl.git|curl-8_10_1"
 )
 
@@ -135,6 +136,21 @@ if [ ! -e boost-hdr/boost ]; then
     else
         echo "WARNING: /usr/include/boost not found. Install libboost-dev or set up boost-hdr/boost manually." >&2
     fi
+fi
+
+# Mozilla CA certificate bundle for libcurl's mbedTLS backend on Android.
+# (Linux/macOS use the OS cert store, Windows uses CURLSSLOPT_NATIVE_CA.)
+# Pinned to a dated release and verified against an in-tree sha256 so a
+# compromised endpoint can't swap the bundle without a visible code change.
+# To update: pick a newer dated URL from https://curl.se/docs/caextract.html
+# and replace the sha256 below (one is published next to each release).
+CACERT_URL="https://curl.se/ca/cacert-2026-05-14.pem"
+CACERT_SHA256="86a1f3366afac7c6f8ae9f3c779ac221129328c43f0ab2b8817eb2f362a5025c"
+if [ ! -f cacert.pem ] || ! echo "$CACERT_SHA256  cacert.pem" | sha256sum -c --status -; then
+    echo "Downloading $(basename "$CACERT_URL")"
+    curl -fsSL -o cacert.pem.tmp "$CACERT_URL"
+    echo "$CACERT_SHA256  cacert.pem.tmp" | sha256sum -c --status -
+    mv cacert.pem.tmp cacert.pem
 fi
 
 echo "All dependencies are in place under $DEPS_DIR"

--- a/include/HTTP.h
+++ b/include/HTTP.h
@@ -146,6 +146,7 @@ public:
 	void				CancelProcessing();
 	void				ClearReceivedData()			{ Mutex::ScopedLock l(const_cast<Mutex &>(Lock)); Data = ""; }
 	HttpError			GetError() const			{ Mutex::ScopedLock l(const_cast<Mutex &>(Lock)); return Error; }
+	long				GetHTTPStatusCode() const	{ Mutex::ScopedLock l(const_cast<Mutex &>(Lock)); return HTTPStatusCode; }
 	const std::string&	GetData() const				{ Mutex::ScopedLock l(const_cast<Mutex &>(Lock)); return curlThread != NULL ? Empty : Data; }
 	std::string			GetMimeType() const;
 	//const std::string&	GetDataToSend() const		{ Mutex::ScopedLock l(Lock); return DataToSend; }
@@ -182,6 +183,7 @@ private:
 
 	HttpProc_t		ProcessingResult;
 	HttpError		Error;
+	long			HTTPStatusCode;	// HTTP status code of the (final) response, 0 if unavailable
 
 	std::string		Empty; // Returned when Data is being processed
 

--- a/src/client/DeprecatedGUI/Menu_Main.cpp
+++ b/src/client/DeprecatedGUI/Menu_Main.cpp
@@ -31,6 +31,7 @@
 #include "DeprecatedGUI/CBrowser.h"
 #include "DeprecatedGUI/CTextButton.h"
 #include "sound/SoundsBase.h"
+#include "game/ServerList.h"
 
 
 namespace DeprecatedGUI {
@@ -146,6 +147,9 @@ void Menu_MainFrame()
                 if( ev->iEventMsg == TBT_CLICKED ) {
 					PlaySoundSample(sfxGeneral.smpClick);
 				    Menu_MainShutdown();
+				    // Refresh the master server lists in the background so the
+				    // server list shown in the Internet menu is up to date.
+				    DownloadMasterServerListFiles();
 				    Menu_NetInitialize();
 				    return;
                 }

--- a/src/common/HTTP.cpp
+++ b/src/common/HTTP.cpp
@@ -29,6 +29,7 @@
 
 #include "LieroX.h"
 #include "Debug.h"
+#include "FindFile.h"
 #include "Options.h"
 #include "HTTP.h"
 #include "Timer.h"
@@ -180,6 +181,7 @@ struct CurlThread : Action {
 CHttp::CHttp()
 {
 	ProcessingResult = HTTP_PROC_FINISHED;
+	HTTPStatusCode = 0;
 	DownloadStart = DownloadEnd = 0;
 	curlThread = NULL;
 }
@@ -225,6 +227,7 @@ CURL * CHttp::InitializeTransfer(const std::string& url, const std::string& prox
 	Proxy = proxy;
 	Useragent = GetFullGameName();
 	Data = "";
+	HTTPStatusCode = 0;
 	DownloadStart = DownloadEnd = tLX->currentTime;
 
 	CURL * curl = curl_easy_init();
@@ -235,6 +238,22 @@ CURL * CHttp::InitializeTransfer(const std::string& url, const std::string& prox
 	curl_easy_setopt( curl, CURLOPT_CONNECTTIMEOUT, (long) HTTP_TIMEOUT );
 	curl_easy_setopt( curl, CURLOPT_FOLLOWLOCATION, (long) 1 ); // Allow server to use 3XX Redirect codes
 	curl_easy_setopt( curl, CURLOPT_MAXREDIRS, (long) 25 ); // Some reasonable limit
+#ifdef CURLSSLOPT_NATIVE_CA
+	// Verify HTTPS certificates against the OS certificate store. Without this,
+	// the OpenSSL build of libcurl looks for a CA bundle file that is not
+	// shipped with the packaged Windows build, so every https:// request fails.
+	curl_easy_setopt( curl, CURLOPT_SSL_OPTIONS, (long) CURLSSLOPT_NATIVE_CA );
+#endif
+	// If a CA bundle is shipped with the game (e.g. the Android APK ships
+	// Mozilla's cacert.pem for libcurl's mbedTLS backend, which has no
+	// system cert store to fall back to), point curl at it. Returns "" on
+	// platforms where no bundle is shipped, in which case we leave the
+	// default verification path in place.
+	{
+		static const std::string caBundle = GetFullFileName("cacert.pem");
+		if(!caBundle.empty())
+			curl_easy_setopt( curl, CURLOPT_CAINFO, caBundle.c_str() );
+	}
 	//curl_easy_setopt( curl, CURLOPT_TIMEOUT, (long) HTTP_TIMEOUT ); // Do not set this if you don't want abort in the middle of large transfer
 	return curl;
 }
@@ -299,7 +318,10 @@ Result CurlThread::handle()
 			parent->Error.sErrorMsg = curl_easy_strerror(res);
 		}
 		parent->DownloadEnd = tLX->currentTime;
-		
+
+		// Remember the HTTP status code so callers can reject error responses.
+		curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &parent->HTTPStatusCode);
+
 		if( curlForm != NULL )
 			curl_formfree(curlForm);
 		curlForm = NULL;

--- a/src/game/ServerList.cpp
+++ b/src/game/ServerList.cpp
@@ -9,6 +9,7 @@
 
 #include "ServerList.h"
 #include "TaskManager.h"
+#include "HTTP.h"
 #include "CBytestream.h"
 #include "Consts.h"
 #include "DeprecatedGUI/Menu.h"
@@ -1143,10 +1144,19 @@ static std::list<std::string> getUdpMasterServerList() {
 
 
 struct UdpUpdater : Task {
+	std::string m_statusTxt;
 	ServerList *m_list;
 
 	UdpUpdater(ServerList *l) : m_list(l) { name = "udp serverlist updater"; }
 	Result handle() { return SvrList_UpdaterFunc(); }
+	std::string statusText() {
+		Mutex::ScopedLock lock(*mutex);
+		return m_statusTxt;
+	}
+	void setStatusText(const std::string& t) {
+		Mutex::ScopedLock lock(*mutex);
+		m_statusTxt = t;
+	}
 	Result SvrList_UpdaterFunc();
 };
 
@@ -1165,6 +1175,9 @@ Result UdpUpdater::SvrList_UpdaterFunc()
 	for (std::list<std::string>::iterator it = tUdpMasterServers.begin(); it != tUdpMasterServers.end(); ++it, ++UdpServerIndex)  
 	{
 		std::string& server = *it;
+		// Show the name exactly as written in udpmasterservers.txt (before the
+		// default port gets appended below), so the status is easy to debug.
+		setStatusText("Querying server " + server + " (" + itoa(UdpServerIndex + 1) + "/" + itoa((int)tUdpMasterServers.size()) + ")");
 		NetworkAddr addr;
 		if (server.find(':') == std::string::npos)
 			server += ":23450";  // Default port
@@ -1407,10 +1420,6 @@ void ServerListUpdater::updateServerList() {
 	CHttp http;
 	
 	while(true) {
-		if( SvrCount > 0 ) {
-			setStatusText("Updating server list: " + itoa(CurServer + 1) + "/" + itoa(SvrCount));
-		}
-		
 		// Do the HTTP requests of the master servers
 		if( !SentRequest ) {
 			
@@ -1424,9 +1433,11 @@ void ServerListUpdater::updateServerList() {
 				TrimSpaces(szLine);
 				
 				if( szLine.length() > 0 && szLine[0] != '#' ) {
-					
+
 					// Send the request
 					//notes << "Getting serverlist from " + szLine + "..." << endl;
+					// Show the master server name exactly as in masterservers.txt.
+					setStatusText("Querying server " + szLine + " (" + itoa(CurServer + 1) + "/" + itoa(SvrCount) + ")");
 					http.RequestData(szLine + LX_SVRLIST, tLXOptions->sHttpProxy);
 					SentRequest = true;
 					
@@ -1466,6 +1477,115 @@ void ServerListUpdater::updateServerList() {
 void ServerList::updateList() {
 	taskManager->start(new ServerListUpdater(this), TaskManager::QT_QueueToSameTypeAndBreakCurrent);
 }
+
+
+/*************************
+ *
+ * Master server list files auto-update
+ *
+ * The lists of master servers themselves (cfg/masterservers.txt and
+ * cfg/udpmasterservers.txt) are kept up to date by downloading the latest
+ * versions from the OpenLieroX serverlist repository.
+ *
+ ************************/
+
+struct MasterServerListFile {
+	const char* url;
+	const char* localFile;
+};
+
+static const MasterServerListFile masterServerListFiles[] = {
+	{ "https://openlierox.github.io/serverlist/masterservers.txt", "cfg/masterservers.txt" },
+	{ "https://openlierox.github.io/serverlist/udpmasterservers.txt", "cfg/udpmasterservers.txt" },
+};
+
+struct MasterServerListUpdater : Task {
+	MasterServerListUpdater() { name = "masterserver list files updater"; }
+	Result handle();
+	// Shown in the menu status bar while the master server files download, before
+	// ServerListUpdater takes over with its own "Updating server list" status.
+	std::string statusText() { return "Updating server list..."; }
+	void updateFile(const MasterServerListFile& f);
+};
+
+void MasterServerListUpdater::updateFile(const MasterServerListFile& f)
+{
+	// Show the full destination path so it's clear where the downloaded file ends up.
+	notes << "Updating " << f.url << " to:\n" << GetWriteFullFileName(f.localFile) << endl;
+
+	CHttp http;
+	http.RequestData(f.url, tLXOptions->sHttpProxy);
+
+	const AbsTime startTime = GetTime();
+	HttpProc_t result = HTTP_PROC_PROCESSING;
+	while(result == HTTP_PROC_PROCESSING) {
+		if(breakSignal) {
+			http.CancelProcessing();
+			return;
+		}
+		if(GetTime() - startTime > 30.0f) {
+			// Bound the wait so a stalled connection can't hang the task
+			// (and block the next file) without leaving a trace.
+			http.CancelProcessing();
+			warnings << "Could not update " << f.localFile << ": download timed out" << endl;
+			return;
+		}
+		SDL_Delay(20);
+		result = http.ProcessRequest();
+	}
+
+	if(result == HTTP_PROC_ERROR) {
+		warnings << "Could not update " << f.localFile << ": " << http.GetError().sErrorMsg << endl;
+		return;
+	}
+
+	// Only accept a successful (2xx) HTTP response, so an error page (e.g. a
+	// "404 Not Found" body) never overwrites a working file.
+	const long status = http.GetHTTPStatusCode();
+	if(status < 200 || status >= 300) {
+		warnings << "Could not update " << f.localFile << ": server returned HTTP status " << status << endl;
+		return;
+	}
+
+	const std::string& data = http.GetData();
+	if(data.empty()) {
+		// Don't overwrite a working file with an empty download.
+		warnings << "Could not update " << f.localFile << ": downloaded file is empty" << endl;
+		return;
+	}
+
+	FILE* fp = OpenGameFile(f.localFile, "wb");
+	if(!fp) {
+		warnings << "Could not update " << f.localFile << ": cannot open the file for writing" << endl;
+		return;
+	}
+	fwrite(data.data(), 1, data.size(), fp);
+	fclose(fp);
+}
+
+Result MasterServerListUpdater::handle()
+{
+	for(size_t i = 0; i < sizeof(masterServerListFiles) / sizeof(masterServerListFiles[0]); ++i) {
+		if(breakSignal) return "break";
+		updateFile(masterServerListFiles[i]);
+	}
+	if(breakSignal) return "break";
+
+	// The master server lists are now up to date, so refresh the server list
+	// shown in the UI. This must happen after the downloads above so that it
+	// reads the freshly downloaded files, not the previous ones.
+	ServerList::get()->updateList();
+	return true;
+}
+
+void DownloadMasterServerListFiles()
+{
+	// Logged here on the main thread, so there is always a trace when Netplay
+	// is clicked - even if the background task below never gets to run.
+	notes << "Updating the master server list files..." << endl;
+	taskManager->start(new MasterServerListUpdater(), TaskManager::QT_QueueToSameTypeAndBreakCurrent);
+}
+
 
 ///////////////////
 // Parse the downloaded server list

--- a/src/game/ServerList.h
+++ b/src/game/ServerList.h
@@ -218,4 +218,9 @@ public:
 	static Ptr get();
 };
 
+
+// Downloads the latest cfg/masterservers.txt and cfg/udpmasterservers.txt
+// from the OpenLieroX serverlist repository. Runs in the background.
+void DownloadMasterServerListFiles();
+
 #endif


### PR DESCRIPTION
I created public pages on Github for storing our server lists. That way we can update the server list without the user having to download a new version of the game to get a new list

Public URLs:
https://openlierox.github.io/serverlist/masterservers.txt
https://openlierox.github.io/serverlist/udpmasterservers.txt

To update the server list, just push to this repo:
https://github.com/openlierox/serverlist


This PR also updates the UI to make it more clear to the user what is happening in regards to fetching servers, e.g. "Updating server list...", "Querying server..." so it is clear for the user what is happening while the client fetches the servers

See status updates in UI:

Note: The server 194.127.178.178 is not in the openlierox/openlierox repo, but defined [here](https://openlierox.github.io/serverlist/masterservers.txt), but the server is found anyway since the server list is now updated from  github

<img width="640" height="488" alt="Server queries" src="https://github.com/user-attachments/assets/8395c4dc-00ea-40a8-8a12-03b404d20e89" />

**Note on Android:**
The first version of this PR had problems with Android, but they are fixed now. This is because the Native C++  Curl we use on Android does not have access to the SSL-certificates of the operative system, so we have to bundle our own SSL-certificates only used by this app. We fetch them from [Mozilla](https://github.com/openlierox/openlierox/pull/888/changes#diff-4e1bbc950047b6baec754fb647b039fe48dc8a90e91204f508fe0b6ddd183d93R98)

The alternative approach would be to implement the download in Java/Kotlin for Android, then we wouldnt need to do this, but the we would have to have 2 downloaders instead one in C++ and one in Java, so I found this a better solution

