### PR TITLE
Fix master release publish failing on prerelease tag

### DIFF
--- a/.github/workflows/master-release.yaml
+++ b/.github/workflows/master-release.yaml
@@ -120,15 +120,23 @@ jobs:
           # Ensure the rolling "latest" release exists, then add this build's
           # artifacts to it. Old artifacts are kept; only assets whose names
           # collide with the incoming ones are overwritten (--clobber).
+          #
+          # --prerelease=false is explicit on both paths: a release flagged as
+          # a prerelease cannot also be marked --latest (GitHub returns
+          # "Latest release cannot be draft or prerelease."). The tag may have
+          # been left behind by the previous beta pipeline as a prerelease, so
+          # we always clear that flag while promoting it to latest.
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release edit "$TAG" \
               --title "OpenLieroX ${VERSION_FULL} (latest master)" \
               --notes "$NOTES" \
+              --prerelease=false \
               --latest
           else
             gh release create "$TAG" \
               --title "OpenLieroX ${VERSION_FULL} (latest master)" \
               --notes "$NOTES" \
+              --prerelease=false \
               --latest \
               --target "$GITHUB_SHA"
           fi


### PR DESCRIPTION
## Problem

The `Latest master` workflow's **Publish latest master release** job failed ([run](https://github.com/openlierox/openlierox/actions/runs/27696232819)):

```
HTTP 422: Validation Failed (https://api.github.com/repos/openlierox/openlierox/releases/340812535)
Latest release cannot be draft or prerelease.
```

All six platform builds succeeded; only the publish step failed.

## Root cause

The rolling `master-beta-latest` release tag still exists from the **old beta pipeline**, where it was created as a **Pre-release**. The new rolling-release workflow (#931) does:

```sh
gh release edit "$TAG" ... --latest
```

GitHub refuses to mark a release as `--latest` while it is still flagged as a prerelease, so the step exits 1.

## Fix

Pass `--prerelease=false` on both the `edit` and `create` paths, so the tag is always cleared of the prerelease flag while being promoted to `--latest`. Merging this re-triggers the pipeline on master, which will then clear the stale flag on the existing release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)