### PR TITLE
Convert beta release workflow into rolling "Latest master" workflow

### DIFF
--- a/.github/workflows/master-release.yaml
+++ b/.github/workflows/master-release.yaml
@@ -1,9 +1,9 @@
-name: Beta Release
+name: Latest master
 
 # Runs whenever a PR is merged (i.e. a push lands) on a release branch.
 # It builds every platform by reusing the existing package-* pipelines,
-# then publishes/refreshes a rolling pre-release on GitHub with all the
-# freshly built artifacts attached.
+# then publishes to a rolling "latest" release on GitHub, adding all the
+# freshly built artifacts to it without removing previously published ones.
 on:
   push:
     branches:
@@ -40,7 +40,7 @@ jobs:
     secrets: inherit
 
   release:
-    name: Publish beta release
+    name: Publish latest master release
     needs: [android, linux-bundle, linux-deb, mac, windows, wasm]
     runs-on: ubuntu-24.04
     steps:
@@ -73,7 +73,7 @@ jobs:
           echo "Artifacts to publish:"
           ls -la dist
 
-      - name: Publish rolling beta pre-release
+      - name: Publish latest master release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.meta.outputs.tag }}
@@ -83,13 +83,13 @@ jobs:
           set -euo pipefail
 
           NOTES="$(cat <<EOF
-          Automated beta build of OpenLieroX **${VERSION}**.
+          Automated build of OpenLieroX **${VERSION}**.
 
           - Branch: \`${GITHUB_REF_NAME}\`
           - Commit: ${GITHUB_SHA}
 
-          This is a rolling pre-release that is refreshed on every merge. The
-          attached artifacts always reflect the latest build of this branch.
+          This is a rolling "latest" release. New build artifacts are added on
+          every merge; previously published artifacts are kept.
           EOF
           )"
 
@@ -117,13 +117,20 @@ jobs:
           echo "Publishing assets:"
           printf '  %s\n' "${ASSETS[@]}"
 
-          # Recreate the rolling release/tag so it points at this commit and
-          # carries only the current build's artifacts.
-          gh release delete "$TAG" --cleanup-tag --yes 2>/dev/null || true
+          # Ensure the rolling "latest" release exists, then add this build's
+          # artifacts to it. Old artifacts are kept; only assets whose names
+          # collide with the incoming ones are overwritten (--clobber).
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --title "OpenLieroX ${VERSION_FULL} (latest master)" \
+              --notes "$NOTES" \
+              --latest
+          else
+            gh release create "$TAG" \
+              --title "OpenLieroX ${VERSION_FULL} (latest master)" \
+              --notes "$NOTES" \
+              --latest \
+              --target "$GITHUB_SHA"
+          fi
 
-          gh release create "$TAG" \
-            --title "OpenLieroX ${VERSION_FULL} (latest beta)" \
-            --notes "$NOTES" \
-            --prerelease \
-            --target "$GITHUB_SHA" \
-            "${ASSETS[@]}"
+          gh release upload "$TAG" "${ASSETS[@]}" --clobber


### PR DESCRIPTION
Rename the workflow (release-beta.yml -> master-release.yaml) and rework it so master builds publish to a single rolling "latest" GitHub release instead of a recreated pre-release:

- Rename the workflow to "Latest master".
- Mark the release as "latest" (--latest) rather than "prerelease".
- Stop deleting the release/tag on each run. The release is created once and thereafter refreshed via `gh release edit`, with new artifacts added through `gh release upload --clobber` so previously published builds are kept and only same-named assets are overwritten.