### PR TITLE
Support widescreen for local games

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build/msvc*/obj
 build/msvc*/Debug
 build/msvc*/Release
 build/Xcode/build
+build/cmake
 *.ncb
 *.suo
 *.vcproj.*.user
@@ -59,3 +60,4 @@ distrib
 build/android/deps
 build/android/output/
 *.claude
+CLAUDE.md

--- a/doc/dev/WIDESCREEN.md
+++ b/doc/dev/WIDESCREEN.md
@@ -1,0 +1,207 @@
+# Widescreen support
+
+OpenLieroX was historically hardcoded to a 640×480 render surface. This
+feature makes the render resolution adapt to the user's display aspect ratio
+while keeping gameplay fair and the (640-authored) UI usable.
+
+Branch: `support-widescreen` (off `0.59`).
+
+## Goals & rules
+
+- **Height stays 480.** Only the *width* varies.
+- **Width adapts to the desktop aspect ratio** at startup (e.g. 854 on 16:9).
+- **Local games use the full width** (the player sees more of the battlefield).
+- **Network games are constrained to 640** so that a wider screen gives **no
+  gameplay advantage** — everyone sees the same amount of the world.
+- **Menus and in-game popups are authored for 640** and are presented
+  **centered** on wider screens, with black bars on the sides.
+
+## Core concepts (VideoPostProcessor — `include/AuxLib.h`)
+
+All of the widescreen logic hangs off a few accessors on `VideoPostProcessor`
+(`get()` is the singleton):
+
+| Accessor | Meaning |
+| --- | --- |
+| `screenWidth()` | The real render-surface / window width (from the aspect ratio). `m_screenWidth`, default 640. |
+| `screenHeight()` | Always 480. |
+| `menuWidth` | The base width the UI is authored for: **640**. The width menus and network games are constrained to. |
+| `displayScreenWidth()` | **The single source of truth** for the current frame's layout width: `screenWidth()` for widescreen games, `menuWidth` (640) for menus and non-widescreen games. Set per-frame by the draw code. |
+
+Whether a game uses widescreen is decided by one function,
+`Game::useWideScreen()` (`src/game/Game.h`) — currently `return isLocalGame();`
+but the intended single place to later also allow widescreen for network games
+where every player runs widescreen.
+| `displayScreenOffsetX()` | `(screenWidth() − displayScreenWidth()) / 2`, clamped ≥0. The offset that centers the displayed view. 0 for a full-width local game. |
+| `popupCenterOffsetX()` | `(displayScreenWidth() − menuWidth) / 2`, clamped ≥0. The offset to center a 640-wide popup *within* the current view. 107 for a full-width local game on 854; 0 for a network game (already centered). |
+
+### Width computation
+
+`VideoPostProcessor::initWindow()` (`src/client/AuxLib.cpp`) calls
+`SDL_GetDesktopDisplayMode(0, …)` just before `SDL_CreateWindow` and sets
+`m_screenWidth = round(screenHeight() * desktop_w / desktop_h)`, snapped up to
+the nearest even number, floored at 320. Falls back to 640 if SDL fails.
+
+Examples: 4:3 → 640, 16:10 → 768, 16:9 → 854. A `desktop mode: WxH -> using
+WxH` line is logged so you can confirm the result.
+
+### Centered presentation (letterbox)
+
+`VideoPostProcessor::render()` (`src/client/AuxLib.cpp`) presents the video
+surface to the screen. When `displayScreenOffsetX() > 0` (i.e. the content is
+narrower than the screen) it copies only the **left `displayScreenWidth`
+columns** of the surface into a horizontally-centered destination rect, leaving
+black bars on the sides. Otherwise it does a normal full-surface copy.
+
+So menus and network games **render into the left part of the surface exactly
+as if the screen were 640** and are simply *presented* centered — none of the
+hundreds of 640-hardcoded UI draw sites had to change.
+
+### Input offset
+
+Because the content is presented shifted, input must be shifted back:
+
+- **Mouse** — `HandleMouseState()` (`src/client/InputEvents.cpp`) subtracts
+  `displayScreenOffsetX()` from `Mouse.X`.
+- **Touch / mouse-synth** — see the Touch section below.
+
+When `displayScreenWidth() == screenWidth()` (local game) the offset is 0, so
+nothing changes.
+
+## Who sets `displayScreenWidth()`
+
+It is pushed in per-frame, by whoever owns the screen that frame:
+
+- **Menus** — `Menu_Frame()` (`src/client/DeprecatedGUI/MenuSystem.cpp`) sets it
+  to `menuWidth` (640).
+- **Gameplay** — `CClient::Draw()` (`src/client/CClient_Draw.cpp`) sets it to
+  `screenWidth()` when `game.useWideScreen()`, else `menuWidth`.
+- **Game start** — `CClient::SetupViewports()` (`src/client/CClient.cpp`) sets
+  it the same way up front, then sizes the viewports from
+  `displayScreenWidth()` (single viewport = full width; split-screen = two
+  halves separated by a 4px gap).
+
+(Two UI helpers that used to center against the full screen were reverted to
+center against `menuWidth` so they fit inside the presented view:
+`Menu_DrawSubTitle`/`Menu_DrawSubTitleAdv`, `Menu_MessageBox`, and the server
+info popups in `Menu_Net_{Internet,Lan,Favourites}.cpp`.)
+
+## In-game popups
+
+Popups that overlay a running game (the Esc menu, in-game chat, …) are 640-wide
+and were left-aligned on a wide local game. They are kept as overlays on the
+**unchanged full-width game** and only the popup itself is centered, shifted by
+`popupCenterOffsetX()`.
+
+Helpers added for this:
+
+- `CWidget::move(dx, dy)` (`include/DeprecatedGUI/CWidget.h`)
+- `CGuiLayout::moveWidgets(dx, dy)` (`src/client/DeprecatedGUI/CGuiLayout.cpp`)
+  — shifts every widget in a layout in one call.
+
+Applied at:
+
+- **Esc game menu** — `CClient::InitializeGameMenu()` calls
+  `cGameMenuLayout.moveWidgets(popupCenterOffsetX(), 0)` after building it, and
+  `CClient::DrawGameMenu()` offsets its background bitmap by the same amount.
+- **In-game chat** — `CChatWidget::GlobalProcessAndDraw()` adds
+  `popupCenterOffsetX()` to its setup X.
+
+Mouse hit-testing lines up automatically: in a local game the widgets are moved
+by +107 and the mouse is in full-screen (854) space; in a network game the
+widgets are not moved (offset 0) and the mouse is already shifted into 640
+space by `displayScreenOffsetX()`.
+
+> **TODO:** the in-game **Options** panel (`Menu_FloatingOptions`, reached via
+> Esc → Options) is not yet centered — it has a near-full-width panel, several
+> sub-layouts and many direct draws plus the shared `Menu_DrawSubTitle`, so it
+> needs more careful offsetting.
+
+## Touch controls (`src/client/TouchControls.cpp`)
+
+The on-screen touch layout adapts to the displayed view too.
+
+- **Coordinate space = `displayScreenWidth()`** (not `screenWidth()`). So touch
+  buttons render into and are hit-tested against the same view the HUD uses:
+  full width for a local game, 640 (centered) for a network game, and 640 for
+  the options-menu preview. This is what makes the controls appear *inside* the
+  centered network-game view instead of in the clipped area.
+- **Finger input** — `HandleFingerEvent()` maps the normalized SDL finger
+  coords by `screenWidth()` and then subtracts `displayScreenOffsetX()` so the
+  touch lands in the displayed view's space.
+- **Mouse→touch bridge** — desktop play without a touchscreen synthesizes
+  finger events from the mouse (`synthFingerFromMouse`,
+  `src/client/InputEvents.cpp`); it normalizes by `screenWidth()`/
+  `screenHeight()` (the mouse already arrives in logical space).
+- **Minimap override** — the touch layout's minimap position is resolved
+  against `displayScreenWidth()` in `CClient::Draw()`.
+
+### Layout YAML: edge-relative coordinates
+
+Touch layouts live in `share/gamedir/touchscreen/*.yaml`. Button (and minimap)
+coordinates may be **negative** to anchor to the opposite edge, which is how a
+layout stays right/bottom-aligned regardless of screen width:
+
+- `x ≥ 0` — usual left origin (button's left edge at `x`).
+- `x < 0` — button's **right** edge sits `|x|` px from the screen's right edge.
+  Resolved as `canvasW + x − w` (`resolveButtonX`).
+- `y ≥ 0` — top origin; `y < 0` — bottom edge `|y|` px from the bottom.
+
+To convert a coordinate authored for 640 into a right-anchored one with the
+same on-screen position: `x_neg = x + w − 640`. (A button whose right edge is
+flush at 640 would compute to 0; give the column a small uniform margin
+instead — `classic.yaml` uses 5px.)
+
+`right-aligned.yaml` and `classic.yaml` have their action columns and minimaps
+converted to negative x.
+
+## Key files
+
+- `include/AuxLib.h` / `src/client/AuxLib.cpp` — `VideoPostProcessor`: width
+  computation, `displayScreenWidth`/offsets, `render()` letterbox.
+- `src/client/CClient.cpp` `SetupViewports` — viewport sizing.
+- `src/client/CClient_Draw.cpp` — gameplay draw sets `displayScreenWidth`;
+  game-menu + minimap popup centering.
+- `src/client/InputEvents.cpp` — mouse + mouse→touch offsetting.
+- `src/client/DeprecatedGUI/MenuSystem.cpp` — menu frame sets
+  `displayScreenWidth`; subtitle/message-box centering.
+- `src/client/TouchControls.cpp` — touch layout, display-relative mapping.
+- `include/DeprecatedGUI/CWidget.h`, `.../CGuiLayout.{h,cpp}` —
+  `move`/`moveWidgets`.
+- `share/gamedir/touchscreen/*.yaml` — touch layouts.
+
+## Build & run (Linux)
+
+```sh
+mkdir -p build/cmake && cd build/cmake
+cmake -DCMAKE_BUILD_TYPE=Release ../..
+make -j"$(nproc)"
+```
+
+Binary: `build/cmake/bin/openlierox`. Run from a dir containing the `data/`
+tree, otherwise font loading fails:
+
+```sh
+cd share/gamedir && /<repo>/build/cmake/bin/openlierox
+```
+
+(`build/CodeBlocks`, `build/msvc*`, `build/Xcode` are project files, not Linux
+build outputs — ignore them.)
+
+## Gotchas
+
+- `SetVideoMode` must run on the main thread; from other threads use
+  `doSetVideoModeInMainThread`.
+- `SDL_RenderSetLogicalSize` is set to `screenWidth() × screenHeight()` (when
+  `bKeepAspectRatio` is on), so the renderer scales the logical surface to the
+  window; the `render()` letterbox rects are in that logical space.
+- `CViewport::Setup(left, top, virtW, virtH, type)` renders the world at 2×
+  scale, so `Width = vw/2`, `Height = vh/2`.
+
+## Known remaining 640/480 assumptions (future work)
+
+- In-game **Options** popup centering (see TODO above).
+- HUD top/bottom bars and several HUD elements are still 640-wide bitmaps drawn
+  left-aligned in a full-width local game.
+- `src/common/CWormHuman.cpp` — `SDL_WarpMouseInWindow(NULL, 640/2, 480/2)`.
+- `src/common/MapLoader_Teeworlds.cpp` — `IVec size(640,480)` minimum viewport.

--- a/include/AuxLib.h
+++ b/include/AuxLib.h
@@ -77,6 +77,15 @@ protected:
 	SmartPointer<SDL_Texture> m_videoTexture;
 	SmartPointer<SDL_Surface> m_videoSurface;
 	SmartPointer<SDL_Surface> m_videoBufferSurface;
+	int m_screenWidth = 640;
+	// The width the current frame's content is laid out for. Either the full
+	// screenWidth() (local games) or the base menuWidth / 640 (menus and
+	// network games, so a wider screen gives no gameplay advantage). When it is
+	// narrower than screenWidth() the content is drawn into the left columns
+	// and presented horizontally centered, with black bars on the sides.
+	// Set per-frame by the menu / gameplay draw. See render() and the mouse
+	// handling, and displayScreenWidth()/displayScreenOffsetX() below.
+	int m_displayScreenWidth = 640;
 	static VideoPostProcessor instance;
 	
 public:
@@ -97,8 +106,31 @@ public:
 	bool initWindow();
 	bool resetVideo(); // this is called from SetVideoMode
 	
-	int screenWidth() { return 640; }
-	int screenHeight() { return 480; }
+	int screenWidth() const { return m_screenWidth; }
+	int screenHeight() const { return 480; }
+
+	// The base view width: what menus are authored for, and the width network
+	// games are constrained to. The actual screen may be wider (computed from
+	// the desktop aspect ratio); such content stays this wide and is centered.
+	// Height always matches screenHeight().
+	static const int menuWidth = 640;
+
+	// The effective layout width for the current frame (see m_displayScreenWidth).
+	// All screen-width-dependent logic (viewport setup, centering, mouse) should
+	// use this instead of screenWidth() so local vs network games behave right.
+	void setDisplayScreenWidth(int w) { m_displayScreenWidth = w; }
+	int displayScreenWidth() const { return m_displayScreenWidth; }
+
+	// Horizontal offset that centers a displayScreenWidth()-wide view on the
+	// screen. Zero when the view already fills the screen (local game, or 4:3).
+	int displayScreenOffsetX() const { int o = (m_screenWidth - m_displayScreenWidth) / 2; return o > 0 ? o : 0; }
+
+	// Horizontal offset to center a menuWidth-wide popup (the in-game Esc menu,
+	// in-game options, ...) within the current view, so it overlays the
+	// unchanged game centered. Zero for a network game (the whole view is
+	// already presented centered); (screenWidth-menuWidth)/2 for a full-width
+	// local game.
+	int popupCenterOffsetX() const { int o = (m_displayScreenWidth - menuWidth) / 2; return o > 0 ? o : 0; }
 
 	static const SmartPointer<SDL_Surface>& videoSurface() { return get()->m_videoSurface; }
 	static const SmartPointer<SDL_Surface>& videoBufferSurface() { return get()->m_videoBufferSurface; }

--- a/include/DeprecatedGUI/CGuiLayout.h
+++ b/include/DeprecatedGUI/CGuiLayout.h
@@ -121,6 +121,9 @@ public:
 
 	gui_event_t	*Process();
 	void		Draw(SDL_Surface * bmpDest);
+	// Shift every widget by (dx,dy). Used to center an in-game popup layout
+	// on a wider-than-640 screen (see VideoPostProcessor::popupCenterOffsetX).
+	void		moveWidgets(int dx, int dy);
 
 	void		Shutdown();
 

--- a/include/DeprecatedGUI/CWidget.h
+++ b/include/DeprecatedGUI/CWidget.h
@@ -127,6 +127,7 @@ public:
 
 	int				getX()							{ return iX; }
 	int				getY()							{ return iY; }
+	void			move(int dx, int dy)			{ iX += dx; iY += dy; }
 	int				getWidth()						{ return iWidth; }
 	int				getHeight()						{ return iHeight; }
 

--- a/share/gamedir/touchscreen/classic.yaml
+++ b/share/gamedir/touchscreen/classic.yaml
@@ -46,13 +46,13 @@ vjoy:
   walk_sensitivity: 40
   aim_sensitivity: 30.0
 
-# Minimap position (top-left, logical 640x480) while the touch UI is
-# visible. Right-aligned (640 - 128 = 512 for the default 128-wide
-# minimap) and pushed up to y=70 so its bottom (y=166) clears the
-# enlarged top row at y=180 with a small breathing gap.
+# Minimap position while the touch UI is visible. Negative x anchors it to
+# the right screen edge (so it tracks the right-aligned action column on
+# wider screens); the default minimap is 128 wide. y=70 (top origin) pushes
+# it up so its bottom (y=166) clears the enlarged top row at y=180.
 # TODO: overriding minimap position causes graphical glitches during net play
 minimap:
-  x: 512
+  x: -5
   y: 70
 
 # In-game (LM_PLAYING).
@@ -75,12 +75,12 @@ minimap:
 # buttons use rotated selweap art — prev_weapon.png is selweap.png
 # rotated 90 degrees (clockwise), next_weapon.png is rotated 270.
 playing:
-  - { x: 560, y:   5, w:  75, h:  40, action: menu,                       label: "MENU" }
-  - { x: 425, y: 180, w: 107, h: 100, action: prev_weapon,                label: "<<",   image: prev_weapon.png }
-  - { x: 532, y: 180, w: 108, h: 100, action: next_weapon,                label: ">>",   image: next_weapon.png }
-  - { x: 425, y: 280, w: 215, h: 100, action: hold, binding: rope,        label: "ROPE", image: rope.png    }
-  - { x: 425, y: 380, w: 107, h: 100, action: hold, binding: shoot,       label: "FIRE", image: shoot.png   }
-  - { x: 532, y: 380, w: 108, h: 100, action: hold, binding: jump,        label: "JUMP", image: jump.png    }
+  - { x:   -5, y:   5, w:  75, h:  40, action: menu,                       label: "MENU" }
+  - { x: -113, y: 180, w: 107, h: 100, action: prev_weapon,                label: "<<",   image: prev_weapon.png }
+  - { x:   -5, y: 180, w: 108, h: 100, action: next_weapon,                label: ">>",   image: next_weapon.png }
+  - { x:   -5, y: 280, w: 215, h: 100, action: hold, binding: rope,        label: "ROPE", image: rope.png    }
+  - { x: -113, y: 380, w: 107, h: 100, action: hold, binding: shoot,       label: "FIRE", image: shoot.png   }
+  - { x:   -5, y: 380, w: 108, h: 100, action: hold, binding: jump,        label: "JUMP", image: jump.png    }
 
 # Weapon picker (LM_WEAPON_SELECT).
 # Same picker UI as the right-aligned layout — D-pad on the lower-left,
@@ -88,10 +88,10 @@ playing:
 # had a randomise shortcut; we adopt the modern UI here so all layouts
 # share the same picker.)
 weapon_select:
-  - { x: 560, y:   5, w:  75, h:  40, action: menu,                       label: "MENU"   }
-  - { x:  60, y: 240, w:  80, h:  70, action: hold, binding: up,          label: "^"      }
-  - { x:  60, y: 400, w:  80, h:  70, action: hold, binding: down,        label: "v"      }
-  - { x:   0, y: 320, w:  80, h:  70, action: hold, binding: left,        label: "<"      }
-  - { x: 140, y: 320, w:  80, h:  70, action: hold, binding: right,       label: ">"      }
-  - { x: 525, y: 240, w: 110, h:  95, action: randomize,                  label: "Random" }
-  - { x: 525, y: 345, w: 110, h:  95, action: done,                       label: "DONE"   }
+  - { x:  60, y: 240, w:  80, h: 70,  action: hold, binding: up,          label: "^"      }
+  - { x:  60, y: 400, w:  80, h: 70,  action: hold, binding: down,        label: "v"      }
+  - { x:   0, y: 320, w:  80, h: 70,  action: hold, binding: left,        label: "<"      }
+  - { x: 140, y: 320, w:  80, h: 70,  action: hold, binding: right,       label: ">"      }
+  - { x:  -5, y:   5, w:  75, h: 40,  action: menu,                       label: "MENU"   }
+  - { x:  -5, y: 240, w: 110, h: 95,  action: randomize,                  label: "Random" }
+  - { x:  -5, y: 345, w: 110, h: 95,  action: done,                       label: "DONE"   }

--- a/share/gamedir/touchscreen/right-aligned.yaml
+++ b/share/gamedir/touchscreen/right-aligned.yaml
@@ -31,12 +31,13 @@ vjoy:
   walk_sensitivity: 40
   aim_sensitivity: 30.0
 
-# Minimap position (top-left, logical 640x480) while the touch UI is
-# visible. Default minimap is 128x96 — these coords put it flush
-# against the bottom, just left of the right-edge action column.
+# Minimap position while the touch UI is visible. Default minimap is
+# 128x96. Negative x is relative to the right screen edge (so it stays
+# just left of the right-edge action column on wider screens); y is the
+# usual top origin, putting it flush against the bottom (height is 480).
 # TODO: overriding minimap position causes graphical glitches during net play
 minimap:
-  x: 393
+  x: -119
   y: 384
 
 # Actions:
@@ -54,20 +55,20 @@ minimap:
 #   ROPE at top, FIRE in the middle, JUMP at the bottom. PREV / NEXT
 #   weapon share a row in the gap between ROPE and FIRE.
 playing:
-  - { x: 560, y:   5, w:  75, h:  40, action: menu,                       label: "MENU" }
-  - { x: 525, y: 165, w:  55, h:  50, action: prev_weapon,                label: "<<"   }
-  - { x: 580, y: 165, w:  55, h:  50, action: next_weapon,                label: ">>"   }
-  - { x: 525, y:  50, w: 110, h: 110, action: hold, binding: rope,        label: "ROPE" }
-  - { x: 525, y: 220, w: 110, h: 180, action: hold, binding: shoot,       label: "FIRE" }
-  - { x: 525, y: 405, w: 110, h:  70, action: hold, binding: jump,        label: "JUMP" }
+  - { x:  -5, y:   5, w:  75, h:  40, action: menu,                       label: "MENU" }
+  - { x: -60, y: 165, w:  55, h:  50, action: prev_weapon,                label: "<<"   }
+  - { x:  -5, y: 165, w:  55, h:  50, action: next_weapon,                label: ">>"   }
+  - { x:  -5, y:  50, w: 110, h: 110, action: hold, binding: rope,        label: "ROPE" }
+  - { x:  -5, y: 220, w: 110, h: 180, action: hold, binding: shoot,       label: "FIRE" }
+  - { x:  -5, y: 405, w: 110, h:  70, action: hold, binding: jump,        label: "JUMP" }
 
 # Weapon picker (LM_WEAPON_SELECT).
 # D-pad on the lower-left + Random/Done on the right edge.
 weapon_select:
-  - { x: 560, y:   5, w:  75, h: 40,  action: menu,                       label: "MENU"   }
   - { x:  60, y: 240, w:  80, h: 70,  action: hold, binding: up,          label: "^"      }
   - { x:  60, y: 400, w:  80, h: 70,  action: hold, binding: down,        label: "v"      }
   - { x:   0, y: 320, w:  80, h: 70,  action: hold, binding: left,        label: "<"      }
   - { x: 140, y: 320, w:  80, h: 70,  action: hold, binding: right,       label: ">"      }
-  - { x: 525, y: 240, w: 110, h: 95,  action: randomize,                  label: "Random" }
-  - { x: 525, y: 345, w: 110, h: 95,  action: done,                       label: "DONE"   }
+  - { x:  -5, y:   5, w:  75, h: 40,  action: menu,                       label: "MENU"   }
+  - { x:  -5, y: 240, w: 110, h: 95,  action: randomize,                  label: "Random" }
+  - { x:  -5, y: 345, w: 110, h: 95,  action: done,                       label: "DONE"   }

--- a/src/client/AuxLib.cpp
+++ b/src/client/AuxLib.cpp
@@ -426,6 +426,26 @@ bool VideoPostProcessor::initWindow() {
 	}
 #endif
 	
+	// Derive the screen width from the desktop's aspect ratio while keeping
+	// the height fixed at screenHeight() (480). 4:3 -> 640, 16:10 -> 768,
+	// 16:9 -> 854, etc. Rounded to an even number to keep buffers/textures happy.
+	{
+		SDL_DisplayMode dm;
+		int displayIdx = 0;
+		if(SDL_GetDesktopDisplayMode(displayIdx, &dm) == 0 && dm.w > 0 && dm.h > 0) {
+			double w = (double)screenHeight() * (double)dm.w / (double)dm.h;
+			int rounded = ((int)(w + 0.5) + 1) & ~1;
+			if(rounded < 320) rounded = 320;
+			m_screenWidth = rounded;
+			notes << "desktop mode: " << dm.w << "x" << dm.h
+				<< " -> using " << m_screenWidth << "x" << screenHeight() << endl;
+		} else {
+			m_screenWidth = 640;
+			warnings << "could not query desktop display mode (" << SDL_GetError()
+				<< "), falling back to " << m_screenWidth << "x" << screenHeight() << endl;
+		}
+	}
+
 setvideomode:
 	// Window title: short version string (see GetGameVersionString), not the
 	// integer-parsed asHumanString() which mangles the new format.
@@ -632,7 +652,20 @@ void VideoPostProcessor::render() {
 	if(!get()->m_renderer.get()) return;
 
 	SDL_RenderClear(get()->m_renderer.get());
-	SDL_RenderCopy(get()->m_renderer.get(), get()->m_videoTexture.get(), NULL, NULL);
+	const int dw = get()->displayScreenWidth();
+	const int centerOffset = get()->displayScreenOffsetX();
+	if(centerOffset > 0) {
+		// The frame's content (a menu, or a network game) is only dw wide and is
+		// drawn into the left dw columns of the (wider) video surface. Present
+		// just that region, centered, so it appears in the middle of the screen
+		// with black bars on the sides. The mouse is shifted by the same offset
+		// (see HandleMouseState) so clicks still line up.
+		SDL_Rect src = { 0, 0, dw, get()->screenHeight() };
+		SDL_Rect dst = { centerOffset, 0, dw, get()->screenHeight() };
+		SDL_RenderCopy(get()->m_renderer.get(), get()->m_videoTexture.get(), &src, &dst);
+	} else {
+		SDL_RenderCopy(get()->m_renderer.get(), get()->m_videoTexture.get(), NULL, NULL);
+	}
 	SDL_RenderPresent(get()->m_renderer.get());
 
 #ifdef __EMSCRIPTEN__

--- a/src/client/CClient.cpp
+++ b/src/client/CClient.cpp
@@ -1590,9 +1590,19 @@ void CClient::SetupViewports(CWorm *w1, CWorm *w2, int type1, int type2)
 		h = 480;
 	}
 	
+	// Non-widescreen games are constrained to the base menuWidth so that a
+	// wider screen gives no gameplay advantage (the narrower view is presented
+	// centered with black bars, see VideoPostProcessor::render). Widescreen
+	// games use the full screen width. Set the display width up front so the
+	// viewports are sized from it (the gameplay draw keeps it updated too).
+	VideoPostProcessor::get()->setDisplayScreenWidth(
+		game.useWideScreen() ? VideoPostProcessor::get()->screenWidth()
+		                     : VideoPostProcessor::menuWidth);
+	const int sw = VideoPostProcessor::get()->displayScreenWidth();
+
 	// One worm
 	if(w2 == NULL) {
-		cViewports[0].Setup(0, top, 640, h, type1);
+		cViewports[0].Setup(0, top, sw, h, type1);
 		if(w1)
 			cViewports[0].setSmooth( !OwnsWorm(w1->getID()) );
 		cViewports[0].setTarget(w1);
@@ -1601,13 +1611,16 @@ void CClient::SetupViewports(CWorm *w1, CWorm *w2, int type1, int type2)
 
 	// Two wormsize
 	else  {
-		cViewports[0].Setup(0, top, 318, h, type1);
+		// Split screen: two equal halves separated by a 4 px gap.
+		const int gap = 4;
+		const int half = (sw - gap) / 2;
+		cViewports[0].Setup(0, top, half, h, type1);
 		if(w1)
 			cViewports[0].setSmooth( !OwnsWorm(w1->getID()) );
 		cViewports[0].setTarget(w1);
 		cViewports[0].setOrigTarget(w1);
-		
-		cViewports[1].Setup(322, top, 318, h, type2);
+
+		cViewports[1].Setup(half + gap, top, half, h, type2);
 		if(w2)
 			cViewports[1].setSmooth( !OwnsWorm(w2->getID()) );
 		cViewports[1].setTarget(w2);

--- a/src/client/CClient_Draw.cpp
+++ b/src/client/CClient_Draw.cpp
@@ -415,6 +415,14 @@ void CClient::DrawBox(SDL_Surface * dst, int x, int y, int w)
 // Main drawing routines
 void CClient::Draw(const SmartPointer<SDL_Surface>& bmpDest)
 {
+	// Widescreen games use the full screen width; others are constrained to the
+	// base menuWidth (presented centered, with black bars) so that a wider
+	// screen gives no gameplay advantage. This also overrides the menuWidth set
+	// by Menu_Frame once we are in a widescreen game.
+	VideoPostProcessor::get()->setDisplayScreenWidth(
+		game.useWideScreen() ? VideoPostProcessor::get()->screenWidth()
+		                     : VideoPostProcessor::menuWidth);
+
 #ifdef DEBUG
 	struct DrawDebugStrPostHandler {
 		CClient& cl;
@@ -508,7 +516,7 @@ void CClient::Draw(const SmartPointer<SDL_Surface>& bmpDest)
 	if(cViewports[1].getUsed())
 		DrawRectFill(bmpDest,640/2-2,0,640/2+2, bgImage.get() ? (480-bgImage.get()->h) : (384), tLX->clViewportSplit);
 	*/
-	DrawRectFill(bmpDest.get(), 640/2-2, 0, 640/2+2, 480, tLX->clViewportSplit);
+	// (The split-screen separator is drawn after the viewports, below.)
 
 	// Top bar (do not draw for Gusanos)
 	/*
@@ -550,6 +558,18 @@ void CClient::Draw(const SmartPointer<SDL_Surface>& bmpDest)
 			}
 		}
 
+		// Vertical separator between the two split-screen viewports. Drawn
+		// AFTER (on top of) the viewports so it reliably paints the gap and the
+		// viewports' edge columns every frame: those columns are not fully
+		// repainted by the viewport blit, so stale weapon-select pixels lingered
+		// there and flickered between the double buffers. Covers the gap plus
+		// 1px of each viewport edge.
+		if(cViewports[0].getUsed() && cViewports[1].getUsed()) {
+			const int gapL = cViewports[0].GetLeft() + cViewports[0].GetVirtW();
+			const int gapR = cViewports[1].GetLeft();
+			DrawRectFill(bmpDest.get(), gapL - 1, 0, gapR + 1, 480, tLX->clViewportSplit);
+		}
+
 		int MiniMapX = tInterfaceSettings.MiniMapX;
 		int MiniMapY = tInterfaceSettings.MiniMapY;
 		//if(game.gameScript() && game.gameScript()->gusEngineUsed()) {
@@ -564,8 +584,14 @@ void CClient::Draw(const SmartPointer<SDL_Surface>& bmpDest)
 		if(TouchControls::IsActive()) {
 			int mx, my;
 			if(TouchControls::GetMinimapPosition(mx, my)) {
-				MiniMapX = mx;
-				MiniMapY = my;
+				// Negative coords are relative to the right/bottom screen edge
+				// (same convention as the touch buttons): anchor the minimap's
+				// far edge |coord| px from that edge, so it stays put on wider
+				// screens. Non-negative coords are the usual top-left origin.
+				const int sw = VideoPostProcessor::get()->displayScreenWidth();
+				const int sh = VideoPostProcessor::get()->screenHeight();
+				MiniMapX = (mx >= 0) ? mx : sw + mx - tInterfaceSettings.MiniMapW;
+				MiniMapY = (my >= 0) ? my : sh + my - tInterfaceSettings.MiniMapH;
 			} else {
 				constexpr int kTouchRightEdge = 525;
 				constexpr int kGap            = 4;
@@ -747,13 +773,29 @@ void CClient::Draw(const SmartPointer<SDL_Surface>& bmpDest)
 
 	// Go through and draw the first two worms select menus
 	if (game.state >= Game::S_Preparing && !bWaitingForMod) {
-		short i = 0;
+		// Darken the whole screen behind the weapon selection. Drawn once here
+		// (not per-viewport) so it always covers the full display width and
+		// does not stack alpha in split-screen.
+		bool anyWeaponSelect = false;
+		for_each_iterator(CWorm*, w, game.localWorms())
+			if(!w->get()->bWeaponsReady) anyWeaponSelect = true;
+		if(anyWeaponSelect)
+			DrawRectFill(bmpDest.get(), 0, 0,
+				VideoPostProcessor::get()->displayScreenWidth(),
+				VideoPostProcessor::get()->screenHeight(), Color(0,0,0,100));
+
 		for_each_iterator(CWorm*, w, game.localWorms()) {
-			++i;
+			if(w->get()->bWeaponsReady) continue;
+			// Render each worm's selection menu in its OWN viewport (the one
+			// targeting it), so in split-screen each player gets the menu
+			// centered in their half rather than a wrong/unused viewport.
 			CViewport* v = NULL;
-			if(i < NUM_VIEWPORTS) v = &cViewports[i];
-			if(!w->get()->bWeaponsReady)
-				w->get()->doWeaponSelectionFrame(bmpDest.get(), v);
+			for(int j = 0; j < NUM_VIEWPORTS; j++)
+				if(cViewports[j].getUsed() && cViewports[j].getTarget() == w->get()) {
+					v = &cViewports[j];
+					break;
+				}
+			w->get()->doWeaponSelectionFrame(bmpDest.get(), v);
 		}
 	}
 
@@ -1523,6 +1565,12 @@ void CClient::InitializeGameMenu()
 
 	AddColumns(Left);
 	AddColumns(Right);
+
+	// The game menu is authored for a 640-wide canvas. On a wider local game
+	// it would sit against the left edge, so shift the whole layout to center
+	// it (DrawGameMenu offsets its background bitmap by the same amount). The
+	// offset is 0 for network games, which are already presented centered.
+	cGameMenuLayout.moveWidgets(VideoPostProcessor::get()->popupCenterOffsetX(), 0);
 }
 
 
@@ -1535,11 +1583,12 @@ void CClient::DrawGameMenu(SDL_Surface * bmpDest)
 		return;
 	}
 	
-	// Background
+	// Background. Offset to match the centered layout (see InitializeGameMenu).
+	const int popupOff = VideoPostProcessor::get()->popupCenterOffsetX();
 	if (game.gameOver)  {
-		DrawImage(bmpDest, DeprecatedGUI::gfxGame.bmpGameover, 0, 0);
+		DrawImage(bmpDest, DeprecatedGUI::gfxGame.bmpGameover, popupOff, 0);
 	} else {
-		DrawImage(bmpDest, DeprecatedGUI::gfxGame.bmpScoreboard, 0, 0);
+		DrawImage(bmpDest, DeprecatedGUI::gfxGame.bmpScoreboard, popupOff, 0);
 	}
 
 	if (GetMouse()->Y >= DeprecatedGUI::gfxGame.bmpScoreboard.get()->h - GetMaxCursorHeight())

--- a/src/client/DeprecatedGUI/CChatWidget.cpp
+++ b/src/client/DeprecatedGUI/CChatWidget.cpp
@@ -435,7 +435,9 @@ void CChatWidget::GlobalProcessAndDraw(SDL_Surface * bmpDest)
 {
 	if( ! globalChat )
 	{
-		int setupX = 30;
+		// Center the chat popup on a wider-than-640 local game (offset 0 for
+		// network games, which are already presented centered).
+		int setupX = 30 + VideoPostProcessor::get()->popupCenterOffsetX();
 		int setupY = 100;
 		int setupW = 580;
 		int setupH = 280;

--- a/src/client/DeprecatedGUI/CGuiLayout.cpp
+++ b/src/client/DeprecatedGUI/CGuiLayout.cpp
@@ -221,6 +221,17 @@ void CGuiLayout::Draw(SDL_Surface * bmpDest)
 }
 
 
+/////////////////
+// Shift every widget by (dx,dy). Used to center an in-game popup layout
+// (which is authored for a 640-wide canvas) on a wider screen.
+void CGuiLayout::moveWidgets(int dx, int dy)
+{
+	if(dx == 0 && dy == 0) return;
+	for( std::list<CWidget *>::iterator w = cWidgets.begin() ; w != cWidgets.end() ; w++)
+		(*w)->move(dx, dy);
+}
+
+
 //////////////////
 // Build the layout according to code specified in skin file
 bool CGuiLayout::Build()

--- a/src/client/DeprecatedGUI/MenuSystem.cpp
+++ b/src/client/DeprecatedGUI/MenuSystem.cpp
@@ -264,7 +264,11 @@ void Menu_Frame() {
 #endif
 
 	if(game.state >= Game::S_Preparing) return; // could be already quitted
-	
+
+	// Menus are authored for menuWidth and presented centered on the screen.
+	// (Overwritten by the gameplay draw, see CClient::Draw.)
+	VideoPostProcessor::get()->setDisplayScreenWidth(VideoPostProcessor::menuWidth);
+
 	// Check if user pressed screenshot key
 	if (tLX->cTakeScreenshot.isDownOnce())  {
 		PushScreenshot("scrshots", "");
@@ -368,7 +372,9 @@ void Menu_RedrawMouse(bool total)
 // Draw a sub title
 void Menu_DrawSubTitle(SDL_Surface * bmpDest, int id)
 {
-	int x = VideoPostProcessor::videoSurface()->w/2;
+	// Center within the menu canvas (menuWidth), not the full screen: the
+	// whole menu is presented centered, so menu-local coordinates are used.
+	int x = VideoPostProcessor::menuWidth/2;
 	x -= tMenu->bmpSubTitles.get()->w/2;
 
 	DrawImageAdv(bmpDest,tMenu->bmpSubTitles, 0, id*70, x,30, tMenu->bmpSubTitles.get()->w, 65);
@@ -379,7 +385,9 @@ void Menu_DrawSubTitle(SDL_Surface * bmpDest, int id)
 // Draw a sub title advanced
 void Menu_DrawSubTitleAdv(SDL_Surface * bmpDest, int id, int y)
 {
-	int x = VideoPostProcessor::videoSurface()->w/2;
+	// Center within the menu canvas (menuWidth), not the full screen: the
+	// whole menu is presented centered, so menu-local coordinates are used.
+	int x = VideoPostProcessor::menuWidth/2;
 	x -= tMenu->bmpSubTitles.get()->w/2;
 
 	DrawImageAdv(bmpDest,tMenu->bmpSubTitles, 0, id*70, x,y, tMenu->bmpSubTitles.get()->w, 65);
@@ -546,7 +554,8 @@ MessageBoxReturnType Menu_MessageBox(const std::string& sTitle, const std::strin
 			longest_line = tw;
 	}
 	w = CLAMP(longest_line + 40, minw, maxw);
-	x = (VideoPostProcessor::get()->screenWidth() - w) / 2;
+	// Center within the menu canvas (menuWidth); the menu itself is centered.
+	x = (VideoPostProcessor::menuWidth - w) / 2;
 
 	// Handle multiline messages
 	lines = splitstring(sText, (size_t)-1, w - 2, tLX->cFont);

--- a/src/client/DeprecatedGUI/Menu_Net_Favourites.cpp
+++ b/src/client/DeprecatedGUI/Menu_Net_Favourites.cpp
@@ -472,7 +472,7 @@ void Menu_Net_FavouritesShowServer(const std::string& szAddress)
 
 	Menu_RedrawMouse(true);
 
-	int center = VideoPostProcessor::videoSurface()->w/2;
+	int center = VideoPostProcessor::menuWidth/2; // menu is presented centered
 	int y = VideoPostProcessor::videoSurface()->h/2 - INFO_H/2;
 
     cDetails.Initialize();

--- a/src/client/DeprecatedGUI/Menu_Net_Internet.cpp
+++ b/src/client/DeprecatedGUI/Menu_Net_Internet.cpp
@@ -582,7 +582,7 @@ void Menu_Net_NETShowServer(const std::string& szAddress)
 
 	Menu_RedrawMouse(true);
 
-	int center = VideoPostProcessor::videoSurface()->w/2;
+	int center = VideoPostProcessor::menuWidth/2; // menu is presented centered
 	int y = VideoPostProcessor::videoSurface()->h/2 - INFO_H/2;
 	
     cDetails.Initialize();

--- a/src/client/DeprecatedGUI/Menu_Net_Lan.cpp
+++ b/src/client/DeprecatedGUI/Menu_Net_Lan.cpp
@@ -421,7 +421,7 @@ void Menu_Net_LanShowServer(const std::string& szAddress)
 
 	Menu_RedrawMouse(true);
 
-	int center = VideoPostProcessor::videoSurface()->w/2;
+	int center = VideoPostProcessor::menuWidth/2; // menu is presented centered
 	int y = VideoPostProcessor::videoSurface()->h/2 - INFO_H/2;
 
     cDetails.Initialize();

--- a/src/client/InputEvents.cpp
+++ b/src/client/InputEvents.cpp
@@ -375,10 +375,12 @@ static void synthFingerFromMouse(Uint32 fingerType, int x, int y) {
 	t.type     = fingerType;
 	t.touchId  = 0;
 	t.fingerId = 0; // single synthetic pointer; mouse can't multi-touch
-	// HandleFingerEvent maps normalised x/y back onto the 640x480 surface,
-	// which is the logical space SDL reports mouse coords in too.
-	t.x = (float)x / 640.0f;
-	t.y = (float)y / 480.0f;
+	// HandleFingerEvent maps normalised x/y back onto the logical render
+	// surface (screenWidth x screenHeight, which may be wider than 640),
+	// which is the logical space the incoming mouse coords are in too.
+	// Normalise by the same dimensions so the round-trip is exact.
+	t.x = (float)x / (float)VideoPostProcessor::get()->screenWidth();
+	t.y = (float)y / (float)VideoPostProcessor::get()->screenHeight();
 	t.pressure = 1.0f;
 	TouchControls::HandleFingerEvent(t);
 }
@@ -586,6 +588,11 @@ static void HandleMouseState() {
 		Mouse.Button = SDL_GetMouseState(NULL,NULL); // Doesn't call libX11 funcs, so it's safe to call not from video thread
 		Mouse.X = mouseX;
 		Mouse.Y = mouseY;
+
+		// When the frame is presented centered (menus, or network games on a
+		// wider screen), shift the mouse into that centered space so clicks line
+		// up with the drawn widgets.
+		Mouse.X -= VideoPostProcessor::get()->displayScreenOffsetX();
 		
 		Mouse.deltaX = Mouse.X-oldX;
 		Mouse.deltaY = Mouse.Y-oldY;

--- a/src/client/TouchControls.cpp
+++ b/src/client/TouchControls.cpp
@@ -453,12 +453,34 @@ static bool sinToAction(int sinIndex, TouchScreenInput::Action& outAction) {
 
 // --- Button state machine ----------------------------------------------
 
+// Resolve a button's top-left corner on a canvasW x canvasH canvas.
+// A non-negative coordinate is the usual left/top origin. A negative
+// coordinate anchors the button to the opposite edge: x<0 places the
+// button's right edge |x| px from the canvas' right edge, y<0 places its
+// bottom edge |y| px from the bottom. So e.g. x:-5 keeps a 5px gap on the
+// right regardless of how wide the screen is.
+// The canvas is the real screen resolution in-game (so wider screens use
+// the extra width) and a fixed 640x480 for the options-menu preview.
+static int resolveButtonX(const Button& b, int canvasW) {
+	return b.x >= 0 ? b.x : canvasW + b.x - b.w;
+}
+static int resolveButtonY(const Button& b, int canvasH) {
+	return b.y >= 0 ? b.y : canvasH + b.y - b.h;
+}
+
 static int hitTestButton(int lx, int ly) {
 	const auto& btns = currentButtons();
 	const int n = (int)btns.size();
+	// Buttons live in the displayed view (full width for local games, 640 for
+	// network games) which is then presented centered — see HandleFingerEvent
+	// for the matching input mapping.
+	const int cw = VideoPostProcessor::get()->displayScreenWidth();
+	const int ch = VideoPostProcessor::get()->screenHeight();
 	for(int i = 0; i < n; i++) {
-		if(lx >= btns[i].x && lx < btns[i].x + btns[i].w
-		&& ly >= btns[i].y && ly < btns[i].y + btns[i].h)
+		const int bx = resolveButtonX(btns[i], cw);
+		const int by = resolveButtonY(btns[i], ch);
+		if(lx >= bx && lx < bx + btns[i].w
+		&& ly >= by && ly < by + btns[i].h)
 			return i;
 	}
 	return -1;
@@ -641,6 +663,13 @@ static void renderVJoy(SDL_Surface* dst) {
 }
 
 static void renderButton(SDL_Surface* dst, const Button& b, bool pressed) {
+	// Resolve negative (right/bottom-anchored) coordinates against the displayed
+	// view width (full width for local games, 640 for network games and the
+	// preview), so right-anchored buttons land inside the presented region.
+	// Height is unchanged.
+	const int bx = resolveButtonX(b, VideoPostProcessor::get()->displayScreenWidth());
+	const int by = resolveButtonY(b, dst->h);
+
 	// Image-based button: blit the artwork at a fixed square size,
 	// centred in the rect; swap to the pressed-state image when the
 	// button is held (and a pressed variant was loaded). The icon
@@ -653,13 +682,13 @@ static void renderButton(SDL_Surface* dst, const Button& b, bool pressed) {
 			(pressed && b.imagePressed.get()) ? b.imagePressed : b.imageNormal;
 		constexpr int kMaxIconSize = 60;
 		const int iconSize = std::min({b.w, b.h, kMaxIconSize});
-		const int iconX = b.x + (b.w - iconSize) / 2;
-		const int iconY = b.y + (b.h - iconSize) / 2;
+		const int iconX = bx + (b.w - iconSize) / 2;
+		const int iconY = by + (b.h - iconSize) / 2;
 		DrawImageResampledAdv(dst, img, 0, 0, iconX, iconY,
 		                      img.get()->w, img.get()->h, iconSize, iconSize);
 		// Optional outline still respected so previews can show the rect.
 		if(gShowButtonBorder)
-			DrawRect(dst, b.x, b.y, b.x + b.w - 1, b.y + b.h - 1, Color(220, 220, 220));
+			DrawRect(dst, bx, by, bx + b.w - 1, by + b.h - 1, Color(220, 220, 220));
 		return;
 	}
 
@@ -667,15 +696,15 @@ static void renderButton(SDL_Surface* dst, const Button& b, bool pressed) {
 	Uint8 alpha  = pressed ? 180 : 90;
 	Color border = Color(220, 220, 220);
 
-	DrawRectFillA(dst, b.x, b.y, b.x + b.w, b.y + b.h, fill, alpha);
+	DrawRectFillA(dst, bx, by, bx + b.w, by + b.h, fill, alpha);
 	if(gShowButtonBorder)
-		DrawRect(dst, b.x, b.y, b.x + b.w - 1, b.y + b.h - 1, border);
+		DrawRect(dst, bx, by, bx + b.w - 1, by + b.h - 1, border);
 
 	if(tLX && !b.label.empty()) {
 		int tw = tLX->cFont.GetWidth(b.label);
 		int th = tLX->cFont.GetHeight();
-		int tx = b.x + (b.w - tw) / 2;
-		int ty = b.y + (b.h - th) / 2;
+		int tx = bx + (b.w - tw) / 2;
+		int ty = by + (b.h - th) / 2;
 		tLX->cFont.Draw(dst, tx, ty, pressed ? tLX->clBlack : tLX->clWhite, b.label);
 	}
 }
@@ -839,10 +868,13 @@ static SmartPointer<SDL_Surface> renderLayoutPreviewSurface(const std::string& l
 	DrawRectFill(dst, 0, 0, dst->w, dst->h, Color(30, 38, 48));
 	DrawRect(dst, 0, 0, gVJoyAreaRight - 1, dst->h - 1, Color(60, 80, 100));
 	if(gMinimapOverride) {
-		const int mmX = gMinimapX;
-		const int mmY = gMinimapY;
 		const int mmW = 128;
 		const int mmH = 96;
+		// Resolve negative (right/bottom-anchored) coords against the preview
+		// canvas, mirroring the in-game resolution in CClient::Draw so the
+		// preview matches gameplay.
+		const int mmX = (gMinimapX >= 0) ? gMinimapX : dst->w + gMinimapX - mmW;
+		const int mmY = (gMinimapY >= 0) ? gMinimapY : dst->h + gMinimapY - mmH;
 		DrawRectFillA(dst, mmX, mmY, mmX + mmW, mmY + mmH, Color(80, 180, 80), 160);
 		DrawRect    (dst, mmX, mmY, mmX + mmW - 1, mmY + mmH - 1, Color(180, 230, 180));
 		// OLX ships only one font size, so to make "MAP" legible after the
@@ -942,8 +974,13 @@ bool HandleFingerEvent(const SDL_TouchFingerEvent& ev) {
 
 	if(!gUIActive) return false;
 
-	const int lx = (int)(ev.x * 640.0f);
-	const int ly = (int)(ev.y * 480.0f);
+	// SDL finger coords are normalized (0..1) over the whole window. Map them to
+	// the render resolution, then shift by the centering offset so they land in
+	// the displayed view's space (for a network game the view is 640 wide and
+	// presented centered; the offset is 0 for a full-width local game).
+	const int lx = (int)(ev.x * (float)VideoPostProcessor::get()->screenWidth())
+	             - VideoPostProcessor::get()->displayScreenOffsetX();
+	const int ly = (int)(ev.y * (float)VideoPostProcessor::get()->screenHeight());
 
 	if(ev.type == SDL_FINGERDOWN) {
 		// In playing mode, the left half is the joystick.

--- a/src/common/CWormHuman.cpp
+++ b/src/common/CWormHuman.cpp
@@ -672,18 +672,30 @@ void CWormHumanInputHandler::doWeaponSelectionFrame(SDL_Surface * bmpDest, CView
 	
 	int l = 0;
 	int t = 0;
-	int centrex = 320; // TODO: hardcoded screen width here
-	
-    if( v ) {
-        if( v->getUsed() ) {
-            l = v->GetLeft();
-	        t = v->GetTop();
-            centrex = v->GetLeft() + v->GetVirtW()/2;
-        }
-		
-		DrawRectFill(bmpDest, l, t, l + v->GetVirtW(), t + v->GetVirtH(), Color(0,0,0,100));
+	// Center on the displayed view; a used viewport (split-screen) overrides
+	// this with its own center. The whole-screen dark overlay behind the
+	// selection is drawn once by the caller (CClient::Draw).
+	int centrex = VideoPostProcessor::get()->displayScreenWidth() / 2;
+
+    if( v && v->getUsed() ) {
+        l = v->GetLeft();
+        t = v->GetTop();
+        centrex = v->GetLeft() + v->GetVirtW()/2;
     }
 		
+	// Clip all weapon-selection drawing to this worm's viewport so the (long)
+	// "Key settings" text can't bleed past the viewport into the split-screen
+	// separator gap. Belt-and-braces with the separator that repaints the gap
+	// (see CClient::Draw). CFont and DrawImageAdv both honour dst->clip_rect.
+	SDL_Rect wsClipRect = bmpDest->clip_rect;
+	if( v && v->getUsed() ) {
+		wsClipRect.x = l;
+		wsClipRect.y = t;
+		wsClipRect.w = v->GetVirtW();
+		wsClipRect.h = v->GetVirtH();
+	}
+	ScopedSurfaceClip wsClip(bmpDest, wsClipRect);
+
 	tLX->cFont.DrawCentre(bmpDest, centrex, t+30, tLX->clWeaponSelectionTitle, "~ Weapons Selection ~");
 		
 	tLX->cFont.DrawCentre(bmpDest, centrex, t+48, tLX->clWeaponSelectionTitle, "(Use up/down and left/right for selection.)");

--- a/src/game/Game.h
+++ b/src/game/Game.h
@@ -65,6 +65,11 @@ public:
 	bool isServer() { return m_isServer; }
 	bool isClient() { return !isServer(); }
 	bool isLocalGame() { return m_isLocalGame; }
+	// Whether this game should render in widescreen (the full screen width)
+	// rather than the fair 640-wide view. Single decision point: currently
+	// only local games, but this may later also cover network games where
+	// every player uses widescreen. See doc/dev/WIDESCREEN.md.
+	bool useWideScreen() { return isLocalGame(); }
 	bool isTeamPlay();
 	bool isGamePaused();
 	bool shouldDoPhysicsFrame();


### PR DESCRIPTION
This PR is adding widescreen support only for local games for now. This PR can be extended to include network multiplayer in the future, but I start with the none controvesial local games. It gets widescreen feature into OpenLieroX

This PR makes OpenLieroX adopt to modern screen aspect ratios. During the 1990s when the original Liero was developed screens was actually 4:3 in aspect ratio. Those screens are long gone today, but OpenLieroX only supports this screen aspect ratio today

This PR aims to address this by supporting modern screen aspect ratios as well as the old ones

**Strategy**:
Currently the game is always 640x480, which is a 4:3 aspect ratio. This PR aims to always keep the height at 480 pixels, but adopt the width to fit the screen it is played on. For example a modern 16:10 screen would use the resolution 480/10*16=768, so a resolution 768x480. This looks much better on screens that are not 4:3 which is almost all modern screens

See pictures for how it looks

Without this PR:
<img width="1920" height="1080" alt="OpenLiero 4 to 3" src="https://github.com/user-attachments/assets/0e18ee87-4395-4a1a-a8b7-92161b6bf693" />

With this PR:
<img width="1920" height="1080" alt="OpenLieroX in 16 to 9" src="https://github.com/user-attachments/assets/c6e8a2e1-89cc-4960-9b34-9feec59fb7d4" />

Technical details:
- Height stays 480; only the width varies.
- The width is derived from the desktop aspect ratio at startup (e.g. 854 on 16:9), even, floored at 320.
- Local games use the full width (the player sees more of the battlefield).
- Network games stay 640 so a wider screen gives no gameplay advantage.
- Menus and in-game popups are 640-authored and presented centered, with black bars on the sides.

Docs: add doc/dev/WIDESCREEN.md describing the feature