### PR TITLE
Also publish an archival per-version release

### DIFF
--- a/.github/workflows/master-release.yaml
+++ b/.github/workflows/master-release.yaml
@@ -82,14 +82,28 @@ jobs:
         run: |
           set -euo pipefail
 
-          NOTES="$(cat <<EOF
+          # Notes differ per release: the rolling one explains that artifacts
+          # accumulate; the archival one is a fixed snapshot of a single build.
+          NOTES_ROLLING="$(cat <<EOF
           Automated build of OpenLieroX **${VERSION}**.
 
           - Branch: \`${GITHUB_REF_NAME}\`
           - Commit: ${GITHUB_SHA}
 
           This is a rolling "latest" release. New build artifacts are added on
-          every merge; previously published artifacts are kept.
+          every merge; previously published artifacts are kept. For a specific
+          build, see the per-version release tagged \`${VERSION}\`.
+          EOF
+          )"
+
+          NOTES_VERSION="$(cat <<EOF
+          Automated build of OpenLieroX **${VERSION}**.
+
+          - Branch: \`${GITHUB_REF_NAME}\`
+          - Commit: ${GITHUB_SHA}
+
+          Archival release for this exact version. The rolling
+          \`${TAG}\` release always points at the newest build.
           EOF
           )"
 
@@ -117,28 +131,48 @@ jobs:
           echo "Publishing assets:"
           printf '  %s\n' "${ASSETS[@]}"
 
-          # Ensure the rolling "latest" release exists, then add this build's
-          # artifacts to it. Old artifacts are kept; only assets whose names
-          # collide with the incoming ones are overwritten (--clobber).
+          # Ensure a release exists for the given tag (creating it on the right
+          # commit if missing, updating its title/notes if it already does),
+          # then add this build's artifacts to it. Existing assets whose names
+          # collide with the incoming ones are overwritten (--clobber); any
+          # others are kept.
           #
-          # --prerelease=false is explicit on both paths: a release flagged as
-          # a prerelease cannot also be marked --latest (GitHub returns
-          # "Latest release cannot be draft or prerelease."). The tag may have
-          # been left behind by the previous beta pipeline as a prerelease, so
-          # we always clear that flag while promoting it to latest.
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release edit "$TAG" \
-              --title "OpenLieroX ${VERSION_FULL} (latest master)" \
-              --notes "$NOTES" \
-              --prerelease=false \
-              --latest
-          else
-            gh release create "$TAG" \
-              --title "OpenLieroX ${VERSION_FULL} (latest master)" \
-              --notes "$NOTES" \
-              --prerelease=false \
-              --latest \
-              --target "$GITHUB_SHA"
-          fi
+          # --prerelease=false is explicit: a release flagged as a prerelease
+          # cannot also be marked --latest (GitHub returns "Latest release
+          # cannot be draft or prerelease."), and the rolling tag may have been
+          # left behind by the previous beta pipeline as a prerelease, so we
+          # always clear that flag. --latest is passed an explicit true/false
+          # so exactly one release (the rolling one) carries the badge and the
+          # archival release never silently steals it.
+          publish_release() {
+            local tag="$1" title="$2" notes="$3" latest="$4"
+            if gh release view "$tag" >/dev/null 2>&1; then
+              gh release edit "$tag" \
+                --title "$title" \
+                --notes "$notes" \
+                --prerelease=false \
+                --latest="$latest"
+            else
+              gh release create "$tag" \
+                --title "$title" \
+                --notes "$notes" \
+                --prerelease=false \
+                --latest="$latest" \
+                --target "$GITHUB_SHA"
+            fi
+            gh release upload "$tag" "${ASSETS[@]}" --clobber
+          }
 
-          gh release upload "$TAG" "${ASSETS[@]}" --clobber
+          # Rolling "latest master" release: holds the GitHub "Latest" badge and
+          # accumulates artifacts across merges.
+          publish_release "$TAG" \
+            "OpenLieroX ${VERSION_FULL} (latest master)" \
+            "$NOTES_ROLLING" \
+            true
+
+          # Archival per-version release: one immutable snapshot per build,
+          # tagged with the bare version, never marked latest.
+          publish_release "$VERSION" \
+            "OpenLieroX ${VERSION_FULL}" \
+            "$NOTES_VERSION" \
+            false


### PR DESCRIPTION
## What

Publishes every master build to **two** releases instead of one, via a shared `publish_release()` helper in [master-release.yaml](.github/workflows/master-release.yaml):

1. **Rolling `master-beta-latest`** — keeps the GitHub **"Latest"** badge and accumulates artifacts across merges (unchanged behavior).
2. **Archival `<version>`** — tagged with the bare version from `./get_version.sh` (e.g. `20260617.7`), one immutable snapshot per build, **never** marked latest.

## Why

Gives a stable, permanent download URL for each specific version (archival/provenance) while keeping the convenient rolling "latest" pointer.

## Notes

- GitHub only allows one release to hold the "Latest" badge, so `--latest` is passed an explicit `true`/`false`: the rolling release carries the badge; the archival release passes `--latest=false` so it never silently steals it.
- `--prerelease=false` remains explicit on both paths (see prior fix in #932).
- The version from `get_version.sh` is date-based and unique per commit (`YYYYMMDD.N`), so each merge produces a fresh archival release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)