### PR TITLE
Fix Android beta release pipeline

### DIFF
--- a/.github/workflows/package-android.yml
+++ b/.github/workflows/package-android.yml
@@ -108,7 +108,6 @@ jobs:
         with:
           name: ${{ steps.apk.outputs.name }}
           path: build/android/output/openlierox-*-android.apk
-          archive: false
           if-no-files-found: error
 
       - name: Publish to Play Store


### PR DESCRIPTION
## Problem

Re-adding Android to the beta-release pipeline (#908) produced a failing release job: the Android artifact failed to download while all other platforms succeeded.

In [the failing run](https://github.com/openlierox/openlierox/actions/runs/27305750343/job/80667789310):

```
Unable to download artifact(s): Unable to download and extract artifact:
Artifact download failed after 5 retries.
```

## Root cause

The Android upload step used `archive: false`, storing the APK as a raw, unarchived blob. `download-artifact@v7` can't download/extract it (its storage redirect URL has no `.zip` suffix, unlike every other artifact), whereas all the zipped artifacts download fine.

## Fix

Drop `archive: false` from the Android `upload-artifact` step so the APK is uploaded as a normal (zipped) artifact, like every other platform. The final published release asset is unchanged: `download-artifact` with `merge-multiple: true` extracts the zip into `dist/openlierox-…-android.apk`, and the publish loop attaches that `.apk` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)