### PR TITLE
Fix broken preview beta pipeline attempt 2

### DIFF
--- a/.github/workflows/package-linux-deb.yml
+++ b/.github/workflows/package-linux-deb.yml
@@ -46,5 +46,4 @@ jobs:
         with:
           name: ${{ steps.bundle.outputs.name }}
           path: openlierox_*.deb
-          archive: false
           if-no-files-found: error


### PR DESCRIPTION
The .deb upload used archive: false, which stores the artifact uncompressed. actions/download-artifact@v7 (with merge-multiple) fails to fetch such an artifact and gives up after 5 retries, failing the whole "Publish beta release" job.

The internal artifact zip is transparent: download-artifact extracts it, so the release still gets the raw .deb. Drop archive: false to match the other three package workflows.