### PR TITLE
Backport Linux build/package workflow to 0.58

### DIFF
--- a/.github/workflows/build-linux.sh
+++ b/.github/workflows/build-linux.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+cd $(dirname $0)"/../.."
+cmake -S . -B build-output -DCMAKE_BUILD_TYPE=Release -DHAWKNL_BUILTIN=Yes
+mkdir -p build-output/bin
+cmake --build build-output -j$(nproc)

--- a/.github/workflows/package-linux-bundle.sh
+++ b/.github/workflows/package-linux-bundle.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+cd $(dirname $0)"/../.."
+
+PACKAGE_NAME="openlierox-$(./get_version.sh)-linux-bundle"
+PACKAGE_DIR="distrib/"$PACKAGE_NAME
+
+rm -Rf $PACKAGE_DIR
+mkdir -p $PACKAGE_DIR
+cp build-output/bin/openlierox $PACKAGE_DIR
+cp -av share/gamedir $PACKAGE_DIR/gamedir
+
+# Copy all .so files this binary was built for, to make a self contained bundle
+mkdir -p $PACKAGE_DIR/lib
+ldd $PACKAGE_DIR/openlierox | grep -v "libc.so*" | grep "=> /" | awk '{print $3}' | xargs -I '{}' cp -v '{}' $PACKAGE_DIR/lib/
+
+cd $PACKAGE_DIR
+
+# Patch openlierox binary to use local lib/ folder
+patchelf --set-rpath '$ORIGIN/lib' --force-rpath openlierox
+
+# Patch libraries to use local lib/ folder for transitive dependencies
+patchelf --set-rpath '$ORIGIN' --force-rpath ./lib/*.so*

--- a/.github/workflows/package-linux-bundle.yml
+++ b/.github/workflows/package-linux-bundle.yml
@@ -28,9 +28,9 @@ jobs:
             build-essential \
             patchelf \
             dpkg-dev \
-            libsdl2-dev \
-            libsdl2-image-dev \
-            libsdl2-mixer-dev \
+            libsdl1.2-dev \
+            libsdl-image1.2-dev \
+            libsdl-mixer1.2-dev \
             libxml2-dev \
             libgd-dev \
             zlib1g-dev \

--- a/.github/workflows/package-linux-bundle.yml
+++ b/.github/workflows/package-linux-bundle.yml
@@ -1,0 +1,63 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - 0.58
+  push:
+    branches:
+      - 0.58
+
+jobs:
+  build-linux:
+    name: Build Linux-bundle
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            build-essential \
+            patchelf \
+            dpkg-dev \
+            libsdl2-dev \
+            libsdl2-image-dev \
+            libsdl2-mixer-dev \
+            libxml2-dev \
+            libgd-dev \
+            zlib1g-dev \
+            libzip-dev \
+            libx11-dev \
+            libcurl4-openssl-dev \
+            libboost-dev \
+            libopenal-dev \
+            libalut-dev \
+            libvorbis-dev \
+            binutils-dev \
+            libiberty-dev
+
+      - name: Build
+        run: |
+          ./.github/workflows/build-linux.sh
+
+      - name: Package
+        run: ./.github/workflows/package-linux-bundle.sh
+
+      - name: Detect bundle filename
+        id: bundle
+        run: echo "name=$(basename distrib/openlierox-*-linux-bundle*)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload openlierox-linux-bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.bundle.outputs.name }}
+          path: distrib/openlierox-*-linux-bundle*
+          if-no-files-found: error


### PR DESCRIPTION
## What

Backports the Linux build-and-package GitHub Actions workflow from the `0.59` branch to `0.58`, so it's easy to produce CI builds of the older version (which many people still use).

Adds under `.github/workflows/`:
- `package-linux-bundle.yml` — builds on `ubuntu-24.04`, packages, and uploads the bundle as an artifact
- `build-linux.sh` — CMake configure + build (`HAWKNL_BUILTIN=Yes`)
- `package-linux-bundle.sh` — bundles the binary with its `.so` deps and patchelf's the rpath to `$ORIGIN/lib` for a self-contained tarball

## Scope

Triggers **only** for the `0.58` branch — on pushes to `0.58` and PRs targeting it. `master` is intentionally excluded since this is purely for maintaining the old version.

## Compatibility notes

The 0.59 scripts work unchanged against 0.58's older CMake setup:
- CMake configure verified locally (`OLX_VERSION = 0.58_rc5`).
- 0.58 uses `OUTPUT_NAME bin/openlierox`, so the binary lands at `build-output/bin/openlierox` — exactly what the package script copies. The `mkdir -p build-output/bin` in `build-linux.sh` pre-creates that dir (0.58 doesn't auto-create it like 0.59).

🤖 Generated with [Claude Code](https://claude.com/claude-code)