### PR TITLE
bugfix: add missing gamedir path in 0.58

### DIFF
--- a/src/common/FindFile.cpp
+++ b/src/common/FindFile.cpp
@@ -441,6 +441,7 @@ void InitBaseSearchPaths() {
 	AddToFileList(&basesearchpaths, "${HOME}/.OpenLieroX");
 	AddToFileList(&basesearchpaths, ".");
 	AddToFileList(&basesearchpaths, SYSTEM_DATA_DIR"/OpenLieroX"); // no use of ${SYSTEM_DATA}, because it is uncommon and could cause confusion to the user
+	AddToFileList(&basesearchpaths, "${BIN}/gamedir");
 #endif
 }
 


### PR DESCRIPTION
This is a bugfix for the last PR: https://github.com/openlierox/openlierox/pull/889

I missed 1 line to add a relative path to "gamedir". This is because it happened to work on my computer without the fix, because I had the gamedir globally available, but that would not work on a freshly installed computer that never had OpenLireoX before

This PR fixes the problem so that the bundle should now also work on computers that did not already have OpenLieroX installed.