### PR TITLE
Center worm option

### DIFF
--- a/include/Options.h
+++ b/include/Options.h
@@ -286,6 +286,7 @@ public:
 	bool	bAutoTyping;
 	bool	bAntiAliasing;
 	bool	bMouseAiming;
+	bool	bAlwaysCenterWorm;	// Keep our own worm centered on screen even at the map borders. Centering is always on while touchscreen controls are active (so the on-screen controls can't cover our worm); this option additionally forces it for non-touchscreen players.
 	int		iMouseSensity;
 	std::string sTouchscreenControls;	// Tri-state "auto"/"true"/"false". "auto" enables on Android, disables elsewhere.
 	std::string sTouchscreenLayout;	// Name of layout file under share/gamedir/touchscreen/<name>.yaml.

--- a/src/client/CClient_Draw.cpp
+++ b/src/client/CClient_Draw.cpp
@@ -558,16 +558,15 @@ void CClient::Draw(const SmartPointer<SDL_Surface>& bmpDest)
 			}
 		}
 
-		// Vertical separator between the two split-screen viewports. Drawn
-		// AFTER (on top of) the viewports so it reliably paints the gap and the
-		// viewports' edge columns every frame: those columns are not fully
-		// repainted by the viewport blit, so stale weapon-select pixels lingered
-		// there and flickered between the double buffers. Covers the gap plus
-		// 1px of each viewport edge.
+		// Vertical separator filling the gap between the two split-screen
+		// viewports. This strip lies outside both viewport rects, so the
+		// per-viewport black fill in DrawViewport_Game never reaches it, and
+		// effects that draw outside the viewport clip (e.g. blood splatter) can
+		// leave artifacts there. Repaint it every frame to keep the gap clean.
 		if(cViewports[0].getUsed() && cViewports[1].getUsed()) {
 			const int gapL = cViewports[0].GetLeft() + cViewports[0].GetVirtW();
 			const int gapR = cViewports[1].GetLeft();
-			DrawRectFill(bmpDest.get(), gapL - 1, 0, gapR + 1, 480, tLX->clViewportSplit);
+			DrawRectFill(bmpDest.get(), gapL, 0, gapR, 480, tLX->clViewportSplit);
 		}
 
 		int MiniMapX = tInterfaceSettings.MiniMapX;
@@ -935,7 +934,13 @@ void CClient::DrawViewport_Game(const SmartPointer<SDL_Surface>& bmpDest, CViewp
 	// Set the clipping
 	SDL_Rect rect = v->getRect();
 	ScopedSurfaceClip clip(bmpDest.get(), rect);
-	
+
+	// Clear the viewport to black first. The map is only blitted where it actually
+	// exists, so any area outside the map (centered camera at the borders, or a map
+	// smaller than the viewport) would otherwise show flickering stale framebuffer
+	// content. FillSurface respects the clip rect, so this fills just this viewport.
+	FillSurface(bmpDest.get(), Color(0,0,0));
+
 	v->gusRender(bmpDest);
 }
 

--- a/src/client/CViewport.cpp
+++ b/src/client/CViewport.cpp
@@ -23,6 +23,7 @@
 #include "MathLib.h"
 #ifndef DEDICATED_ONLY
 #include "sound/sfx.h"
+#include "TouchControls.h"
 #endif
 
 
@@ -312,6 +313,26 @@ void CViewport::Process(CViewport *pcViewList, int MWidth, int MHeight, int iGam
 	}	// switch
 
 
