### PR TITLE
Publish to Google Play only on merge (not on preview)

### DIFF
--- a/.github/workflows/master-release.yaml
+++ b/.github/workflows/master-release.yaml
@@ -19,6 +19,13 @@ jobs:
     uses: ./.github/workflows/package-android.yml
     secrets: inherit
 
+  # Publish to the Play Store only on merge, after the Android build has
+  # produced and uploaded the signed bundle. PRs build but never publish.
+  publish-google-play:
+    needs: android
+    uses: ./.github/workflows/publish-to-google-play.yaml
+    secrets: inherit
+
   linux-bundle:
     uses: ./.github/workflows/package-linux-bundle.yml
     secrets: inherit

--- a/.github/workflows/package-android.yml
+++ b/.github/workflows/package-android.yml
@@ -110,13 +110,12 @@ jobs:
           path: build/android/output/openlierox-*-android.apk
           if-no-files-found: error
 
-      - name: Publish to Play Store
-        uses: r0adkll/upload-google-play@v1
-        continue-on-error: true
+      # Hand the signed bundle off as an artifact so the separate
+      # "Publish to Google Play" workflow can pick it up on merge. The
+      # build itself runs on every PR, but publishing must not.
+      - name: Upload Android App Bundle
+        uses: actions/upload-artifact@v7
         with:
-          serviceAccountJsonPlainText: ${{secrets.SERVICE_ACCOUNT_JSON}}
-          packageName: openlierox.net
-          releaseFiles: build/android/output/openlierox-release.aab
-          tracks: beta
-          #changesNotSentForReview: true
-          status: completed
+          name: openlierox-aab
+          path: build/android/output/openlierox-release.aab
+          if-no-files-found: error

--- a/.github/workflows/publish-to-google-play.yaml
+++ b/.github/workflows/publish-to-google-play.yaml
@@ -1,0 +1,32 @@
+name: Publish to Google Play
+
+# Publishes the signed Android App Bundle to the Play Store beta track.
+# This only runs on merges to master (invoked by master-release.yaml via
+# workflow_call), never on pull requests, so PRs build the bundle but
+# never publish it. The bundle is produced by package-android.yml and
+# passed across as the "openlierox-aab" artifact within the same run.
+on:
+  workflow_call:
+
+jobs:
+  publish:
+    name: Publish to Google Play
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Download Android App Bundle
+        uses: actions/download-artifact@v7
+        with:
+          name: openlierox-aab
+          path: build/android/output
+
+      - name: Publish to Play Store
+        uses: r0adkll/upload-google-play@v1
+        continue-on-error: true
+        with:
+          serviceAccountJsonPlainText: ${{secrets.SERVICE_ACCOUNT_JSON}}
+          packageName: openlierox.net
+          releaseFiles: build/android/output/openlierox-release.aab
+          tracks: beta
+          #changesNotSentForReview: true
+          status: completed


### PR DESCRIPTION
Publish to Google Play only on merge (not on preview)

This is to avoid accidental pushes to Google Play

See [discussion](https://github.com/openlierox/openlierox/discussions/936)