### PR TITLE
Add gamepad joystick support (not just D-pad support)

### DIFF
--- a/doc/dev/GAMEPAD.md
+++ b/doc/dev/GAMEPAD.md
@@ -1,0 +1,170 @@
+# Gamepad support
+
+OpenLieroX can drive human players with a gamepad. There are two halves to it:
+
+- **Digital controls** — buttons, the d-pad and the triggers — are bound through
+  the normal key-mapping system (fire / jump / rope / weapon select /
+  previous-next weapon), exactly like keyboard keys.
+- **Analog sticks** add a **twin-stick** aiming/movement scheme on top: left
+  stick walks, right stick aims.
+
+Each human player uses their own pad — player 1 → pad 0, player 2 → pad 1, and so
+on. This applies to the human worms you control on your own machine, so it works
+the same in single-player, split-screen and network games (your own player gets
+gamepad control on your client).
+
+The key idea for the rest of this document: **the gamepad is added on top of the
+existing controls, it never replaces them.** Keyboard, mouse and d-pad behave
+exactly as they always did; the analog sticks are an extra input layer that only
+does something while a stick is actually pushed.
+
+## Controls at a glance
+
+| Input | What it does |
+|-------|--------------|
+| **Left stick** | Walks left/right. It *never turns the worm* — the worm keeps facing/aiming where the right stick points, i.e. strafing is always on. If the right stick is idle, the left stick also aims (so a one-stick player aims where they walk). |
+| **Right stick** | Aims. The stick's direction *is* the aim: left/right picks the facing side, up/down sets the aim angle. Wins over the left stick when both are pushed. |
+| **Buttons / triggers / d-pad** | Fire / jump / rope / weapon select / previous-next weapon — the normal, configurable gamepad bindings. |
+
+## Twin-stick controls
+
+This section covers the analog-stick half. A few behaviours worth knowing:
+
+- **Aim speed is capped, and there's a helper cursor.** The worm's aim does not
+  jump instantly to the stick; it *rotates toward* it at the same maximum speed a
+  keyboard player has, so a gamepad player can't out-aim the keyboard. To keep
+  this from feeling disconnected, two cursors are drawn: a **green cursor** jumps
+  instantly to where the stick points (your intended aim), and the normal cursor
+  shows the worm's actual aim catching up to it.
+- **Walking always digs.** Pushing the left stick into a wall tunnels straight
+  through it, in the walk direction, no matter where you're aiming.
+- **Aim holds when released.** The aim only updates while a stick is outside its
+  deadzone; let go of both sticks and the worm keeps its last aim.
+- **Weapon select.** On the weapon-selection screen the left stick moves the
+  cursor up/down (one row per push, then auto-repeats if held), alongside the
+  usual keyboard/d-pad keys.
+
+### Design rules (how the layering works)
+
+These three rules explain every code change below:
+
+1. **Additive, never a replacement.** The keyboard/mouse/d-pad aim and movement
+   code runs unconditionally, unchanged. The stick code runs *after* it and only
+   takes effect while a stick is pushed. With no stick touched, behaviour is
+   identical to before this feature.
+2. **The aim stick owns the facing.** While a stick is aiming, walking (with the
+   keys, d-pad, *or* the left stick) only moves the worm — it does not turn it.
+   So the right stick decides which way you face, overriding any walk input.
+3. **Aim speed is always capped** to the keyboard aim max speed. There is no
+   option to turn this off.
+
+### Engine note (important)
+
+Twin-stick runs on the **gusanos engine** (the default mods), not the classic
+LX56 path. Aiming, digging and shooting go through the gus code
+(`getPointingAngle()`, `CWorm::dig()`), not the LX56 crosshair/carve code — so
+several changes below only make sense because the gus engine is active.
+
+### Which worms get it
+
+It is decided per worm, at the top of `CWormHumanInputHandler::getInput()`:
+
+```cpp
+const int  twinPad   = localHumanWormIndex(m_worm); // 0 = first human, 1 = second, ...
+const bool twinStick = (twinPad >= 0) && isPadPresent(twinPad);
+```
+
+`localHumanWormIndex()` returns the worm's position among the human worms
+controlled on this machine (or −1) — in a network game that's your own player(s).
+That index doubles as its gamepad slot, so each human player you control gets
+twin-stick on the pad with the matching index; bots, remote players and humans
+without a pad are untouched. Extra controllers are opened into their slots
+automatically on SDL hotplug (`CInput::OnControllerAdded`).
+
+## Binding model
+
+The digital controls (buttons, d-pad, triggers) live in the gamepad binding
+table (`Joysticks[]` in `src/client/CInput.cpp`) and remain bindable via the
+`j<N>_<suffix>` config form. The analog sticks are **not** in that table — the
+four stick-axis entries were removed, so the sticks can't be mapped to actions in
+config. The twin-stick code reads them directly off the controller instead (see
+the readers below). The default gamepad bindings never used the sticks, so no
+defaults change.
+
+## Implementation map
+
+### `include/CInput.h` / `src/client/CInput.cpp` — raw stick readers
+The twin-stick code reads the physical controller directly so it doesn't depend
+on any key bindings:
+- `isPadPresent(padIndex)`
+- `getPadLeftStickX/Y(padIndex)`, `getPadRightStickX/Y(padIndex)` — raw axis
+  values, −32768..32767 (0 if the pad is absent).
+- `getPadStickDeadzone()` — the shared stick deadzone, so stick code and the
+  classic binding code agree on one value.
+
+These are thin wrappers over `SDL_GameControllerGetAxis`. Dedicated/headless
+builds (`DEDICATED_ONLY`) get stubs returning 0/false. The deadzone is set by
+`JOY_DEADZONE_PERCENT` (default **60%** of full deflection) — one knob to tune,
+or to expose in a UI later. This file also removes the stick axes from
+`Joysticks[]` (see [Binding model](#binding-model)).
+
+### `src/common/CWormHuman.cpp` (`getInput()`) — aiming & walking
+Resolves the active aim stick *before* the aim code into `stickAiming` +
+`(aimAx, aimAy)`: the right stick if it's past its deadzone, otherwise the left
+stick. While a stick is active it sets the facing side instantly, and computes
+the absolute target angle the stick points at
+(`targetAngle = CLAMP(atan2f(aimAy, |aimAx|) * 180/PI, -90, maxAngle)`).
+
+- **Aim (rule 1 + 3).** The keyboard/mouse aim block (`cUp`/`cDown`, i.e. the
+  d-pad) runs unchanged. Then, when a stick is aiming, `fAngle` *rotates toward*
+  `targetAngle` capped per frame to `aimMaxSpeed * dt` (`fAimMaxSpeed`, or 100°/s
+  under `FT_ForceLX56Aim`) — it never snaps. It also stores `fAimCursorAngle` and
+  sets `bAimCursorActive` for the cursor (drawn in `CWorm::draw`, below).
+- **Walk (rule 1 + 2).** The original `cLeft`/`cRight` movement block runs
+  unchanged. Its two `iFaceDirectionSide = ...` writes are gated by
+  `!stickAiming`, so while a stick aims, keyboard/d-pad walking only sets the
+  move direction and never turns the worm. A separate `if(twinStick)` block then
+  adds the left stick the same way (move direction only, never facing).
+- **Walk-to-dig.** In the left-stick walk branch, `ws->bCarve` is pulsed every
+  `carveDelay` (0.2s) while moving (`bCarve` is reset each frame, so the throttle
+  makes it pulse); `OlxInputToGusEvents()` then fires `baseActionStart(DIG)` on
+  each rising edge → `CWorm::dig()`.
+
+### `src/gusanos/base_worm.cpp` — aim vs. dig direction
+- **`getPointingAngle()`** now follows `iFaceDirectionSide` (the aim/right stick)
+  instead of `iMoveDirectionSide` (walk/left stick). In normal play face == move,
+  so nothing changes; while strafing it keeps the aim line, firecone and shots
+  pointing where the right stick aims.
+- **`getDiggingAngle()`** (new) is a purely horizontal angle along the *movement*
+  direction (`DIR_RIGHT → 90°`, `DIR_LEFT → 270°`). `CWorm::dig()` uses it
+  instead of `getPointingAngle()`, so walking into a wall always tunnels through
+  it regardless of aim.
+
+### `src/game/CWorm.h` / `src/common/CWorm.cpp` — the aim cursors
+- **`fAimCursorAngle` / `bAimCursorActive`** (new, render-only, **not**
+  networked). Set in `getInput()` whenever a stick is aiming; `bAimCursorActive`
+  is reset to false at the top of `getInput()` each frame. `fAimCursorAngle` uses
+  the same convention as `fAngle`.
+- **`CWorm::draw()`** draws the two cursors via the `drawAimCrosshair()` helper
+  when `bAimCursorActive && drawExtras && bLocal`: first the **green** cursor at
+  `fAimCursorAngle` (the stick's intended direction), then the **normal** cursor
+  at the worm's actual aim (`fAngle`) on top. They have **no** `gusEngineUsed()`
+  gate (unlike the classic crosshair), so they show on the gus engine where the
+  feature runs.
+
+## Angle & coordinate conventions (gotchas)
+
+- **`fAngle`** ranges −90..60 (or 90 with `FT_FullAimAngle`); negative = up,
+  positive = down. The left/right sign is **not** in `fAngle` — it's in
+  `iFaceDirectionSide`. Rendering/laser flip with `a = 180 - a` when facing left.
+- **Gus `Angle`**: `getAimAngle() == Angle(fAngle + 90)`. Aim right → 90°, up →
+  0°, down → 180°, left → 270°. `Vec(angle, len)` builds a direction from it.
+- **SDL sticks**: left/up = negative, right/down = positive. Deadzone is
+  `getPadStickDeadzone()`, derived from `JOY_DEADZONE_PERCENT` (60% → 19660).
+
+## Trying it out
+
+Build the client (see the top-level build docs), plug in a controller per human
+player (player 1 → first pad, player 2 → second pad, ...), start a game with
+those players, and the gamepad controls apply to each of them on their matching
+pad.

--- a/include/CInput.h
+++ b/include/CInput.h
@@ -167,6 +167,19 @@ bool isPlayer1KeyBinding(SDL_Keycode sym);
 // given controller instance ID drives, or -1 if not registered.
 int  getControllerPlayerSlot(SDL_JoystickID instanceID);
 
+// Twin-stick controls: raw analog stick values for the given 0-based gamepad
+// slot, range -32768..32767 (0 if pad absent). Read directly so the twin-stick
+// aim/move logic doesn't depend on any configurable key bindings; the analog
+// sticks are reserved for twin-stick control and are not separately bindable.
+bool isPadPresent(int padIndex);
+int  getPadLeftStickX(int padIndex);
+int  getPadLeftStickY(int padIndex);
+int  getPadRightStickX(int padIndex);
+int  getPadRightStickY(int padIndex);
+// Deadzone in raw axis units below which a stick is treated as centered.
+// Shared with the classic binding code so there's a single source of truth.
+int  getPadStickDeadzone();
+
 
 
 

--- a/include/CWormHuman.h
+++ b/include/CWormHuman.h
@@ -112,6 +112,13 @@ private:
 	bool jumping;
 	bool walkingLeft;
 	bool walkingRight;
+
+	// Gamepad left-stick navigation in the weapon-selection menu (the analog
+	// sticks aren't bindable, so the menu reads the pad directly). Tracks the
+	// stick so one push moves one row, with keyboard-style auto-repeat while held.
+	AbsTime	fLastWeaponSelStickMove;
+	bool	weaponSelStickHeld;
+	bool	weaponSelStickRepeated;
 };
 
 #endif  //  __CWORMHUMAN_H__

--- a/src/client/CInput.cpp
+++ b/src/client/CInput.cpp
@@ -191,6 +191,14 @@ bool isPlayer1KeyBinding(SDL_Keycode sym) {
 
 	
 	
+// Analog stick deadzone, expressed as a percentage of full stick deflection
+// (SDL analog axes range -32768..32767). Kept as a percentage so it's easy to
+// expose in a configuration UI later; the raw axis threshold used by the input
+// code is derived from it. Defined here (outside the dedicated/non-dedicated
+// split) so both the real readers and the dedicated stubs share one value.
+static const int JOY_DEADZONE_PERCENT = 60;
+static const int JOY_DEADZONE = (32767 * JOY_DEADZONE_PERCENT) / 100; // 60% -> 19660
+
 #ifdef DEDICATED_ONLY
 
 void updateAxisStates() {}
@@ -200,27 +208,35 @@ void CInput::OnControllerAdded(int) {}
 void CInput::OnControllerRemoved(int) {}
 int getControllerPlayerSlot(SDL_JoystickID) { return -1; }
 
+// Twin-stick control helpers — no joystick support in dedicated builds.
+bool isPadPresent(int) { return false; }
+int getPadLeftStickX(int) { return 0; }
+int getPadLeftStickY(int) { return 0; }
+int getPadRightStickX(int) { return 0; }
+int getPadRightStickY(int) { return 0; }
+int getPadStickDeadzone() { return JOY_DEADZONE; } // unused without joystick support
+
 #else
 
 #define HAVE_JOYSTICK
 
-// Analog stick deadzone (axes range -32768..32767)
-static const int JOY_DEADZONE = 8000;
+// JOY_DEADZONE is defined above (shared with the dedicated stubs).
 // Trigger threshold: triggers range 0..32767; fire at 75% travel
 static const int JOY_TRIGGER_THRESHOLD = 24576;
 
 // Binding table — maps the per-pad suffix to JOY_* flag and SDL constant.
 // Config strings use the form "j<N>_<suffix>" where N is 1-based pad index
-// (e.g. "j1_button_south", "j5_lefty_up"). Pad count is unbounded; the N is
+// (e.g. "j1_button_south", "j2_triggerright"). Pad count is unbounded; the N is
 // parsed at Setup() time and the suffix is matched against this table.
 // Text names use SDL's naming: SDL_GameControllerGetStringForButton/Axis
 // For axes:    sdl_index = SDL_GameControllerAxis
 // For buttons: sdl_index = SDL_GameControllerButton
+//
+// The analog sticks are deliberately NOT in this table: both sticks are
+// reserved for twin-stick controls (left stick walks, right stick aims; see
+// CWormHumanInputHandler::getInput), which read them directly rather than
+// through a binding. Only buttons, the d-pad and the triggers are bindable.
 joystick_t Joysticks[] = {
-	{ "lefty_up",      JOY_UP,             SDL_CONTROLLER_AXIS_LEFTY},
-	{ "lefty_down",    JOY_DOWN,           SDL_CONTROLLER_AXIS_LEFTY},
-	{ "leftx_left",    JOY_LEFT,           SDL_CONTROLLER_AXIS_LEFTX},
-	{ "leftx_right",   JOY_RIGHT,          SDL_CONTROLLER_AXIS_LEFTX},
 	{ "button_south",  JOY_BUTTON,         SDL_CONTROLLER_BUTTON_A},
 	{ "button_east",   JOY_BUTTON,         SDL_CONTROLLER_BUTTON_B},
 	{ "button_west",   JOY_BUTTON,         SDL_CONTROLLER_BUTTON_X},
@@ -232,10 +248,6 @@ joystick_t Joysticks[] = {
 	{ "rightstick",    JOY_BUTTON,         SDL_CONTROLLER_BUTTON_RIGHTSTICK},
 	{ "lshoulder",     JOY_BUTTON,         SDL_CONTROLLER_BUTTON_LEFTSHOULDER},
 	{ "rshoulder",     JOY_BUTTON,         SDL_CONTROLLER_BUTTON_RIGHTSHOULDER},
-	{ "rightx_left",   JOY_TURN_LEFT,      SDL_CONTROLLER_AXIS_RIGHTX},
-	{ "rightx_right",  JOY_TURN_RIGHT,     SDL_CONTROLLER_AXIS_RIGHTX},
-	{ "righty_up",     JOY_THROTTLE_LEFT,  SDL_CONTROLLER_AXIS_RIGHTY},
-	{ "righty_down",   JOY_THROTTLE_RIGHT, SDL_CONTROLLER_AXIS_RIGHTY},
 	{ "d_up",          JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_UP},
 	{ "d_down",        JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_DOWN},
 	{ "d_left",        JOY_HAT,            SDL_CONTROLLER_BUTTON_DPAD_LEFT},
@@ -327,6 +339,19 @@ static bool checkControllerState(int flag, int sdl_index, int idx)
 	}
 	return false;
 }
+
+// --- Twin-stick control helpers (raw analog values, -32768..32767) ---
+bool isPadPresent(int padIndex) { return getController(padIndex) != NULL; }
+static int rawAxis(int padIndex, SDL_GameControllerAxis axis) {
+	SDL_GameController* gc = getController(padIndex);
+	if(!gc) return 0;
+	return SDL_GameControllerGetAxis(gc, axis);
+}
+int getPadLeftStickX(int padIndex)  { return rawAxis(padIndex, SDL_CONTROLLER_AXIS_LEFTX); }
+int getPadLeftStickY(int padIndex)  { return rawAxis(padIndex, SDL_CONTROLLER_AXIS_LEFTY); }
+int getPadRightStickX(int padIndex) { return rawAxis(padIndex, SDL_CONTROLLER_AXIS_RIGHTX); }
+int getPadRightStickY(int padIndex) { return rawAxis(padIndex, SDL_CONTROLLER_AXIS_RIGHTY); }
+int getPadStickDeadzone() { return JOY_DEADZONE; }
 
 static void initController(int i, bool isTemp) {
 	if(i < 0) return;

--- a/src/client/Options.cpp
+++ b/src/client/Options.cpp
@@ -52,17 +52,19 @@ const std::string    ply_def2[] = {"kp 8",  "kp 5",    "kp 4",    "kp 6",     "k
 // second alternative alongside the keyboard defaults above, so each control
 // works from either input out of the box. The pad index is added at
 // registration time (j1 for player 1, j2 for player 2).
-// Movement and aiming are on the d-pad (digital); weapons are intentionally
-// left keyboard-only (you cycle them on the pad with SelectWeapon). Empty
-// string means "no gamepad binding for this control". Note we deliberately
-// avoid the right-stick-Y "throttle" axes here: those switch the worm to
-// analog aiming, which would override the keyboard's digital aiming when both
-// are bound to one control.
+// The analog sticks are NOT bound here: during play, walking and aiming come
+// from the twin-stick controls (left stick walks, right stick aims), which
+// read the sticks directly and are always active for a local human with a pad,
+// superseding these Up/Down/Left/Right bindings. The d-pad entries are kept
+// because they still drive non-gameplay input such as the weapon-select
+// screen. The Weapon1-5 quick-select slots are left keyboard-only (on the pad
+// you cycle weapons with Previous/Next Weapon on the shoulders). Empty string
+// means "no gamepad binding".
 const std::string    ply_gamepad_def[] = {
-	"d_up",         // Up           - d-pad up (aim up)
-	"d_down",       // Down         - d-pad down (aim down)
-	"d_left",       // Left         - d-pad left (move left)
-	"d_right",      // Right        - d-pad right (move right)
+	"d_up",         // Up           - d-pad up (weapon-select scroll up)
+	"d_down",       // Down         - d-pad down (weapon-select scroll down)
+	"d_left",       // Left         - d-pad left
+	"d_right",      // Right        - d-pad right
 	"triggerright", // Shoot        - right trigger
 	"button_south", // Jump         - A
 	"button_north", // Rope         - Y

--- a/src/common/CWorm.cpp
+++ b/src/common/CWorm.cpp
@@ -210,6 +210,8 @@ CWorm::CWorm() :
 	iFaceDirectionSide = DIR_RIGHT;
 	fAngle = 0.f;
 	fAngleSpeed = 0.f;
+	fAimCursorAngle = 0.f;
+	bAimCursorActive = false;
 	fMoveSpeedX = 0.f;
 	fFrame = 0;
 	bDrawMuzzle = false;
@@ -953,6 +955,25 @@ static INLINE bool _isWormVisible(CWorm* w, CViewport* v) {
 	return w->isVisible(v);
 }
 
+// Draw a crosshair sprite at the given aim angle (fAngle convention; the facing
+// side carries the left/right sign) at the crosshair distance from the worm.
+// spriteX selects the frame (0 = normal, 6 = green/target).
+static void drawAimCrosshair(SDL_Surface* bmpDest, const VectorD2<int>& wormPos, float angle, int faceSide, int spriteX) {
+	int a = (int)angle;
+	if(faceSide == DIR_LEFT)
+		a = 180 - a;
+
+	CVec forw;
+	GetVecsFromAngle((float)a, &forw, NULL);
+	forw *= tLXOptions->fCrosshairDistance;
+
+	VectorD2<int> cp = wormPos;
+	cp.x += (int)forw.x;
+	cp.y += (int)forw.y;
+
+	DrawImageAdv(bmpDest, DeprecatedGUI::gfxGame.bmpCrosshair, spriteX, 0, cp.x - 2, cp.y - 2, 6, 6);
+}
+
 Color CWorm::renderColorAt(/* relative game coordinates */ int x, int y) const {
 	if(!bAlive)
 		return Color(0,0,0,SDL_ALPHA_TRANSPARENT);
@@ -1158,6 +1179,25 @@ void CWorm::Draw(SDL_Surface * bmpDest, CViewport *v)
 		}
 
 		DrawImageAdv(bmpDest, DeprecatedGUI::gfxGame.bmpCrosshair, x, 0, cp.x - 2, cp.y - 2, 6, 6);
+	}
+
+	//
+	// Draw the gamepad aim cursors
+	//
+	// The worm's actual aim rotates toward the stick at keyboard speed, so it
+	// lags the stick. Two cursors are drawn (regardless of engine — the gamepad
+	// feature runs on the gus engine, which skips the classic crosshair above):
+	//  1. a green helper cursor at the direction the stick currently points
+	//     (fAimCursorAngle), giving instant feedback of the intended aim, and
+	//  2. on top of it, a normal cursor at the worm's *actual* current aim
+	//     (fAngle), so the player can see the real aim catching up to the helper.
+	// The worm aim cursor is drawn last so it stays visible above the helper.
+	if(bAimCursorActive && drawExtras && bLocal) {
+		// 1. Joystick aim helper cursor (green) at the stick's target direction,
+		//    then 2. the worm's actual aim (normal) on top, so the worm aim cursor
+		//    stays visible above the helper as the real aim catches up.
+		drawAimCrosshair(bmpDest, p, fAimCursorAngle, iFaceDirectionSide, 6);
+		drawAimCrosshair(bmpDest, p, fAngle, iFaceDirectionSide, 0);
 	}
 
 	//

--- a/src/common/CWormHuman.cpp
+++ b/src/common/CWormHuman.cpp
@@ -61,6 +61,21 @@ static bool isFirstLocalHumanWorm(const CWorm* worm) {
 	return false;
 }
 
+// Index of this worm among the local *human* worms (0 = first human player,
+// 1 = second, ...), or -1 if it isn't a local human worm. This doubles as the
+// gamepad slot the player uses: human player N is driven by gamepad N, so every
+// local human gets twin-stick controls on their own controller.
+static int localHumanWormIndex(const CWorm* worm) {
+	int idx = 0;
+	for_each_iterator(CWorm*, w, game.localWorms()) {
+		if(dynamic_cast<CWormHumanInputHandler*>(w->get()->inputHandler())) {
+			if(w->get() == worm) return idx;
+			idx++;
+		}
+	}
+	return -1;
+}
+
 ///////////////////
 // Get the input from a human worm
 void CWormHumanInputHandler::getInput() {
@@ -162,23 +177,49 @@ void CWormHumanInputHandler::getInput() {
 			notes("dt: %f\n", dt); */
 	}
 
-	// angle section
+	// ---- Twin-stick controls (any local human player on their pad) ----
+	// Left stick walks, right stick aims. Walking never turns the worm
+	// (strafing is effectively always on) — the right stick alone decides the
+	// facing side and the exact aim angle. Each local human player uses the
+	// gamepad with the same index (player N -> pad N). Always active for a
+	// local human with a connected pad: the analog sticks are reserved for
+	// this and are not separately bindable.
+	const int twinPad = localHumanWormIndex(m_worm);
+	const bool twinStick = (twinPad >= 0) && isPadPresent(twinPad);
+	const int twinDeadzone = getPadStickDeadzone();
+
+	// Twin-stick aim source, resolved before the angle section so the keyboard
+	// aim path can be shared. The right stick is the primary aim stick; if it's
+	// idle the left stick drives the aim (so a single-stick player aims where
+	// they walk), and when both are pushed the right stick wins.
+	bool stickAiming = false;
+	int aimAx = 0, aimAy = 0; // chosen stick (SDL: up/left negative, down/right positive)
+	if(twinStick) {
+		const int rx = getPadRightStickX(twinPad);
+		const int ry = getPadRightStickY(twinPad);
+		const int lx = getPadLeftStickX(twinPad);
+		const int ly = getPadLeftStickY(twinPad);
+		const bool rightAiming = (rx*rx + ry*ry > twinDeadzone*twinDeadzone);
+		const bool leftAiming  = (lx*lx + ly*ly > twinDeadzone*twinDeadzone);
+		if(rightAiming || leftAiming) {
+			stickAiming = true;
+			aimAx = rightAiming ? rx : lx;
+			aimAy = rightAiming ? ry : ly;
+			// Horizontal sign picks the facing side instantly (keyboard players
+			// also turn instantly by walking).
+			m_worm->setFaceDirectionSide((aimAx >= 0) ? DIR_RIGHT : DIR_LEFT);
+		}
+	}
+	// Reset the aim cursor each frame; the stick limit-aim path below turns it on
+	// when active (an instantaneous marker showing where the stick points while
+	// the worm's actual aim rotates toward it at keyboard speed).
+	m_worm->bAimCursorActive = false;
+
+	// angle section: keyboard / mouse / d-pad aiming. Runs unconditionally and
+	// unchanged from before this PR — the d-pad up/down keeps aiming through the
+	// normal key-mapping system exactly as it always did. The stick aim is
+	// layered on after this block.
 	{
-		static const float joystickCoeff = 150.0f/65536.0f;
-		static const float joystickShift = 15; // 15 degrees
-
-		// Joystick up
-		if (cDown.isJoystickThrottle())  {
-			m_worm->fAngleSpeed = 0;
-			m_worm->fAngle = CLAMP((float)cUp.getJoystickValue() * joystickCoeff - joystickShift, -90.0f, 60.0f);
-		}
-
-		// Joystick down
-		if (cDown.isJoystickThrottle())  {
-			m_worm->fAngleSpeed = 0;
-			m_worm->fAngle = CLAMP((float)cUp.getJoystickValue() * joystickCoeff - joystickShift, -90.0f, 60.0f);
-		}
-
 		float aimMaxSpeed = MAX((float)fabs(tLXOptions->fAimMaxSpeed), 20.0f); // Note: 100 was LX56 max aimspeed
 		float aimAccel = MAX((float)fabs(tLXOptions->fAimAcceleration), 100.0f); // HINT: 500 is the LX56 value here (rev 1)
 		float aimFriction = CLAMP(tLXOptions->fAimFriction, 0.0f, 1.0f); // we didn't had that in LX56; it behaves more natural
@@ -188,14 +229,14 @@ void CWormHumanInputHandler::getInput() {
 			aimAccel = 500;
 			aimLikeLX56 = true;
 		}
-		
-		if((cUp.isDown() || tUp) && !cUp.isJoystickThrottle()) { // Up
+
+		if(cUp.isDown() || tUp) { // Up
 			m_worm->fAngleSpeed -= aimAccel * dt.seconds();
 			if(!aimLikeLX56) CLAMP_DIRECT(m_worm->fAngleSpeed, -aimMaxSpeed, aimMaxSpeed);
-		} else if((cDown.isDown() || tDown) && !cDown.isJoystickThrottle()) { // Down
+		} else if(cDown.isDown() || tDown) { // Down
 			m_worm->fAngleSpeed += aimAccel * dt.seconds();
 			if(!aimLikeLX56) CLAMP_DIRECT(m_worm->fAngleSpeed, -aimMaxSpeed, aimMaxSpeed);
-		} else {			
+		} else {
 			if(!mouseControl) {
 				// HINT: this is the original order and code (before mouse patch - rev 1007)
 				CLAMP_DIRECT(m_worm->fAngleSpeed, -aimMaxSpeed, aimMaxSpeed);
@@ -222,7 +263,39 @@ void CWormHumanInputHandler::getInput() {
 		m_worm->fAngle += m_worm->fAngleSpeed * dt.seconds();
 		if(CLAMP_DIRECT(m_worm->fAngle.write(), -90.0f, cClient->getGameLobby()[FT_FullAimAngle] ? 90.0f : 60.0f) != 0)
 			m_worm->fAngleSpeed = 0;
+	}
 
+	// Additionally, the analog sticks aim (joystick add-on). The facing side was
+	// already set above. The stick direction gives an absolute target angle: the
+	// angle above/below horizontal (atan2 against |aimAx| measures it from
+	// horizontal; the left/right sign is carried by the facing side; SDL Y is
+	// negative-up, matching the engine's positive-down convention).
+	if(stickAiming) {
+		const float maxAngle = cClient->getGameLobby()[FT_FullAimAngle] ? 90.0f : 60.0f;
+		float ang = atan2f((float)aimAy, fabsf((float)aimAx)) * (180.0f / (float)PI);
+		const float targetAngle = CLAMP(ang, -90.0f, maxAngle);
+
+		// Rotate the actual aim toward the stick target, but no faster than a
+		// keyboard player can (fAimMaxSpeed, or 100°/s under FT_ForceLX56Aim),
+		// capped per frame, so a gamepad player can't aim faster than a keyboard
+		// player. The worm thus "eventually ends" at the stick angle. A separate
+		// instantaneous cursor (drawn in CWorm::draw) shows the target direction
+		// right away, so the player still gets direct feedback of where they're
+		// aiming while the worm catches up.
+		float aimMaxSpeed = MAX((float)fabs(tLXOptions->fAimMaxSpeed), 20.0f);
+		if(cClient->getGameLobby()[FT_ForceLX56Aim] || cClient->getServerVersion() < OLXRcVersion(0,58,3))
+			aimMaxSpeed = 100; // LX56 keyboard aim max speed
+		const float maxStep = aimMaxSpeed * dt.seconds();
+		float diff = targetAngle - m_worm->getAngle();
+		CLAMP_DIRECT(diff, -maxStep, maxStep);
+		m_worm->fAngle = m_worm->getAngle() + diff;
+		m_worm->fAngleSpeed = 0;
+
+		// Feed the instantaneous cursor: store the target angle (fAngle
+		// convention; the facing side carries the left/right sign) and flag it
+		// on for this frame.
+		m_worm->fAimCursorAngle = targetAngle;
+		m_worm->bAimCursorActive = true;
 	} // end angle section
 
 	const CVec ninjaShootDir = m_worm->getFaceDirection();
@@ -386,13 +459,21 @@ void CWormHumanInputHandler::getInput() {
 	}
 
 
+	// Keyboard / d-pad movement. Runs unconditionally. With no aim stick active
+	// it is unchanged from before this PR — the d-pad left/right walks *and
+	// turns* the worm through the normal key-mapping system exactly as it always
+	// did. While a stick is aiming (stickAiming), the aim stick owns the facing
+	// side, so walking here only moves and never turns: the worm strafes and
+	// keeps aiming where the stick points (the right stick thus overrides the
+	// facing from keyboard/d-pad walking, not just from the left stick). The
+	// left stick walk add-on below also only moves, never turns.
 	if(!(cSelWeapon.isDown() || tSelWeap)) {
 		if(cLeft.isDown() || tLeft) {
 			ws->bMove = true;
 			m_worm->lastMoveTime = tLX->currentTime;
 
 			if(!(cRight.isDown() || tRight)) {
-				if(!cClient->isHostAllowingStrafing() || !(cStrafe.isDown() || tStrafe)) m_worm->iFaceDirectionSide = DIR_LEFT;
+				if(!stickAiming && (!cClient->isHostAllowingStrafing() || !(cStrafe.isDown() || tStrafe))) m_worm->iFaceDirectionSide = DIR_LEFT;
 				m_worm->iMoveDirectionSide = DIR_LEFT;
 			}
 
@@ -407,7 +488,7 @@ void CWormHumanInputHandler::getInput() {
 			m_worm->lastMoveTime = tLX->currentTime;
 
 			if(!(cLeft.isDown() || tLeft)) {
-				if(!cClient->isHostAllowingStrafing() || !(cStrafe.isDown() || tStrafe)) m_worm->iFaceDirectionSide = DIR_RIGHT;
+				if(!stickAiming && (!cClient->isHostAllowingStrafing() || !(cStrafe.isDown() || tStrafe))) m_worm->iFaceDirectionSide = DIR_RIGHT;
 				m_worm->iMoveDirectionSide = DIR_RIGHT;
 			}
 
@@ -421,6 +502,30 @@ void CWormHumanInputHandler::getInput() {
 		if(!cClient->isHostAllowingStrafing() && cStrafe.isDownOnce())
 			// TODO: perhaps in chat?
 			hints << "strafing is not allowed on this server." << endl;
+	}
+
+	// Additionally, the left stick walks (joystick add-on). Strafe: it sets the
+	// movement direction but never the facing side, so the worm keeps aiming
+	// where the sticks point regardless of which way it walks. Walking always
+	// digs. When the stick is idle this does nothing, leaving the keyboard/d-pad
+	// movement above untouched.
+	if(twinStick) {
+		const float carveDelay = 0.2f; // same throttle as the mouse/touch carve below
+		const int lx = getPadLeftStickX(twinPad);
+		if(abs(lx) > twinDeadzone) {
+			ws->bMove = true;
+			m_worm->lastMoveTime = tLX->currentTime;
+			m_worm->iMoveDirectionSide = (lx < 0) ? DIR_LEFT : DIR_RIGHT;
+
+			// Walking always digs: pulse carve in the walk direction (throttled)
+			// so the worm tunnels straight through dirt instead of stopping at
+			// a wall. bCarve is reset to false each frame, so the throttle makes
+			// it pulse, which the gus DIG action triggers on each rising edge.
+			if(tLX->currentTime - m_worm->fLastCarve >= carveDelay) {
+				ws->bCarve = true;
+				m_worm->fLastCarve = tLX->currentTime;
+			}
+		}
 	}
 
 
@@ -518,6 +623,8 @@ WormType* PRF_HUMAN = &PRF_HUMAN_instance;
 CWormHumanInputHandler::CWormHumanInputHandler(CWorm* w) : CWormInputHandler(w) {
 	bRopeDown = bRopeDownOnce = false;
 	m_localPlayerSlot = -1;
+	weaponSelStickHeld = false;
+	weaponSelStickRepeated = false;
 	gusInit();
 	
 	game.onNewPlayer( this );
@@ -826,21 +933,45 @@ void CWormHumanInputHandler::doWeaponSelectionFrame(SDL_Surface * bmpDest, CView
 	
 	if(!bChat_Typing) {
 		// move selection up or down
-		if (cDown.isJoystickThrottle() || cUp.isJoystickThrottle())  {
-			m_worm->iCurrentWeapon = (cUp.getJoystickValue() + 32768) * (m_worm->tWeapons.size() + 2) / 65536; // We have 7 rows and 65536 throttle states
-			
-		} else {
-			int change = cDown.wasDown() - cUp.wasDown();
-			if(touchForThisWorm) {
-				// tapCount() returns (and consumes) every queued tap, so a
-				// burst of taps during a slow frame still moves N rows.
-				change += TouchScreenInput::tapCount(1, TouchScreenInput::Action::Down);
-				change -= TouchScreenInput::tapCount(1, TouchScreenInput::Action::Up);
-			}
-			m_worm->iCurrentWeapon += change;
-			m_worm->iCurrentWeapon %= (int)m_worm->tWeapons.size() + 2;
-			if(m_worm->iCurrentWeapon < 0) m_worm->iCurrentWeapon += (int)m_worm->tWeapons.size() + 2;
+		int change = cDown.wasDown() - cUp.wasDown();
+		if(touchForThisWorm) {
+			// tapCount() returns (and consumes) every queued tap, so a
+			// burst of taps during a slow frame still moves N rows.
+			change += TouchScreenInput::tapCount(1, TouchScreenInput::Action::Down);
+			change -= TouchScreenInput::tapCount(1, TouchScreenInput::Action::Up);
 		}
+
+		// Gamepad left stick navigates up/down too. The sticks aren't bindable
+		// (the in-game twin-stick path owns them), so read the pad directly via
+		// the same helpers and slot mapping (player N -> pad N). Push up/down to
+		// move one row, then it auto-repeats while held, mimicking key-repeat.
+		const int padSlot = localHumanWormIndex(m_worm);
+		if(padSlot >= 0 && isPadPresent(padSlot)) {
+			const int ly = getPadLeftStickY(padSlot); // SDL: up negative, down positive
+			const int dz = getPadStickDeadzone();
+			const int dir = (ly < -dz) ? -1 : (ly > dz) ? 1 : 0;
+			if(dir == 0) {
+				weaponSelStickHeld = false;
+			} else if(!weaponSelStickHeld) {
+				// rising edge: move one row right away
+				change += dir;
+				weaponSelStickHeld = true;
+				weaponSelStickRepeated = false;
+				fLastWeaponSelStickMove = tLX->currentTime;
+			} else {
+				// held: wait longer before the first repeat, then repeat faster
+				const float delay = weaponSelStickRepeated ? 0.12f : 0.4f;
+				if(tLX->currentTime - fLastWeaponSelStickMove >= delay) {
+					change += dir;
+					weaponSelStickRepeated = true;
+					fLastWeaponSelStickMove = tLX->currentTime;
+				}
+			}
+		}
+
+		m_worm->iCurrentWeapon += change;
+		m_worm->iCurrentWeapon %= (int)m_worm->tWeapons.size() + 2;
+		if(m_worm->iCurrentWeapon < 0) m_worm->iCurrentWeapon += (int)m_worm->tWeapons.size() + 2;
 	}
 
 	stopInputSystem(); // if not done yet... otherwise it will also not hurt. it will shut down the regular ingame input system

--- a/src/game/CWorm.h
+++ b/src/game/CWorm.h
@@ -248,6 +248,14 @@ protected:
 	ATTR(CWorm, float,	fAngle, 26, {serverside = false; serverCanUpdate = false;})
     float       fAngleSpeed;
     float		fMoveSpeedX;
+
+	// Gamepad twin-stick aim cursor (local, render-only). The worm's aim rotates
+	// toward the stick angle at keyboard speed; this is the instantaneous target
+	// the stick points at, drawn as a separate cursor so the player sees their
+	// intended aim right away. Same convention as fAngle (the facing side carries
+	// the left/right sign). Not networked.
+	float		fAimCursorAngle;
+	bool		bAimCursorActive;
 	
 	ATTR(CWorm,	float,	fSpeedFactor, 30, { defaultValue = 1.0f; })
 	ATTR(CWorm, bool,	bCanUseNinja, 31, { defaultValue = true; })
@@ -694,6 +702,7 @@ public:
 	//right ( it will wrap the value so that its always inside the worm's weapons size )
 	int getWeaponIndexOffset( int offset );
 	Angle getPointingAngle();
+	Angle getDiggingAngle(); // walk-direction dig angle (twin-stick: walking into a wall digs)
 	void setDir(int d); // Only use this if you are going to sync it over netplay with an event
 	int getDir()
 	{

--- a/src/gusanos/base_worm.cpp
+++ b/src/gusanos/base_worm.cpp
@@ -438,7 +438,21 @@ Vec CWorm::getRenderPos()
 
 Angle CWorm::getPointingAngle()
 {
-	return (iMoveDirectionSide == DIR_RIGHT) ? getAimAngle() : (Angle(360.0) - getAimAngle());
+	// Aim/pointing follows the *facing* side, not the movement side. They are
+	// identical in normal play (walking turns the worm), but the twin-stick
+	// controls decouple them: the right stick sets the facing/aim while the left
+	// stick walks (strafe). Using the facing side keeps the aim line, firecone
+	// and shots pointing where the player is actually aiming.
+	return (iFaceDirectionSide == DIR_RIGHT) ? getAimAngle() : (Angle(360.0) - getAimAngle());
+}
+
+Angle CWorm::getDiggingAngle()
+{
+	// Digging goes straight along the *movement* (walk) direction, so walking
+	// into a wall always tunnels through it regardless of where the worm is
+	// aiming. 90deg == horizontal-right, 270deg == horizontal-left in this
+	// angle convention (see getAimAngle: horizontal aim -> 90deg).
+	return (iMoveDirectionSide == DIR_RIGHT) ? Angle(90.0) : Angle(270.0);
 }
 
 int CWorm::getWeaponIndexOffset( int offset )
@@ -586,14 +600,14 @@ void CWorm::dig()
 {
 	if( weOwnThis() || !m_node ) {
 		if ( getAlive() ) {
-			dig( pos(), getPointingAngle() );
-		
+			dig( pos(), getDiggingAngle() );
+
 			// NetWorm code
 			if( weOwnThis() && m_node ) {
 				BitStream *data = new BitStream;
 				addEvent(data, Dig);
 				game.gameMap()->vectorEncoding.encode<Vec>(*data, pos());
-				data->addInt(int(getPointingAngle()), Angle::prec);
+				data->addInt(int(getDiggingAngle()), Angle::prec);
 				m_node->sendEvent(eNet_ReliableOrdered, Net_REPRULE_AUTH_2_ALL, data);
 			}
 		}


### PR DESCRIPTION
The current gamepad support only allows playing with the button and D-pad in a good way. This PR makes it possible to use the joystick of the gamepad, both for walking and aiming. The aim speed is limited to the aim speed of the arrow keys to not give this way of playing any advantage over keyboard (just the same as aim speed is the same)

The gamepad support is described in detail in [GAMEPAD.md](https://github.com/openlierox/openlierox/pull/941/changes#diff-9b368d3d7e9c925cb6ffa1a8e8fdf5b6f800bed1b9e6c11aae4728fdfed64ea6)