+	// Keep our own worm centered on screen even at the map borders, which means
+	// skipping the clamping for the follow viewport (the area beyond the map edge
+	// is left as background). This is enabled either explicitly via the option, or
+	// automatically while touchscreen controls are active, so the on-screen
+	// controls can't end up covering our worm against a map edge.
+	bool centerScreen = tLXOptions->bAlwaysCenterWorm;
+#ifndef DEDICATED_ONLY
+	if( TouchControls::IsActive() )
+		centerScreen = true;
+#endif
+	const bool centerOwnWorm = centerScreen && nType == VW_FOLLOW && pcTargetWorm;
+
+	// Before the worm has spawned (e.g. during weapon selection) it has no real
+	// position yet (defaults to ~0,0), so centering on it would dump us in the
+	// off-map corner. Instead, center the view on the middle of the map.
+	if( centerOwnWorm && !pcTargetWorm->haveSpawnedOnce() ) {
+		WorldX = (MWidth - Width) / 2;
+		WorldY = (MHeight - Height) / 2;
+	}
+
 	// Shake the viewport a bit
 	if(bShaking) {
 		if(tLX->currentTime - fShakestart > 0.2f) {
@@ -321,11 +342,13 @@ void CViewport::Process(CViewport *pcViewList, int MWidth, int MHeight, int iGam
 		else {
 
             // Don't shake the action/freelook cam
-            if( nType != VW_ACTIONCAM && nType != VW_FREELOOK && 
+            if( nType != VW_ACTIONCAM && nType != VW_FREELOOK &&
             	( cClient->getGameLobby()[FT_ScreenShaking] ) ) {
 
-                // Clamp it to the edges, then shake. So we can still see shaking near edges
-                Clamp(MWidth, MHeight);
+                // Clamp it to the edges, then shake. So we can still see shaking near edges.
+                // Skip when centering our own worm, so the centering isn't broken at borders.
+                if( !centerOwnWorm )
+                    Clamp(MWidth, MHeight);
 
 			    // Shake
 			    WorldX += (int)(GetRandomNum() * (float)iShakeAmount);
@@ -334,8 +357,9 @@ void CViewport::Process(CViewport *pcViewList, int MWidth, int MHeight, int iGam
 		}
 	}
 
-	// Clamp it
-	Clamp(MWidth, MHeight);
+	// Clamp it (unless we are centering our own spawned worm).
+	if( !centerOwnWorm )
+		Clamp(MWidth, MHeight);
 
 #ifndef DEDICATED_ONLY
 	m_listener->pos = Vec((float)WorldX, (float)WorldY) + Vec((float)(Width/2), (float)(Height/2));

--- a/src/client/DeprecatedGUI/Menu_Options.cpp
+++ b/src/client/DeprecatedGUI/Menu_Options.cpp
@@ -146,6 +146,7 @@ enum {
 	og_ScreenShaking,
 	og_DamagePopups,
 	og_ColorizeDamageByWorm,
+	og_AlwaysCenterWorm,
 };
 
 enum {
@@ -543,6 +544,9 @@ bool Menu_OptionsInitialize()
 
 	cOpt_Game.Add( new CLabel("Colorize damage popups by worm",tLX->clNormalLabel), Static, 330, 240, 0,0);
 	cOpt_Game.Add( new CCheckbox(tLXOptions->bColorizeDamageByWorm),     og_ColorizeDamageByWorm, 550, 240, 17,17);
+
+	cOpt_Game.Add( new CLabel("Always center worm",tLX->clNormalLabel), Static, 330, 270, 0,0);
+	cOpt_Game.Add( new CCheckbox(tLXOptions->bAlwaysCenterWorm),     og_AlwaysCenterWorm, 550, 270, 17,17);
 
 /*
 	cOpt_Game.Add( new CLabel("Allow mouse control (Server)",tLX->clNormalLabel), Static, 330, 360, 0,0);
@@ -1087,6 +1091,11 @@ void Menu_OptionsFrame()
 				case og_ColorizeDamageByWorm:
 					if(ev->iEventMsg == CHK_CHANGED)
 						tLXOptions->bColorizeDamageByWorm = cOpt_Game.SendMessage(og_ColorizeDamageByWorm, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
+					break;
+
+				case og_AlwaysCenterWorm:
+					if(ev->iEventMsg == CHK_CHANGED)
+						tLXOptions->bAlwaysCenterWorm = cOpt_Game.SendMessage(og_AlwaysCenterWorm, CKM_GETCHECK, (uintptr_t)0, 0) != 0;
 					break;
 			}
 		}

--- a/src/client/Options.cpp
+++ b/src/client/Options.cpp
@@ -216,6 +216,7 @@ bool GameOptions::Init() {
 		( tLXOptions->sTheme, "Game.Theme", "" )
 		( tLXOptions->bAntiAliasing, "Game.Antialiasing", true )
 		( tLXOptions->bMouseAiming, "Game.MouseAiming", false ) // TODO: rename to mouse control?
+		( tLXOptions->bAlwaysCenterWorm, "Game.AlwaysCenterWorm", false )
 		( tLXOptions->iMouseSensity, "Game.MouseSensity", 200 )
 		( tLXOptions->sTouchscreenControls, "Game.TouchscreenControls", "auto" )
 		( tLXOptions->sTouchscreenLayout, "Game.TouchscreenLayout", "classic" )


### PR DESCRIPTION
Adds an option to always center the worm

Background:
I realized when I played with touch screen controls that it is very problematic when the touch screen controls cover the worm, so you cannot see your own worm or what you are doing.

The best fix for it I think is the one used in 0.58 where the worm is ALWAYS in the middle of the screen when using touch screen. That way you cannot cover your own worm with your finger because you play touch screen


I made it so that:
* When playing with touch screen "Always center worm" is used
* When not playing touch screen there is an option to turn it on in the settings, but it is off by default.

@pelya pointed out this problem before, and after plaing a bit with touch screen I realize it is very important for the touch screen experience 

On by default on touch screen:
<img width="853" height="488" alt="Screenshot from 2026-06-17 13-10-20" src="https://github.com/user-attachments/assets/d210572c-93c6-481f-94ef-69b6dcb6483b" />

Can be enabled for anyone in the settings:
<img width="645" height="480" alt="Screenshot from 2026-06-17 13-09-30" src="https://github.com/user-attachments/assets/f52edc75-7669-4980-bb24-77eee3e21b8a" />
