### PR TITLE
Manually bump android version (to fix Google Play out of sync)

### DIFF
--- a/build/android/app/build.gradle
+++ b/build/android/app/build.gradle
@@ -21,7 +21,7 @@ def architectures = project.hasProperty('architectures') ? project.architectures
 
 // versionCode = fixed base + number of commits on the current branch, so each
 // new commit automatically bumps the Play Store version code.
-def versionCodeBase = 10591008 // 0.59_beta10 Android revision 08
+def versionCodeBase = 10591026
 def gitCommitCount = { ->
     try {
         def proc = ['git', 'rev-list', '--count', 'HEAD'].execute(null, olxRoot)


### PR DESCRIPTION
Manually bump android version (to fix Google Play out of sync)

How it works:
* The review pipeline accidently created a .18 version and published it to the Google Play store
* This PR increases the gradle version counter by 18, so things we publish now should overwrite the old gradle number 

Fixes the issue discussed here:
https://github.com/openlierox/openlierox/discussions/936