### PR TITLE
Exclude Android from github beta release (since it is handled by Google Play)

### DIFF
--- a/.github/workflows/package-android.yml
+++ b/.github/workflows/package-android.yml
@@ -2,8 +2,10 @@ name: Build Android
 
 on:
   pull_request:
-  # Reusable: invoked by release-beta.yml on merges to master/0.59.
-  workflow_call:
+  push:
+    branches:
+      - master
+      - 0.59
 
 jobs:
   build-android:

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -16,10 +16,6 @@ permissions:
 jobs:
   # Reuse the existing build pipelines. secrets: inherit lets the Android
   # job reach the signing / Play Store secrets just like before.
-  android:
-    uses: ./.github/workflows/package-android.yml
-    secrets: inherit
-
   linux-bundle:
     uses: ./.github/workflows/package-linux-bundle.yml
     secrets: inherit


### PR DESCRIPTION
Exclude android from github beta release, since it is handled by Google Play