### PR TITLE
Restore "Fix fullscreen for modern android" as there is no release of the SDL fix as of now

### DIFF
--- a/build/android/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/build/android/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -38,6 +38,8 @@ import android.view.Surface;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.view.WindowInsets;
+import android.view.WindowInsetsController;
 import android.view.WindowManager;
 import android.view.inputmethod.BaseInputConnection;
 import android.view.inputmethod.EditorInfo;
@@ -773,21 +775,10 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
                         Window window = ((Activity) context).getWindow();
                         if (window != null) {
                             if ((msg.obj instanceof Integer) && ((Integer) msg.obj != 0)) {
-                                int flags = View.SYSTEM_UI_FLAG_FULLSCREEN |
-                                        View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
-                                        View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY |
-                                        View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
-                                        View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
-                                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.INVISIBLE;
-                                window.getDecorView().setSystemUiVisibility(flags);
-                                window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-                                window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+                                mSystemUiController.hideSystemUi(window);
                                 SDLActivity.mFullscreenModeActive = true;
                             } else {
-                                int flags = View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_VISIBLE;
-                                window.getDecorView().setSystemUiVisibility(flags);
-                                window.addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
-                                window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                                mSystemUiController.showSystemUi(window);
                                 SDLActivity.mFullscreenModeActive = false;
                             }
                             if (Build.VERSION.SDK_INT >= 28 /* Android 9 (Pie) */) {
@@ -1620,19 +1611,80 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         dialog.show();
     }
 
+    // Hiding the status & navigation bars (immersive fullscreen) is done in two
+    // completely different ways depending on the OS, so each lives in its own
+    // implementation of SystemUiController instead of being spelled out with an
+    // SDK_INT check at every call site. mSystemUiController picks the right one
+    // once, below.
+    private interface SystemUiController {
+        /** Enter immersive fullscreen: hide the status & navigation bars. */
+        void hideSystemUi(Window window);
+        /** Leave fullscreen: show the status & navigation bars again. */
+        void showSystemUi(Window window);
+    }
+
+    // Android 11+ (API 30). The legacy setSystemUiVisibility() flags are ignored
+    // on Android 15+ (API 35+), where edge-to-edge is enforced for apps
+    // targeting that SDK, so the bars would never hide (e.g. on a Samsung S25).
+    private static class ModernSystemUiController implements SystemUiController {
+        @Override
+        public void hideSystemUi(Window window) {
+            window.setDecorFitsSystemWindows(false);
+            final WindowInsetsController controller = window.getInsetsController();
+            if (controller != null) {
+                controller.hide(WindowInsets.Type.systemBars());
+                // Sticky-immersive: a swipe shows the bars transiently, then
+                // they auto-hide again (replaces SYSTEM_UI_FLAG_IMMERSIVE_STICKY).
+                controller.setSystemBarsBehavior(
+                        WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+            }
+        }
+
+        @Override
+        public void showSystemUi(Window window) {
+            window.setDecorFitsSystemWindows(true);
+            final WindowInsetsController controller = window.getInsetsController();
+            if (controller != null) {
+                controller.show(WindowInsets.Type.systemBars());
+            }
+        }
+    }
+
+    // Android 10 and below (API < 30): the pre-Android-11 immersive-sticky API.
+    private static class LegacySystemUiController implements SystemUiController {
+        @Override
+        public void hideSystemUi(Window window) {
+            int flags = View.SYSTEM_UI_FLAG_FULLSCREEN |
+                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
+                    View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY |
+                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
+                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.INVISIBLE;
+            window.getDecorView().setSystemUiVisibility(flags);
+            window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+        }
+
+        @Override
+        public void showSystemUi(Window window) {
+            int flags = View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_VISIBLE;
+            window.getDecorView().setSystemUiVisibility(flags);
+            window.addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+            window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+        }
+    }
+
+    // The single place the OS version is checked. Everything else just calls
+    // mSystemUiController.hide/showSystemUi().
+    private static final SystemUiController mSystemUiController =
+            (Build.VERSION.SDK_INT >= 30 /* Android 11 (R) */)
+                    ? new ModernSystemUiController()
+                    : new LegacySystemUiController();
+
     private final Runnable rehideSystemUi = new Runnable() {
         @Override
         public void run() {
-            if (Build.VERSION.SDK_INT >= 19 /* Android 4.4 (KITKAT) */) {
-                int flags = View.SYSTEM_UI_FLAG_FULLSCREEN |
-                        View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
-                        View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY |
-                        View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
-                        View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
-                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.INVISIBLE;
-
-                SDLActivity.this.getWindow().getDecorView().setSystemUiVisibility(flags);
-            }
+            mSystemUiController.hideSystemUi(SDLActivity.this.getWindow());
         }
     };
 


### PR DESCRIPTION
I realise the fix we did in SDL has not been released yet, so we keep using the in-openlierox-fix until there is a release with a SDL based one