### PR TITLE
Add default configuration for gamepads

### DIFF
--- a/include/CInput.h
+++ b/include/CInput.h
@@ -21,6 +21,7 @@
 #define __CINPUT_H__
 
 #include <string>
+#include <vector>
 #include "InputEvents.h"
 
 
@@ -48,35 +49,50 @@
 struct KeyboardEvent;
 
 class CInput {
-	friend void HandleNextEvent();
-	friend void HandleCInputs_UpdateDownOnceForNonKeyboard();
-	friend void HandleCInputs_UpdateUpForNonKeyboard();
-	friend void HandleCInputs_KeyEvent(const KeyboardEvent& ev);
-
 public:
 	CInput();
 	~CInput();
 
 private:
-	// Attributes
+	// A single physical binding (one key, mouse button or joystick control).
+	// A CInput can hold several of these so that one game action may be bound
+	// to multiple inputs (e.g. a keyboard key and a gamepad button); the
+	// action is considered active when any of the bindings is active.
+	struct Binding {
+		int		Type; // keyboard, mouse or joystick
+		int		Data;
+		int		SdlIndex;
+		int		JoystickIndex; // 0-based pad index for INP_JOYSTICK
+		ModifiersState m_modifiers; // required modifier keys for keyboard bindings
 
-	int		Type; // keyboard, mouse or joystick
-	int		Data;
-	int		SdlIndex;
-	int		JoystickIndex; // 0-based pad index for INP_JOYSTICK
-	std::string m_EventName;
-	ModifiersState m_modifiers; // required modifier keys for keyboard bindings
-	bool	resetEachFrame;
+		// HINT: currently these are only used for keyboard exept nDownOnce
+		int		nDown;
+		int		nDownOnce; // this is also updated for non-keyboards with currently the old code
+		int		nUp;
+		bool	bDown;
 
-	// HINT: currently these are only used for keyboard exept nDownOnce
-	// TODO: change this in HandleNextEvent() and here
-	int		nDown;
-	int		nDownOnce; // this is also updated for non-keyboards with currently the old code
-	int		nUp;
-	bool	bDown;
+		Binding() : Type(INP_NOTUSED), Data(0), SdlIndex(0), JoystickIndex(0),
+					nDown(0), nDownOnce(0), nUp(0), bDown(false) {}
 
-private:
-	int		wasDown_withoutRepeats() const;
+		bool	setup(const std::string& text); // parse a single binding token
+
+		bool	isUsed() const { return Type >= 0; }
+		bool	isJoystick() const { return Type == INP_JOYSTICK; }
+		bool	isKeyboard() const { return Type == INP_KEYBOARD; }
+
+		bool	isUp() const;
+		bool	isDown() const;
+		int		wasDown() const;
+		int		wasDown_withoutRepeats() const { return nDownOnce; }
+		int		wasUp() const;
+		int		getJoystickValue() const;
+		bool	isJoystickThrottle() const;
+		void	reset() { nDown = nDownOnce = nUp = 0; }
+	};
+
+	std::vector<Binding>	m_bindings;
+	std::string				m_EventName; // the original (possibly comma-separated) config string
+	bool					resetEachFrame;
 
 public:
 	// Methods
@@ -92,11 +108,12 @@ public:
 	static void OnControllerAdded(int deviceIndex);
 	static void OnControllerRemoved(int instanceId);
 	static int Wait(std::string& strText); // TODO: change this name. this function doesn't realy wait, it just checks the event-state
-	bool	isUsed() { return Type >= 0; }
-	int		getData() { return Data; }
-	int		getType() { return Type; }
-	bool	isJoystick() { return Type == INP_JOYSTICK; }
-	bool	isKeyboard() { return Type == INP_KEYBOARD; }
+	bool	isUsed() const;
+	bool	isJoystick() const;
+	bool	isJoystickDown() const;     // true if any joystick binding is currently down
+	bool	isJoystickDownOnce() const; // true if any joystick binding was just pressed
+	bool	isKeyboard() const;
+	bool	usesKeyboardKey(int sym) const; // true if any keyboard binding is bound to this key sym
 	void	setResetEachFrame(bool r)	{ resetEachFrame = r; }
 	bool	getResetEachFrame()			{ return resetEachFrame; }
 	int		getJoystickValue();
@@ -105,14 +122,16 @@ public:
 	bool	isUp();
 	bool	isDown() const;
 	bool	isDownOnce();
-	int wasDown(bool withRepeats) const {
-		if(withRepeats) return wasDown();
-		else return wasDown_withoutRepeats();
-	}
+	int		wasDown(bool withRepeats) const;
 	int		wasDown() const; // checks if there was such an event in the queue; returns the count of presses (down-events)
 	int		wasUp(); // checks if there was an keyup-event; returns the count of up-events
 
 	std::string getEventName() { return m_EventName; }
+
+	// event handling, called from the global input-event dispatchers
+	void	handleKeyEvent(const KeyboardEvent& ev);
+	void	updateDownOnceForNonKeyboard();
+	void	updateUpForNonKeyboard();
 
 	// resets the current state
 	// this is called automatically if resetEachFrame

--- a/include/DeprecatedGUI/CInputBox.h
+++ b/include/DeprecatedGUI/CInputBox.h
@@ -39,11 +39,15 @@ enum {
 
 class CInputbox : public CWidget {
 public:
-	// Constructor
-	CInputbox(int val, const std::string& _text, SmartPointer<SDL_Surface> img, const std::string& name) {
+	// Constructor.
+	// slot selects which binding of a comma-separated control value this box
+	// edits (0-based). -1 (the default) means the box represents the whole
+	// value, as before.
+	CInputbox(int val, const std::string& _text, SmartPointer<SDL_Surface> img, const std::string& name, int slot = -1) {
 		iKeyvalue = val;
 		sText = _text;
 		sName = name;
+		iSlot = slot;
 
 		bmpImage = img;
 		iType = wid_Inputbox;
@@ -56,6 +60,7 @@ private:
 	// Attributes
 
 	int			iKeyvalue;
+	int			iSlot;
 	std::string	sText;
 	SmartPointer<SDL_Surface> bmpImage;
 	bool		bMouseOver;
@@ -103,6 +108,7 @@ public:
 
 	INLINE int		getValue()						{ return iKeyvalue; }
 	INLINE void	setValue(int _v)					{ iKeyvalue = _v; }
+	INLINE int		getSlot()						{ return iSlot; }
 	INLINE std::string	getText()				{ return sText; }
 	INLINE void	setText(const std::string& _t)		{ sText = _t; }
 	INLINE std::string	getName()				{ return sName; }

--- a/src/client/CInput.cpp
+++ b/src/client/CInput.cpp
@@ -433,13 +433,7 @@ void CInput::OnControllerRemoved(int instanceId) {
 
 
 CInput::CInput() {
-	Type = INP_NOTUSED;
-	Data = 0;
-	SdlIndex = 0;
-	JoystickIndex = 0;
 	resetEachFrame = true;
-	bDown = false;
-	reset();
 
 	RegisterCInput(this);
 }
@@ -541,10 +535,53 @@ int CInput::Wait(std::string& strText)
 
 ///////////////////
 // Setup
+// The config value may be a single binding or a comma-separated list of
+// bindings (e.g. "lalt, j1_button_south"). Each token is parsed into its own
+// Binding; the action is active when any of them is active.
 int CInput::Setup(const std::string& string)
 {
 	m_EventName = string;
 	resetEachFrame = true;
+	m_bindings.clear();
+
+	int ret = false;
+	std::vector<std::string> tokens = explode(string, ",");
+	for(std::vector<std::string>::iterator it = tokens.begin(); it != tokens.end(); ++it) {
+		std::string token = Trimmed(*it);
+		if(token.empty()) continue;
+		Binding b;
+		bool ok = b.setup(token);
+		m_bindings.push_back(b);
+		if(ok) ret = true;
+	}
+
+	// Fallback: nothing usable came out of splitting (e.g. the binding is the
+	// comma key itself, written as ","). Treat the whole string as one token.
+	if(m_bindings.empty()) {
+		std::string whole = Trimmed(string);
+		if(!whole.empty()) {
+			Binding b;
+			ret = b.setup(whole);
+			m_bindings.push_back(b);
+		}
+	}
+
+	// Always keep at least one (unused) binding so the rest of the code can
+	// treat a control uniformly whether or not it parsed to anything.
+	if(m_bindings.empty())
+		m_bindings.push_back(Binding());
+
+	return ret;
+}
+
+///////////////////
+// Parse a single binding token
+bool CInput::Binding::setup(const std::string& string)
+{
+	Type = INP_NOTUSED;
+	Data = 0;
+	SdlIndex = 0;
+	JoystickIndex = 0;
 	m_modifiers.clear();
 
 	// Parse optional modifier prefixes: "alt+", "ctrl+", "shift+"
@@ -646,7 +683,7 @@ int CInput::Setup(const std::string& string)
 
 ////////////////////
 // Returns the "force" value for a joystick axis
-int CInput::getJoystickValue()
+int CInput::Binding::getJoystickValue() const
 {
 #ifdef HAVE_JOYSTICK
 	if(Type == INP_JOYSTICK)
@@ -655,10 +692,23 @@ int CInput::getJoystickValue()
 	return 0;
 }
 
+int CInput::getJoystickValue()
+{
+	// Return the joystick binding with the largest force (by magnitude).
+	int best = 0;
+	for(std::vector<Binding>::iterator it = m_bindings.begin(); it != m_bindings.end(); ++it) {
+		int v = it->getJoystickValue();
+		int vMag = (v < 0) ? -v : v;
+		int bestMag = (best < 0) ? -best : best;
+		if(vMag > bestMag) best = v;
+	}
+	return best;
+}
+
 
 ////////////////////
 // Returns true if this joystick is a throttle
-bool CInput::isJoystickThrottle()
+bool CInput::Binding::isJoystickThrottle() const
 {
 #ifdef HAVE_JOYSTICK
 	if (Type == INP_JOYSTICK)
@@ -667,12 +717,18 @@ bool CInput::isJoystickThrottle()
 	return false;
 }
 
+bool CInput::isJoystickThrottle()
+{
+	for(std::vector<Binding>::iterator it = m_bindings.begin(); it != m_bindings.end(); ++it)
+		if(it->isJoystickThrottle()) return true;
+	return false;
+}
+
 
 ///////////////////
 // Returns if the input has just been released
-bool CInput::isUp()
+bool CInput::Binding::isUp() const
 {
-
 	switch(Type) {
 
 		// Keyboard
@@ -697,10 +753,17 @@ bool CInput::isUp()
 	return false;
 }
 
+bool CInput::isUp()
+{
+	for(std::vector<Binding>::iterator it = m_bindings.begin(); it != m_bindings.end(); ++it)
+		if(it->isUp()) return true;
+	return false;
+}
+
 
 ///////////////////
 // Returns if the input is down
-bool CInput::isDown() const
+bool CInput::Binding::isDown() const
 {
 	switch(Type) {
 
@@ -725,66 +788,202 @@ bool CInput::isDown() const
 	return false;
 }
 
+bool CInput::isDown() const
+{
+	for(std::vector<Binding>::const_iterator it = m_bindings.begin(); it != m_bindings.end(); ++it)
+		if(it->isDown()) return true;
+	return false;
+}
+
 
 ///////////////////
 // Returns if the input was pushed down once
 bool CInput::isDownOnce()
 {
-	return nDownOnce != 0;
-}
-
-int CInput::wasDown_withoutRepeats() const {
-	return nDownOnce;
+	for(std::vector<Binding>::iterator it = m_bindings.begin(); it != m_bindings.end(); ++it)
+		if(it->nDownOnce != 0) return true;
+	return false;
 }
 
 // goes through the event-signals and searches for the event
+int CInput::Binding::wasDown() const {
+	switch(Type) {
+	case INP_KEYBOARD:
+		return nDown;
+
+	case INP_MOUSE:
+		// TODO: to make this possible, we need to go extend HandleNextEvent to save the mouse events
+		return nDownOnce; // no other way at the moment
+
+#ifdef HAVE_JOYSTICK
+	case INP_JOYSTICK:
+		return nDownOnce; // no other way at the moment
+#endif
+	}
+
+	return 0;
+}
+
 int CInput::wasDown() const {
 	int counter = 0;
+	for(std::vector<Binding>::const_iterator it = m_bindings.begin(); it != m_bindings.end(); ++it)
+		counter += it->wasDown();
+	return counter;
+}
 
-	switch(Type) {
-	case INP_KEYBOARD:
-		counter = nDown;
-		break;
-
-	case INP_MOUSE:
-		// TODO: to make this possible, we need to go extend HandleNextEvent to save the mouse events
-		counter = nDownOnce; // no other way at the moment
-		break;
-
-#ifdef HAVE_JOYSTICK
-	case INP_JOYSTICK:
-		counter = nDownOnce; // no other way at the moment
-		break;
-#endif
-	}
-
+int CInput::wasDown(bool withRepeats) const {
+	if(withRepeats) return wasDown();
+	int counter = 0;
+	for(std::vector<Binding>::const_iterator it = m_bindings.begin(); it != m_bindings.end(); ++it)
+		counter += it->wasDown_withoutRepeats();
 	return counter;
 }
 
 // goes through the event-signals and searches for the event
-int CInput::wasUp() {
-	int counter = 0;
-
+int CInput::Binding::wasUp() const {
 	switch(Type) {
 	case INP_KEYBOARD:
-		counter = nUp;
-		break;
+		return nUp;
 
 	case INP_MOUSE:
 		// TODO: to make this possible, we need to go extend HandleNextEvent to save the mouse events
-		counter = 0;  // no other way at the moment
-		break;
+		return 0;  // no other way at the moment
 
 #ifdef HAVE_JOYSTICK
 	case INP_JOYSTICK:
-		counter = 0; // no other way at the moment
-		break;
+		return 0; // no other way at the moment
 #endif
 	}
 
+	return 0;
+}
+
+int CInput::wasUp() {
+	int counter = 0;
+	for(std::vector<Binding>::iterator it = m_bindings.begin(); it != m_bindings.end(); ++it)
+		counter += it->wasUp();
 	return counter;
+}
+
+bool CInput::isUsed() const {
+	for(std::vector<Binding>::const_iterator it = m_bindings.begin(); it != m_bindings.end(); ++it)
+		if(it->isUsed()) return true;
+	return false;
+}
+
+bool CInput::isJoystick() const {
+	for(std::vector<Binding>::const_iterator it = m_bindings.begin(); it != m_bindings.end(); ++it)
+		if(it->isJoystick()) return true;
+	return false;
+}
+
+bool CInput::isJoystickDown() const {
+	for(std::vector<Binding>::const_iterator it = m_bindings.begin(); it != m_bindings.end(); ++it)
+		if(it->isJoystick() && it->isDown()) return true;
+	return false;
+}
+
+bool CInput::isJoystickDownOnce() const {
+	for(std::vector<Binding>::const_iterator it = m_bindings.begin(); it != m_bindings.end(); ++it)
+		if(it->isJoystick() && it->nDownOnce != 0) return true;
+	return false;
+}
+
+bool CInput::isKeyboard() const {
+	for(std::vector<Binding>::const_iterator it = m_bindings.begin(); it != m_bindings.end(); ++it)
+		if(it->isKeyboard()) return true;
+	return false;
+}
+
+bool CInput::usesKeyboardKey(int sym) const {
+	for(std::vector<Binding>::const_iterator it = m_bindings.begin(); it != m_bindings.end(); ++it)
+		if(it->isKeyboard() && it->Data == sym) return true;
+	return false;
 }
 
 void CInput::reset() {
-	nDown = nDownOnce = nUp = 0;
+	for(std::vector<Binding>::iterator it = m_bindings.begin(); it != m_bindings.end(); ++it)
+		it->reset();
+}
+
+
+///////////////////
+// Update keyboard bindings from a key event
+void CInput::handleKeyEvent(const KeyboardEvent& ev) {
+	for(std::vector<Binding>::iterator b = m_bindings.begin(); b != m_bindings.end(); ++b) {
+		if(!b->isKeyboard() || b->Data != ev.sym)
+			continue;
+		// If the binding requires specific modifiers, enforce an exact match.
+		// If no modifiers are required, fire regardless of modifier state (backward compat).
+		const ModifiersState& req = b->m_modifiers;
+		if(req.bAlt || req.bCtrl || req.bShift || req.bGui) {
+			if(req.bAlt   != ev.state.bAlt)   continue;
+			if(req.bCtrl  != ev.state.bCtrl)  continue;
+			if(req.bShift != ev.state.bShift) continue;
+			if(req.bGui   != ev.state.bGui)   continue;
+		}
+		if(ev.down) {
+			b->nDown++;
+			if(!b->bDown) {
+				b->nDownOnce++;
+				b->bDown = true;
+			}
+		} else {
+			b->bDown = false;
+			b->nUp++;
+		}
+	}
+}
+
+
+///////////////////
+// Update down-once state for non-keyboard bindings (polled each frame)
+void CInput::updateDownOnceForNonKeyboard() {
+	for(std::vector<Binding>::iterator b = m_bindings.begin(); b != m_bindings.end(); ++b) {
+		if(!b->isUsed() || b->isKeyboard())
+			continue;
+
+		// HINT: It is possible that wasUp() and !Down (a case which is not covered in further code)
+		if(b->wasUp() && !b->bDown) {
+			b->nDownOnce++;
+			continue;
+		}
+
+		// HINT: It's possible that wasDown() > 0 and !isDown().
+		// That is the case when we press a key and release it directly after (in one frame).
+		// Though wasDown() > 0 doesn't mean directly isDownOnce because it also counts keypresses.
+		// HINT: It's also possible that wasDown() == 0 and isDown().
+		// That is the case when we have pressed the key in a previous frame and we still hold it
+		// and the keyrepeat-interval is bigger than FPS. (Rare case.)
+		if(b->wasDown() || b->isDown()) {
+			// wasUp() > 0 always means that it was down once (though it is not down anymore).
+			// Though the released key in wasUp() > 0 was probably already recognised before.
+			if(b->wasUp()) {
+				b->bDown = b->isDown();
+				if(b->bDown) // if it is again down, there is another new press
+					b->nDownOnce++;
+				continue;
+			}
+			// !Down means that we haven't recognised yet that it is down.
+			if(!b->bDown) {
+				b->bDown = b->isDown();
+				b->nDownOnce++;
+				continue;
+			}
+		}
+		else
+			b->bDown = false;
+	}
+}
+
+
+///////////////////
+// Update up state for non-keyboard bindings (polled each frame)
+void CInput::updateUpForNonKeyboard() {
+	for(std::vector<Binding>::iterator b = m_bindings.begin(); b != m_bindings.end(); ++b) {
+		if(!b->isUsed() || b->isKeyboard())
+			continue;
+		if(b->isDown() && !b->bDown)
+			b->nUp++;
+	}
 }

--- a/src/client/DeprecatedGUI/CInputBox.cpp
+++ b/src/client/DeprecatedGUI/CInputBox.cpp
@@ -28,13 +28,31 @@ namespace DeprecatedGUI {
 // Draw the input box
 void CInputbox::Draw(SDL_Surface * bmpDest)
 {
+	const int nativeW = bmpImage.get()->w;
+	// Draw at the widget's width; if it's wider than the box image, widen it.
+	const int bw = (iWidth > nativeW) ? iWidth : nativeW;
+
 	if (bRedrawMenu)
-		Menu_redrawBufferRect(iX,iY, bmpImage.get()->w, MAX(bmpImage.get()->h, tLX->cFont.GetHeight()));
+		Menu_redrawBufferRect(iX,iY, bw, MAX(bmpImage.get()->h, tLX->cFont.GetHeight()));
 
 	int y = bMouseOver ? 17 : 0;
-	DrawImageAdv(bmpDest,bmpImage, 0, y, iX, iY, bmpImage.get()->w, 17);
+	if(bw <= nativeW) {
+		DrawImageAdv(bmpDest, bmpImage, 0, y, iX, iY, nativeW, 17);
+	} else {
+		// Widen via a horizontal 3-slice: keep the left/right caps (which hold
+		// the rounded corners and borders) at native size and repeat a flat
+		// middle column to fill the gap. We use DrawImageAdv throughout so the
+		// box image's alpha is blended (a plain stretch did not blend and
+		// looked broken).
+		const int capW = nativeW / 2;       // left/right cap width
+		const int midSrcX = capW - 1;       // a flat interior column to repeat
+		DrawImageAdv(bmpDest, bmpImage, 0, y, iX, iY, capW, 17);                          // left cap
+		for(int dx = iX + capW; dx < iX + bw - capW; dx++)
+			DrawImageAdv(bmpDest, bmpImage, midSrcX, y, dx, iY, 1, 17);                   // repeated middle
+		DrawImageAdv(bmpDest, bmpImage, capW, y, iX + bw - capW, iY, nativeW - capW, 17); // right cap
+	}
 	bMouseOver = false;
-    tLX->cFont.DrawCentre(bmpDest, iX+25, iY+1, tLX->clWhite, sText);
+    tLX->cFont.DrawCentre(bmpDest, iX + bw/2, iY+1, tLX->clWhite, sText);
 }
 
 CInputbox * CInputbox::InputBoxSelected = NULL;

--- a/src/client/DeprecatedGUI/Menu_Options.cpp
+++ b/src/client/DeprecatedGUI/Menu_Options.cpp
@@ -23,6 +23,7 @@
 #include "GfxPrimitives.h"
 #include "FindFile.h"
 #include "StringUtils.h"
+#include "CScriptableVars.h"
 #include "DeprecatedGUI/CAnimation.h"
 #include "DeprecatedGUI/CButton.h"
 #include "DeprecatedGUI/CLabel.h"
@@ -38,9 +39,26 @@ namespace DeprecatedGUI {
 
 int OptionsMode = 0;
 CGuiLayout	cOptions;
-CGuiLayout	cOpt_Controls;
+CGuiLayout	cOpt_Controls;     // Player 1 controls (sub-tab 0)
+CGuiLayout	cOpt_Controls2;    // Player 2 controls (sub-tab 1)
+CGuiLayout	cOpt_ControlsGen;  // General controls (sub-tab 2)
 CGuiLayout	cOpt_System;
 CGuiLayout	cOpt_Game;
+
+// The Controls screen is split into three sub-tabs so each section gets the
+// full width. ControlsSubTab selects which one is shown.
+enum {
+	ct_Player1 = 0,
+	ct_Player2,
+	ct_General,
+	ct__Count
+};
+int ControlsSubTab = ct_Player1;
+static const char* ControlsTabNames[ct__Count] = { "Player 1", "Player 2", "General" };
+// Tab header hit-boxes, filled in when drawn (see Menu_OptionsDrawControlsTabs).
+static SDL_Rect ControlsTabRects[ct__Count];
+// "Reset defaults" button hit-box, filled in when drawn.
+static SDL_Rect ResetBtnRect;
 CButton		TopButtons[3];
 
 // Control id's
@@ -143,8 +161,95 @@ std::string InputNames[] = {
 	"Strafe"
 };
 
+// General controls shown on the "General" sub-tab: display label, index into
+// tLXOptions->sGeneralControls, and the row's control id.
+struct GenCtrl { const char* label; int sin; int id; };
+static const GenCtrl GeneralControlsList[] = {
+	{ "Chat",              SIN_CHAT,          oc_Gen_Chat },
+	{ "Scoreboard",        SIN_SCORE,         oc_Gen_Score },
+	{ "Health Bar",        SIN_HEALTH,        oc_Gen_Health },
+	{ "Current Settings",  SIN_SETTINGS,      oc_Gen_CurSettings },
+	{ "Take Screenshot",   SIN_SCREENSHOTS,   oc_Gen_TakeScreenshot },
+	{ "Viewport Manager",  SIN_VIEWPORTS,     oc_Gen_ViewportManager },
+	{ "Switch Video Mode", SIN_SWITCHMODE,    oc_Gen_SwitchMode },
+	{ "Toggle Top Bar",    SIN_TOGGLETOPBAR,  oc_Gen_ToggleTopBar },
+	{ "Teamchat",          SIN_TEAMCHAT,      oc_Gen_TeamChat },
+	{ "IRC chat window",   SIN_IRCCHAT,       oc_Gen_IrcChat },
+	{ "Toggle console",    SIN_CONSOLETOGGLE, oc_Gen_ConsoleToggle },
+};
+static const int kNumGeneralControls = sizeof(GeneralControlsList) / sizeof(GeneralControlsList[0]);
+
 
 bool bSpeedTest = false;
+
+// Each control can hold several bindings (a comma-separated list). On the
+// Controls screen we show one input box per binding slot, side by side, so
+// the keyboard (slot 0) and gamepad (slot 1) bindings can be edited
+// independently. This is how many slot-columns we display per control.
+static const int kControlSlots = 2;
+static const char* ControlSlotNames[kControlSlots] = { "Keyboard", "Gamepad" };
+// Control-id offset added per slot column so each box has a distinct id.
+static const int kSlotIdStride = 100;
+
+// Return the binding at the given 0-based slot of a (possibly comma-separated)
+// control value, or "" if that slot is empty.
+static std::string Menu_ControlSlotText(const std::string& full, int slot)
+{
+	if(slot < 0) return full;
+	std::vector<std::string> parts = explode(full, ",");
+	if(slot >= (int)parts.size()) return "";
+	return Trimmed(parts[slot]);
+}
+
+// Return a copy of full with the binding at the given slot replaced by value,
+// keeping the other slots in place. Trailing empty slots are dropped.
+static std::string Menu_ControlSetSlot(const std::string& full, int slot, const std::string& value)
+{
+	if(slot < 0) return value;
+	std::vector<std::string> parts = explode(full, ",");
+	for(size_t k = 0; k < parts.size(); k++) parts[k] = Trimmed(parts[k]);
+	while((int)parts.size() <= slot) parts.push_back("");
+	parts[slot] = Trimmed(value);
+	while(!parts.empty() && parts.back().empty()) parts.pop_back();
+	std::string res;
+	for(size_t k = 0; k < parts.size(); k++) {
+		if(k) res += ", ";
+		res += parts[k];
+	}
+	return res;
+}
+
+// Input-box width on the Controls screen, sized so long bindings like
+// "j1_button_south" fit. The box widens via a 3-slice in CInputbox::Draw.
+// Column positions account for the wider boxes (box1 300-399, box2 420-519).
+static const int kControlBoxW = 99;
+static const int kControlSlotX[kControlSlots] = { 300, 420 };
+static const int kControlLabelX = 140;
+
+// Adds the "Keyboard" / "Gamepad" column headers to a controls layout,
+// centered over their columns (the boxes draw their text centered too).
+static void Menu_AddControlHeaders(CGuiLayout& layout, int y)
+{
+	for(int s = 0; s < kControlSlots; s++) {
+		const int colCentre = kControlSlotX[s] + kControlBoxW / 2;
+		const int textW = tLX->cFont.GetWidth(ControlSlotNames[s]);
+		layout.Add( new CLabel(ControlSlotNames[s], tLX->clSubHeading), Static, colCentre - textW / 2, y, 0, 0);
+	}
+}
+
+// Adds one control row: a name label plus one input box per binding slot.
+// sinIndex is the control's index into its options array; fullValue is its
+// current (possibly comma-separated) value; baseId is the row's control id.
+static void Menu_AddControlRow(CGuiLayout& layout, const std::string& label, int sinIndex,
+                               const std::string& fullValue, int baseId, int y)
+{
+	layout.Add( new CLabel(label, tLX->clNormalLabel), Static, kControlLabelX, y, 0, 0);
+	for(int s = 0; s < kControlSlots; s++) {
+		const std::string boxName = label + " (" + ControlSlotNames[s] + ")";
+		layout.Add( new CInputbox(sinIndex, Menu_ControlSlotText(fullValue, s), tMenu->bmpInputbox, boxName, s),
+		            baseId + s * kSlotIdStride, kControlSlotX[s], y, kControlBoxW, 17 );
+	}
+}
 
 ///////////////////
 // Initialize the options
@@ -183,6 +288,12 @@ bool Menu_OptionsInitialize()
 	cOpt_Controls.Shutdown();
 	cOpt_Controls.Initialize();
 
+	cOpt_Controls2.Shutdown();
+	cOpt_Controls2.Initialize();
+
+	cOpt_ControlsGen.Shutdown();
+	cOpt_ControlsGen.Initialize();
+
 	cOpt_Game.Shutdown();
 	cOpt_Game.Initialize();
 
@@ -191,74 +302,41 @@ bool Menu_OptionsInitialize()
 	cOptions.Add( new CButton(BUT_BACK, tMenu->bmpButtons), op_Back, 25,440, 50,15);
 
 
-	// Controls
-	cOpt_Controls.Add( new CLabel("Player Controls", tLX->clHeading), Static, 40,  150, 0,0);
-	cOpt_Controls.Add( new CLabel("Player 1",tLX->clSubHeading),      Static, 163, 170, 0,0);
-	cOpt_Controls.Add( new CLabel("Player 2",tLX->clSubHeading),      Static, 268, 170, 0,0);
-	cOpt_Controls.Add( new CLabel("General Controls", tLX->clHeading),Static, 390, 150, 0,0);
-
-	int y = 190;
-	for(i=0;i<9;i++,y+=25) {
-		cOpt_Controls.Add( new CLabel(InputNames[i],tLX->clNormalLabel), Static, 40, y, 0,0);
-
-		cOpt_Controls.Add( new CInputbox(SIN_UP+i, tLXOptions->sPlayerControls[0][SIN_UP+i], tMenu->bmpInputbox, InputNames[i]),
-			               oc_Ply1_Up+i, 165, y, 50,17);
-		cOpt_Controls.Add( new CInputbox(SIN_UP+i, tLXOptions->sPlayerControls[1][SIN_UP+i], tMenu->bmpInputbox, InputNames[i]),
-			               oc_Ply2_Up+i, 270, y, 50,17);
-
+	// Controls — Player 1 / Player 2 each get their own sub-tab. Every control
+	// shows one input box per binding slot (Keyboard, Gamepad) so the slots can
+	// be edited independently.
+	{
+		int y = 205;
+		Menu_AddControlHeaders(cOpt_Controls,  y - 20);
+		Menu_AddControlHeaders(cOpt_Controls2, y - 20);
+		for(i=0;i<9;i++,y+=26) {
+			Menu_AddControlRow(cOpt_Controls,  InputNames[i], SIN_UP+i,
+			                   tLXOptions->sPlayerControls[0][SIN_UP+i], oc_Ply1_Up+i, y);
+			Menu_AddControlRow(cOpt_Controls2, InputNames[i], SIN_UP+i,
+			                   tLXOptions->sPlayerControls[1][SIN_UP+i], oc_Ply2_Up+i, y);
+		}
 	}
 
-	// General Controls
-	cOpt_Controls.Add( new CLabel("Chat", tLX->clNormalLabel), Static, 390, 190, 0,0);
-	cOpt_Controls.Add( new CInputbox(SIN_CHAT, tLXOptions->sGeneralControls[SIN_CHAT], tMenu->bmpInputbox, "Chat"),
-						   oc_Gen_Chat, 525, 190, 50,17);
+	// Controls — General (third sub-tab), same per-slot columns
+	{
+		int y = 200;
+		Menu_AddControlHeaders(cOpt_ControlsGen, y - 18);
+		for(int g=0; g<kNumGeneralControls; g++, y+=22) {
+			Menu_AddControlRow(cOpt_ControlsGen, GeneralControlsList[g].label, GeneralControlsList[g].sin,
+			                   tLXOptions->sGeneralControls[GeneralControlsList[g].sin], GeneralControlsList[g].id, y);
+		}
+	}
 
-    cOpt_Controls.Add( new CLabel("Scoreboard", tLX->clNormalLabel), Static, 390, 215, 0,0);
-	cOpt_Controls.Add( new CInputbox(SIN_SCORE, tLXOptions->sGeneralControls[SIN_SCORE], tMenu->bmpInputbox, "Scoreboard"),
-						   oc_Gen_Score, 525, 215, 50,17);
+	// The "Reset defaults" button is drawn manually (see
+	// Menu_OptionsDrawResetButton) so it can show that exact text — the atlas
+	// buttons only offer a generic "Default" graphic.
 
-    cOpt_Controls.Add( new CLabel("Health Bar", tLX->clNormalLabel), Static, 390, 240, 0,0);
-	cOpt_Controls.Add( new CInputbox(SIN_HEALTH, tLXOptions->sGeneralControls[SIN_HEALTH], tMenu->bmpInputbox, "Health Bar"),
-						   oc_Gen_Health, 525, 240, 50,17);
 
-    cOpt_Controls.Add( new CLabel("Current Settings", tLX->clNormalLabel), Static, 390, 265, 0,0);
-	cOpt_Controls.Add( new CInputbox(SIN_SETTINGS, tLXOptions->sGeneralControls[SIN_SETTINGS], tMenu->bmpInputbox, "Current Settings"),
-						   oc_Gen_CurSettings, 525, 265, 50,17);
-
-    cOpt_Controls.Add( new CLabel("Take Screenshot", tLX->clNormalLabel), Static, 390, 290, 0,0);
-	cOpt_Controls.Add( new CInputbox(SIN_SCREENSHOTS, tLXOptions->sGeneralControls[SIN_SCREENSHOTS], tMenu->bmpInputbox, "Take Screenshot"),
-						   oc_Gen_TakeScreenshot, 525, 290, 50,17);
-
-    cOpt_Controls.Add( new CLabel("Viewport Manager", tLX->clNormalLabel), Static, 390, 315, 0,0);
-	cOpt_Controls.Add( new CInputbox(SIN_VIEWPORTS, tLXOptions->sGeneralControls[SIN_VIEWPORTS], tMenu->bmpInputbox, "Viewport Manager"),
-						   oc_Gen_ViewportManager, 525, 315, 50,17);
-
-    cOpt_Controls.Add( new CLabel("Switch Video Mode", tLX->clNormalLabel), Static, 390, 340, 0,0);
-	cOpt_Controls.Add( new CInputbox(SIN_SWITCHMODE, tLXOptions->sGeneralControls[SIN_SWITCHMODE], tMenu->bmpInputbox, "Switch Video Mode"),
-						   oc_Gen_SwitchMode, 525, 340, 50,17);
-
-    cOpt_Controls.Add( new CLabel("Toggle Top Bar", tLX->clNormalLabel), Static, 390, 365, 0,0);
-	cOpt_Controls.Add( new CInputbox(SIN_TOGGLETOPBAR, tLXOptions->sGeneralControls[SIN_TOGGLETOPBAR], tMenu->bmpInputbox, "Toggle Top Bar"),
-						   oc_Gen_ToggleTopBar, 525, 365, 50,17);
-
-	cOpt_Controls.Add( new CLabel("Teamchat", tLX->clNormalLabel), Static, 390, 390, 0,0);
-	cOpt_Controls.Add( new CInputbox(SIN_TEAMCHAT, tLXOptions->sGeneralControls[SIN_TEAMCHAT], tMenu->bmpInputbox, "Teamchat"),
-						   oc_Gen_TeamChat, 525, 390, 50,17);
-
-	cOpt_Controls.Add( new CLabel("IRC chat window", tLX->clNormalLabel), Static, 390, 415, 0,0);
-	cOpt_Controls.Add( new CInputbox(SIN_IRCCHAT, tLXOptions->sGeneralControls[SIN_IRCCHAT], tMenu->bmpInputbox, "IRC chat"),
-						   oc_Gen_IrcChat, 525, 415, 50,17);
-
-	cOpt_Controls.Add( new CLabel("Toggle console", tLX->clNormalLabel), Static, 390, 440, 0,0);
-	cOpt_Controls.Add( new CInputbox(SIN_CONSOLETOGGLE, tLXOptions->sGeneralControls[SIN_CONSOLETOGGLE], tMenu->bmpInputbox, "Console"),
-	                   oc_Gen_ConsoleToggle, 525, 440, 50,17);
-	
-	
 
 	// System
 	const Color lineCol = tLX->clLine; //tLX->clHeading.derived(0,0,0,-200);
 	const int starty = 130;
-	y = starty;
+	int y = starty;
 	cOpt_System.Add( new CLabel("Video",tLX->clHeading),              Static, 40, y, 0,0);
 	cOpt_System.Add( new CLine(0,0,0,0, lineCol), Static, 90, y + 8, 620 - 90, 0);
 	y += 20;
@@ -478,6 +556,109 @@ void Menu_OptionsUpdateUpload(float speed)
 
 
 ///////////////////
+// Returns the gui layout for the currently selected Controls sub-tab
+static CGuiLayout& Menu_OptionsControlsLayout()
+{
+	switch(ControlsSubTab) {
+		case ct_Player2: return cOpt_Controls2;
+		case ct_General: return cOpt_ControlsGen;
+		default:         return cOpt_Controls;
+	}
+}
+
+///////////////////
+// Draws the Controls sub-tab headers (Player 1 / Player 2 / General) and
+// records their hit-boxes in ControlsTabRects.
+static void Menu_OptionsDrawControlsTabs(SDL_Surface* dest)
+{
+	const int tabY = 150;
+	const int gap = 35;
+	const int h = tLX->cFont.GetHeight();
+	int x = 60;
+	for(int t = 0; t < ct__Count; t++) {
+		const std::string name = ControlsTabNames[t];
+		const int w = tLX->cFont.GetWidth(name);
+
+		ControlsTabRects[t].x = x;
+		ControlsTabRects[t].y = tabY;
+		ControlsTabRects[t].w = w;
+		ControlsTabRects[t].h = h;
+
+		const bool active = (t == ControlsSubTab);
+		tLX->cFont.Draw(dest, x, tabY, active ? tLX->clHeading : tLX->clNormalLabel, name);
+		if(active)
+			DrawRectFill(dest, x, tabY + h + 1, x + w, tabY + h + 2, tLX->clHeading);
+
+		x += w + gap;
+	}
+}
+
+///////////////////
+// Draws the "Reset defaults" button (a bordered text button, so it can show
+// that exact label) and records its hit-box in ResetBtnRect.
+static void Menu_OptionsDrawResetButton(SDL_Surface* dest)
+{
+	mouse_t* Mouse = GetMouse();
+	const std::string text = "Reset defaults";
+	const int textW = tLX->cFont.GetWidth(text);
+	const int h = 18;
+	// Left-aligned under the action-name column (same x as "Up", "Down", ...).
+	const int x = kControlLabelX;
+	const int y = 440;
+
+	ResetBtnRect.x = x;
+	ResetBtnRect.y = y;
+	ResetBtnRect.w = textW;
+	ResetBtnRect.h = h;
+
+	// No border: match the borderless clickable text used by the sub-tabs.
+	// A hover colour change signals it is clickable.
+	const bool hover = (Mouse->X >= x && Mouse->X <= x + textW && Mouse->Y >= y && Mouse->Y <= y + h);
+	tLX->cFont.Draw(dest, x, y + 3, hover ? tLX->clHeading : tLX->clNormalLabel, text);
+}
+
+///////////////////
+// Restore a whole control section (Ply1Controls / Ply2Controls /
+// GeneralControls) to its registered default values.
+static void Menu_ResetControlSection(const std::string& prefix)
+{
+	for(CScriptableVars::const_iterator it = CScriptableVars::lower_bound(prefix);
+	    it != CScriptableVars::end(); ++it) {
+		if(!strStartsWith(it->first, prefix)) break;
+		it->second.var.setDefault();
+	}
+}
+
+// Update the per-slot input boxes of one control row to match the given value.
+static void Menu_RefreshControlRow(CGuiLayout& layout, int baseId, const std::string& full)
+{
+	for(int s = 0; s < kControlSlots; s++) {
+		CWidget* w = layout.getWidget(baseId + s * kSlotIdStride);
+		if(w && w->getType() == wid_Inputbox)
+			((CInputbox*)w)->setText(Menu_ControlSlotText(full, s));
+	}
+}
+
+// Reset the currently shown Controls sub-tab to its defaults and refresh boxes.
+static void Menu_ResetControlsTab(int tab)
+{
+	if(tab == ct_General) {
+		Menu_ResetControlSection("GameOptions.GeneralControls.");
+		for(int g = 0; g < kNumGeneralControls; g++)
+			Menu_RefreshControlRow(cOpt_ControlsGen, GeneralControlsList[g].id,
+			                       tLXOptions->sGeneralControls[GeneralControlsList[g].sin]);
+	} else {
+		const int ply = (tab == ct_Player2) ? 1 : 0;
+		Menu_ResetControlSection(ply == 0 ? "GameOptions.Ply1Controls." : "GameOptions.Ply2Controls.");
+		CGuiLayout& layout = (ply == 0) ? cOpt_Controls : cOpt_Controls2;
+		const int baseId = (ply == 0) ? oc_Ply1_Up : oc_Ply2_Up;
+		for(int i = 0; i < 9; i++)
+			Menu_RefreshControlRow(layout, baseId + i, tLXOptions->sPlayerControls[ply][SIN_UP + i]);
+	}
+	tLX->setupInputs();
+}
+
+///////////////////
 // Options main frame
 void Menu_OptionsFrame()
 {
@@ -540,9 +721,35 @@ void Menu_OptionsFrame()
 
 	if(OptionsMode == 0) {
 
-		// Controls
-		ev = bSpeedTest ? NULL : cOpt_Controls.Process();
-		cOpt_Controls.Draw(VideoPostProcessor::videoSurface().get());
+		// Sub-tabs: Player 1 / Player 2 / General — only one shown at a time
+		Menu_OptionsDrawControlsTabs(VideoPostProcessor::videoSurface().get());
+		if(!bSpeedTest && Mouse->Up) {
+			for(int t = 0; t < ct__Count; t++) {
+				if(t == ControlsSubTab) continue;
+				const SDL_Rect& r = ControlsTabRects[t];
+				if(Mouse->X >= r.x && Mouse->X <= r.x + r.w && Mouse->Y >= r.y && Mouse->Y <= r.y + r.h) {
+					ControlsSubTab = t;
+					// Clear the old sub-tab's widgets from the screen
+					DrawImageAdv(VideoPostProcessor::videoSurface().get(), tMenu->bmpBuffer, 20,140, 20,140, 620,340);
+					PlaySoundSample(sfxGeneral.smpClick);
+					break;
+				}
+			}
+		}
+
+		// Active sub-tab content
+		CGuiLayout& ctrlLayout = Menu_OptionsControlsLayout();
+		ev = bSpeedTest ? NULL : ctrlLayout.Process();
+		ctrlLayout.Draw(VideoPostProcessor::videoSurface().get());
+
+		// "Reset defaults" button (manual, so it can show that exact label)
+		Menu_OptionsDrawResetButton(VideoPostProcessor::videoSurface().get());
+		if(!bSpeedTest && Mouse->Up &&
+		   Mouse->X >= ResetBtnRect.x && Mouse->X <= ResetBtnRect.x + ResetBtnRect.w &&
+		   Mouse->Y >= ResetBtnRect.y && Mouse->Y <= ResetBtnRect.y + ResetBtnRect.h) {
+			Menu_ResetControlsTab(ControlsSubTab);
+			PlaySoundSample(sfxGeneral.smpClick);
+		}
 
 		if(ev) {
 
@@ -550,11 +757,8 @@ void Menu_OptionsFrame()
 
 				if(ev->iEventMsg == INB_MOUSEUP) {
 
-					int ply = 0;
-					if(ev->iControlID >= oc_Ply2_Up && ev->iControlID <= oc_Ply2_Strafe)
-						ply = 1;
-					if(ev->iControlID >= oc_Gen_Chat)
-						ply = -1;
+					// 0 = Player 1, 1 = Player 2, -1 = general controls
+					int ply = (ControlsSubTab == ct_General) ? -1 : ControlsSubTab;
 
 					// Get an input
 					CInputbox *b = (CInputbox *)ev->cWidget;
@@ -912,7 +1116,8 @@ void Menu_OptionsWaitInput(int ply, const std::string& name, CInputbox *b)
 
 	// Draw the back buffer
 	cOptions.Draw(tMenu->bmpBuffer.get());
-	cOpt_Controls.Draw(tMenu->bmpBuffer.get());
+	Menu_OptionsControlsLayout().Draw(tMenu->bmpBuffer.get());
+	Menu_OptionsDrawControlsTabs(tMenu->bmpBuffer.get());
 
 	Menu_DrawBox(tMenu->bmpBuffer.get(), 210, 170, 430, 310);
 	//DrawImageAdv(tMenu->bmpBuffer, tMenu->bmpMainBack, 212,172, 212,172, 217,137);
@@ -960,11 +1165,15 @@ void Menu_OptionsWaitInput(int ply, const std::string& name, CInputbox *b)
 	}
 	CInput::UnInitJoysticksTemp();
 
-	// Change the options
+	// Change the options. The box only edits its own binding slot, so merge
+	// the captured input back into the control's comma-separated value.
 	if(ply >= 0) {
-		tLXOptions->sPlayerControls[ply][b->getValue()] = b->getText();
-	} else
-		tLXOptions->sGeneralControls[b->getValue()] = b->getText();
+		std::string& ctrl = tLXOptions->sPlayerControls[ply][b->getValue()];
+		ctrl = Menu_ControlSetSlot(ctrl, b->getSlot(), b->getText());
+	} else {
+		std::string& ctrl = tLXOptions->sGeneralControls[b->getValue()];
+		ctrl = Menu_ControlSetSlot(ctrl, b->getSlot(), b->getText());
+	}
 
 	// Disable quick weapon selection keys if they collide with other keys
 	for( uint ply1 = 0; ply1 < tLXOptions->sPlayerControls.size(); ply1 ++ )
@@ -1003,6 +1212,8 @@ void Menu_OptionsShutdown()
 {
 	cOptions.Shutdown();
 	cOpt_Controls.Shutdown();
+	cOpt_Controls2.Shutdown();
+	cOpt_ControlsGen.Shutdown();
 	cOpt_System.Shutdown();
 	cOpt_Game.Shutdown();
 

--- a/src/client/InputEvents.cpp
+++ b/src/client/InputEvents.cpp
@@ -140,74 +140,18 @@ static void ResetCInputs() {
 }
 
 void HandleCInputs_KeyEvent(const KeyboardEvent& ev) {
-	for(std::set<CInput*>::iterator it = cInputs.begin(); it != cInputs.end(); it++) {
-		if(!(*it)->isKeyboard() || (*it)->getData() != ev.sym)
-			continue;
-		// If the binding requires specific modifiers, enforce an exact match.
-		// If no modifiers are required, fire regardless of modifier state (backward compat).
-		const ModifiersState& req = (*it)->m_modifiers;
-		if(req.bAlt || req.bCtrl || req.bShift || req.bGui) {
-			if(req.bAlt   != ev.state.bAlt)   continue;
-			if(req.bCtrl  != ev.state.bCtrl)  continue;
-			if(req.bShift != ev.state.bShift) continue;
-			if(req.bGui   != ev.state.bGui)   continue;
-		}
-		if(ev.down) {
-			(*it)->nDown++;
-			if(!(*it)->bDown) {
-				(*it)->nDownOnce++;
-				(*it)->bDown = true;
-			}
-		} else {
-			(*it)->bDown = false;
-			(*it)->nUp++;
-		}
-	}
+	for(std::set<CInput*>::iterator it = cInputs.begin(); it != cInputs.end(); it++)
+		(*it)->handleKeyEvent(ev);
 }
 
 void HandleCInputs_UpdateDownOnceForNonKeyboard() {
 	for(std::set<CInput*>::iterator it = cInputs.begin(); it != cInputs.end(); it++)
-		if((*it)->isUsed() && !(*it)->isKeyboard()) {
-			// HINT: It is possible that wasUp() and !Down (a case which is not covered in further code)
-			if((*it)->wasUp() && !(*it)->bDown) {
-				(*it)->nDownOnce++;
-				continue;
-			}
-
-			// HINT: It's possible that wasDown() > 0 and !isDown().
-			// That is the case when we press a key and release it directly after (in one frame).
-			// Though wasDown() > 0 doesn't mean directly isDownOnce because it also counts keypresses.
-			// HINT: It's also possible that wasDown() == 0 and isDown().
-			// That is the case when we have pressed the key in a previous frame and we still hold it
-			// and the keyrepeat-interval is bigger than FPS. (Rare case.)
-			if((*it)->wasDown() || (*it)->isDown()) {
-				// wasUp() > 0 always means that it was down once (though it is not down anymore).
-				// Though the released key in wasUp() > 0 was probably already recognised before.
-				if((*it)->wasUp()) {
-					(*it)->bDown = (*it)->isDown();
-					if((*it)->bDown) // if it is again down, there is another new press
-						(*it)->nDownOnce++;
-					continue;
-				}
-				// !Down means that we haven't recognised yet that it is down.
-				if(!(*it)->bDown) {
-					(*it)->bDown = (*it)->isDown();
-					(*it)->nDownOnce++;
-					continue;
-				}
-			}
-			else
-				(*it)->bDown = false;
-		}
+		(*it)->updateDownOnceForNonKeyboard();
 }
 
 void HandleCInputs_UpdateUpForNonKeyboard() {
 	for(std::set<CInput*>::iterator it = cInputs.begin(); it != cInputs.end(); it++)
-		if((*it)->isUsed() && !(*it)->isKeyboard()) {
-			if((*it)->isDown() && !(*it)->bDown) {
-				(*it)->nUp++;
-			}
-		}
+		(*it)->updateUpForNonKeyboard();
 }
 
 static void ResetCurrentEventStorage() {
@@ -415,6 +359,22 @@ static void EvHndl_ControllerDeviceRemoved(SDL_Event* ev) {
 	CInput::OnControllerRemoved(ev->cdevice.which);
 }
 
+static void EvHndl_ControllerButton(SDL_Event* ev) {
+	// The START button on any controller mirrors the Escape key, so it
+	// opens/closes the in-game menu (and acts as Escape elsewhere) exactly
+	// like the keyboard. We synthesize a matching Escape key event rather
+	// than special-casing the menu, so every Escape-driven behaviour stays
+	// in sync automatically.
+	if(ev->cbutton.button != SDL_CONTROLLER_BUTTON_START)
+		return;
+	KeyboardEvent kbev;
+	kbev.sym = SDLK_ESCAPE;
+	kbev.ch = 0;
+	kbev.down = (ev->type == SDL_CONTROLLERBUTTONDOWN);
+	kbev.state = evtModifiersState;
+	pushKeyboardEv(kbev);
+}
+
 void InitEventSystem() {	
 	Mouse.Button = 0;
 	Mouse.Down = 0;
@@ -433,6 +393,8 @@ void InitEventSystem() {
 	sdlEvents[SDL_USEREVENT].handler() = getEventHandler(&EvHndl_UserEvent);
 	sdlEvents[SDL_CONTROLLERDEVICEADDED  ].handler() = getEventHandler(&EvHndl_ControllerDeviceAdded);
 	sdlEvents[SDL_CONTROLLERDEVICEREMOVED].handler() = getEventHandler(&EvHndl_ControllerDeviceRemoved);
+	sdlEvents[SDL_CONTROLLERBUTTONDOWN   ].handler() = getEventHandler(&EvHndl_ControllerButton);
+	sdlEvents[SDL_CONTROLLERBUTTONUP     ].handler() = getEventHandler(&EvHndl_ControllerButton);
 	// Note: SDL_SYSWMEVENT is handled directly on the main thread by handleSDLEvents().
 	
 	bEventSystemInited = true;

--- a/src/client/Options.cpp
+++ b/src/client/Options.cpp
@@ -48,12 +48,39 @@ const std::string    ply_def1[] =
 	{"up", "down", "left", "right", "lctrl", "lalt", "lshift", "x", "z", "1", "2", "3", "4", "5" };
 #endif
 const std::string    ply_def2[] = {"kp 8",  "kp 5",    "kp 4",    "kp 6",     "kp +", "kp enter", "kp 0", "kp -", "kp .", "6", "7", "8", "9", "0" };
+// Gamepad defaults, in the same order as ply_keys. These are bound as a
+// second alternative alongside the keyboard defaults above, so each control
+// works from either input out of the box. The pad index is added at
+// registration time (j1 for player 1, j2 for player 2).
+// Movement and aiming are on the d-pad (digital); weapons are intentionally
+// left keyboard-only (you cycle them on the pad with SelectWeapon). Empty
+// string means "no gamepad binding for this control". Note we deliberately
+// avoid the right-stick-Y "throttle" axes here: those switch the worm to
+// analog aiming, which would override the keyboard's digital aiming when both
+// are bound to one control.
+const std::string    ply_gamepad_def[] = {
+	"d_up",         // Up           - d-pad up (aim up)
+	"d_down",       // Down         - d-pad down (aim down)
+	"d_left",       // Left         - d-pad left (move left)
+	"d_right",      // Right        - d-pad right (move right)
+	"triggerright", // Shoot        - right trigger
+	"button_south", // Jump         - A
+	"lshoulder",    // SelectWeapon - left shoulder
+	"button_north", // Rope         - Y
+	"button_east",  // Strafe       - B
+	"",             // Weapon1      - keyboard only
+	"",             // Weapon2      - keyboard only
+	"",             // Weapon3      - keyboard only
+	"",             // Weapon4      - keyboard only
+	"",             // Weapon5      - keyboard only
+};
 const std::string    gen_keys[] = {"Chat", "ShowScore", "ShowHealth", "ShowSettings",  "TakeScreenshot",  "ViewportManager", "SwitchMode", "ToggleTopBar", "TeamChat",	"IrcChat", "Console"};
 const std::string    gen_def[]  = {"i",    "tab",		"h",		  "space",	       "F12",				"F2",				 "alt+enter", "F8",		   "o",			"F4",	"F3"};
 
 static_assert( sizeof(ply_keys) / sizeof(std::string) == __SIN_PLY_BOTTOM, "ply_keys__sizecheck" );
 static_assert( sizeof(ply_def1) / sizeof(std::string) == __SIN_PLY_BOTTOM, "ply_def1__sizecheck" );
 static_assert( sizeof(ply_def2) / sizeof(std::string) == __SIN_PLY_BOTTOM, "ply_def2__sizecheck" );
+static_assert( sizeof(ply_gamepad_def) / sizeof(std::string) == __SIN_PLY_BOTTOM, "ply_gamepad_def__sizecheck" );
 static_assert( sizeof(gen_keys) / sizeof(std::string) == __SIN_GENERAL_BOTTOM, "gen_keys__sizecheck" );
 static_assert( sizeof(gen_def) / sizeof(std::string) == __SIN_GENERAL_BOTTOM, "gen_def__sizecheck" );
 
@@ -255,8 +282,17 @@ bool GameOptions::Init() {
 
 	for( uint i = 0; i < sizeof(ply_keys) / sizeof(ply_keys[0]) ; i ++ )
 	{
-		CScriptableVars::RegisterVars("GameOptions.Ply1Controls") ( tLXOptions->sPlayerControls[0][i], ply_keys[i], ply_def1[i] );
-		CScriptableVars::RegisterVars("GameOptions.Ply2Controls") ( tLXOptions->sPlayerControls[1][i], ply_keys[i], ply_def2[i] );
+		// Default to keyboard (slot 1) plus a gamepad binding (slot 2).
+		// Player 1 uses pad j1, player 2 uses pad j2. Controls with no
+		// gamepad default (empty suffix, e.g. weapon select) stay keyboard-only.
+		std::string def1 = ply_def1[i];
+		std::string def2 = ply_def2[i];
+		if( !ply_gamepad_def[i].empty() ) {
+			def1 += ", j1_" + ply_gamepad_def[i];
+			def2 += ", j2_" + ply_gamepad_def[i];
+		}
+		CScriptableVars::RegisterVars("GameOptions.Ply1Controls") ( tLXOptions->sPlayerControls[0][i], ply_keys[i], def1 );
+		CScriptableVars::RegisterVars("GameOptions.Ply2Controls") ( tLXOptions->sPlayerControls[1][i], ply_keys[i], def2 );
 	}
 	for( uint i = 0; i < sizeof(gen_keys) / sizeof(gen_keys[0]) ; i ++ )
 	{

--- a/src/common/CWorm.cpp
+++ b/src/common/CWorm.cpp
@@ -1489,20 +1489,21 @@ bool CWorm::CanType()
 bool CWormHumanInputHandler::canType() {
 	keyboard_t* kb = GetKeyboard();
 	for (int i = 0; i < kb->queueLength; i++)  {
-		if (cUp.getData() == kb->keyQueue[i].sym ||
-			cDown.getData() == kb->keyQueue[i].sym ||
-			cLeft.getData() == kb->keyQueue[i].sym ||
-			cRight.getData() == kb->keyQueue[i].sym ||
-			cShoot.getData() == kb->keyQueue[i].sym ||
-			cJump.getData() == kb->keyQueue[i].sym ||
-			cSelWeapon.getData() == kb->keyQueue[i].sym ||
-			cInpRope.getData() == kb->keyQueue[i].sym ||
-			cStrafe.getData() == kb->keyQueue[i].sym ||
-			cWeapons[0].getData() == kb->keyQueue[i].sym ||
-			cWeapons[1].getData() == kb->keyQueue[i].sym ||
-			cWeapons[2].getData() == kb->keyQueue[i].sym ||
-			cWeapons[3].getData() == kb->keyQueue[i].sym ||
-			cWeapons[4].getData() == kb->keyQueue[i].sym)
+		const int sym = kb->keyQueue[i].sym;
+		if (cUp.usesKeyboardKey(sym) ||
+			cDown.usesKeyboardKey(sym) ||
+			cLeft.usesKeyboardKey(sym) ||
+			cRight.usesKeyboardKey(sym) ||
+			cShoot.usesKeyboardKey(sym) ||
+			cJump.usesKeyboardKey(sym) ||
+			cSelWeapon.usesKeyboardKey(sym) ||
+			cInpRope.usesKeyboardKey(sym) ||
+			cStrafe.usesKeyboardKey(sym) ||
+			cWeapons[0].usesKeyboardKey(sym) ||
+			cWeapons[1].usesKeyboardKey(sym) ||
+			cWeapons[2].usesKeyboardKey(sym) ||
+			cWeapons[3].usesKeyboardKey(sym) ||
+			cWeapons[4].usesKeyboardKey(sym))
 			return false;
 	}
 	return true;

--- a/src/common/CWormHuman.cpp
+++ b/src/common/CWormHuman.cpp
@@ -256,7 +256,7 @@ void CWormHumanInputHandler::getInput() {
 		const float carveDelay = 0.2f;
 
 		if(		(mouseControl && ws->bMove && m_worm->iMoveDirectionSide == DIR_LEFT)
-			||	( ( (cLeft.isJoystick() && cLeft.isDown()) /*|| (cLeft.isKeyboard() && leftOnce)*/ ) && !cSelWeapon.isDown())
+			||	( cLeft.isJoystickDown() /*|| (cLeft.isKeyboard() && leftOnce)*/ && !cSelWeapon.isDown())
 			) {
 
 			if(tLX->currentTime - m_worm->fLastCarve >= carveDelay) {
@@ -267,7 +267,7 @@ void CWormHumanInputHandler::getInput() {
 		}
 
 		if(		(mouseControl && ws->bMove && m_worm->iMoveDirectionSide == DIR_RIGHT)
-			||	( ( (cRight.isJoystick() && cRight.isDown()) /*|| (cRight.isKeyboard() && rightOnce)*/ ) && !cSelWeapon.isDown())
+			||	( cRight.isJoystickDown() /*|| (cRight.isKeyboard() && rightOnce)*/ && !cSelWeapon.isDown())
 			) {
 
 			if(tLX->currentTime - m_worm->fLastCarve >= carveDelay) {
@@ -297,7 +297,7 @@ void CWormHumanInputHandler::getInput() {
 			MOD(m_worm->iCurrentWeapon, m_worm->getWeaponSlotsCount());
 
 			// Joystick: if the button is pressed, change the weapon (it is annoying to move the axis for weapon changing)
-			if (cSelWeapon.isJoystick() && change == 0 && cSelWeapon.isDownOnce())  {
+			if (change == 0 && cSelWeapon.isJoystickDownOnce())  {
 				m_worm->iCurrentWeapon++;
 				MOD(m_worm->iCurrentWeapon, m_worm->getWeaponSlotsCount());
 			}


### PR DESCRIPTION
Each action can now have multiple configurations. This is used for having the first one for Keyboard and the second one for Gamepad by default

https://github.com/user-attachments/assets/6167c7ab-45b6-416c-9fab-9c8b6c215e5f


Keyboard works still exactly like it did before

The input configuration in options.cfg can now be a single item, or an array:

Example:
```
[Ply1Controls]
Up = up, j1_d_up
Down = down, j1_d_down
Left = left, j1_d_left
Right = right, j1_d_right
Shoot = lctrl, j1_triggerright
Jump = lalt, j1_button_south
SelectWeapon = lshift, j1_lshoulder
Rope = x, j1_button_north
Strafe = z, j1_button_east
Weapon1 = 1
Weapon2 = 2
Weapon3 = 3
Weapon4 = 4
Weapon5 = 5
```

This is currently the default configuration for gamepad which is what I play with. It could be argued which is the best "keybinding" of course

```
const std::string    ply_gamepad_def[] = {
	"d_up",         // Up           - d-pad up (aim up)
	"d_down",       // Down         - d-pad down (aim down)
	"d_left",       // Left         - d-pad left (move left)
	"d_right",      // Right        - d-pad right (move right)
	"triggerright", // Shoot        - right trigger
	"button_south", // Jump         - A
	"lshoulder",    // SelectWeapon - left shoulder
	"button_north", // Rope         - Y
	"button_east",  // Strafe       - B
	"",             // Weapon1      - keyboard only
	"",             // Weapon2      - keyboard only
	"",             // Weapon3      - keyboard only
	"",             // Weapon4      - keyboard only
	"",             // Weapon5      - keyboard only
};
```