### PR TITLE
Gate touchscreen double-shoot weapon switch behind a setting

### DIFF
--- a/include/Options.h
+++ b/include/Options.h
@@ -290,6 +290,7 @@ public:
 	int		iMouseSensity;
 	std::string sTouchscreenControls;	// Tri-state "auto"/"true"/"false". "auto" enables on Android, disables elsewhere.
 	std::string sTouchscreenLayout;	// Name of layout file under share/gamedir/touchscreen/<name>.yaml.
+	bool	bTouchscreenDoubleShootToSwitchWeapon;	// Double-tap the touchscreen Shoot button to cycle weapons. Off by default.
 	bool	bAntilagMovementPrediction;
 	std::string	sLastSelectedPlayer;
 	std::string	sLastSelectedPlayer2;

--- a/src/client/DeprecatedGUI/Menu_Options.cpp
+++ b/src/client/DeprecatedGUI/Menu_Options.cpp
@@ -78,6 +78,9 @@ static SDL_Rect ResetBtnRect;
 // plus the per-tile hit-boxes filled in by Menu_OptionsDrawTouchTiles.
 static std::vector<TouchControls::LayoutInfo> gTouchLayoutInfos;
 static std::vector<SDL_Rect>                  gTouchLayoutTileRects;
+// Hit-box of the "Double shoot to switch weapon" checkbox shown below the
+// layout tiles on the Touchscreen sub-tab (filled in by Menu_OptionsDrawTouchOptions).
+static SDL_Rect gTouchDoubleShootRect = {0, 0, 0, 0};
 
 // The On / Off / Auto selector for Game.TouchscreenControls, shown on the top
 // row of the Touchscreen sub-tab (above the layout tiles). The labels map to
@@ -753,6 +756,34 @@ static void Menu_OptionsDrawTouchTiles(SDL_Surface* dest)
 }
 
 ///////////////////
+// Draw the "Double shoot to switch weapon" checkbox below the layout tiles on
+// the Touchscreen sub-tab. Drawn manually (like the rest of this tab) so it
+// can sit under the layout selection. Records its hit-box in
+// gTouchDoubleShootRect for click handling in Menu_OptionsFrame.
+static void Menu_OptionsDrawTouchOptions(SDL_Surface* dest)
+{
+	mouse_t* Mouse = GetMouse();
+	// Sit below the layout tiles (tiles end at ~393, plus their name labels).
+	const int y = 420;
+	const int box = 17;
+	const int x = kControlLabelX;
+
+	const bool on = tLXOptions->bTouchscreenDoubleShootToSwitchWeapon;
+
+	// Checkbox square.
+	DrawRect(dest, x, y, x + box, y + box, tLX->clNormalLabel);
+	if(on)
+		DrawRectFill(dest, x + 3, y + 3, x + box - 3, y + box - 3, tLX->clHeading);
+
+	const std::string label = "Double shoot to switch weapon";
+	const int labelX = x + box + 8;
+	tLX->cFont.Draw(dest, labelX, y + 2, tLX->clNormalLabel, label);
+
+	const int w = (labelX + tLX->cFont.GetWidth(label)) - x;
+	gTouchDoubleShootRect = SDL_Rect{(Sint16)x, (Sint16)y, (Uint16)w, (Uint16)box};
+}
+
+///////////////////
 // Draws the "Reset defaults" button (a bordered text button, so it can show
 // that exact label) and records its hit-box in ResetBtnRect.
 static void Menu_OptionsDrawResetButton(SDL_Surface* dest)
@@ -938,6 +969,16 @@ void Menu_OptionsFrame()
 						}
 						break;
 					}
+				}
+			}
+			// "Double shoot to switch weapon" toggle below the layout tiles.
+			Menu_OptionsDrawTouchOptions(VideoPostProcessor::videoSurface().get());
+			if(Mouse->Up) {
+				const SDL_Rect& r = gTouchDoubleShootRect;
+				if(Mouse->X >= r.x && Mouse->X <= r.x + r.w &&
+				   Mouse->Y >= r.y && Mouse->Y <= r.y + r.h) {
+					tLXOptions->bTouchscreenDoubleShootToSwitchWeapon = !tLXOptions->bTouchscreenDoubleShootToSwitchWeapon;
+					PlaySoundSample(sfxGeneral.smpClick);
 				}
 			}
 		} else {

--- a/src/client/Options.cpp
+++ b/src/client/Options.cpp
@@ -220,6 +220,7 @@ bool GameOptions::Init() {
 		( tLXOptions->iMouseSensity, "Game.MouseSensity", 200 )
 		( tLXOptions->sTouchscreenControls, "Game.TouchscreenControls", "auto" )
 		( tLXOptions->sTouchscreenLayout, "Game.TouchscreenLayout", "classic" )
+		( tLXOptions->bTouchscreenDoubleShootToSwitchWeapon, "Game.TouchscreenDoubleShootToSwitchWeapon", false )
 		( tLXOptions->bAntilagMovementPrediction, "Game.AntilagMovementPrediction", true )
 		( tLXOptions->sLastSelectedPlayer, "Game.LastSelectedPlayer", "" )
 		( tLXOptions->sLastSelectedPlayer2, "Game.LastSelectedPlayer2", "" )

--- a/src/common/CWormHuman.cpp
+++ b/src/common/CWormHuman.cpp
@@ -331,7 +331,7 @@ void CWormHumanInputHandler::getInput() {
 
 	if (ws->bShoot) {
 		const float comboTapTime = 0.3f;
-		if (TouchControls::IsActive() && allowCombo && !m_worm->bTouchscreenWeaponCycle) {
+		if (TouchControls::IsActive() && allowCombo && tLXOptions->bTouchscreenDoubleShootToSwitchWeapon && !m_worm->bTouchscreenWeaponCycle) {
 			if (m_worm->fLastShoot + comboTapTime > tLX->currentTime) {
 				// Cycle weapons by tapping Shoot button rapidly
 				m_worm->iCurrentWeapon++;


### PR DESCRIPTION
This PR adds a new "Double shoot to switch weapon" option that is configured on the Touchscreen settings

I don't think this should be turned on for everyone, since I think only some power users would like it. Many people including me mostly get confused when the game is switching weapon when I didnt explicitly asked for it


This make the previous commit optional to use, based on user settings:
https://github.com/openlierox/openlierox/commit/cffc45f99875d2b7edc146aa4fcdfef1887ada32

@pelya @albertz 
<img width="642" height="488" alt="Screenshot from 2026-06-17 15-00-17" src="https://github.com/user-attachments/assets/a9fff343-4fac-4d48-a819-d8096d6f1a29" />
