### PR TITLE
[work in progress] Android: re-extract bundled gamedir data when its content changes (from updates)

### DIFF
--- a/build/android/ANDROID-PORT.md
+++ b/build/android/ANDROID-PORT.md
@@ -231,6 +231,15 @@ On launch the activity:
    `assets/gamedir/` tree into `getFilesDir()/OpenLieroX/` and writes
    the new version marker.
 
+`gamedir.version` is `"<olx-version> data:<sha1>"`, where the sha1 is a content
+hash of the fully-staged `gamedir` tree (computed in `build-android.sh`). It is
+deliberately **not** just the git version: editing bundled data without bumping
+the git version (e.g. uncommitted changes, or rebuilding the same commit) would
+otherwise leave the marker unchanged, so the device would keep serving a stale
+copy and the new data would never be extracted. Hashing the staged tree means
+*any* change to bundled data changes the marker and forces a re-extract, while
+identical data is left untouched. 
+
 The native build sees `getFilesDir() == /data/data/net.openlierox/files`,
 which is what `SYSTEM_DATA_DIR` resolves to.
 

--- a/build/android/build-android.sh
+++ b/build/android/build-android.sh
@@ -113,9 +113,29 @@ if [ "$SKIP_DATA" -eq 0 ]; then
         exit 1
     fi
     cp "$ANDROID_DIR/deps/cacert.pem" "$ANDROID_DIR/output/assets/gamedir/cacert.pem"
-    # Drop a marker so the runtime can check that the data was extracted.
-    # get_version.sh fails the build if the version can't be determined.
-    "$OLX_ROOT/get_version.sh" > "$ANDROID_DIR/output/assets/gamedir.version"
+    # Drop a version marker the runtime compares against to decide whether to
+    # re-extract the bundled data (see OpenLieroXActivity.extractGamedirIfNeeded).
+    #
+    # This must change whenever the *bundled data* changes, otherwise the device
+    # keeps using a stale copy from a previous install. The git version alone is
+    # not enough: editing data without committing (or rebuilding the same commit)
+    # leaves the version string unchanged, so the new data never gets extracted.
+    #
+    # So base the marker on a content hash of the fully-staged gamedir (the git
+    # version is kept in the string too, for readable logs). Any change to any
+    # bundled file -> different hash -> the runtime re-extracts.
+    olx_version="$("$OLX_ROOT/get_version.sh")"   # fails the build if undeterminable
+    data_hash="$(cd "$ANDROID_DIR/output/assets" \
+        && find gamedir -type f -print0 \
+        | LC_ALL=C sort -z \
+        | xargs -0 sha1sum \
+        | sha1sum | cut -c1-40)"
+    if [ -z "$data_hash" ]; then
+        echo "ERROR: failed to hash staged gamedir for the version marker." >&2
+        exit 1
+    fi
+    printf '%s data:%s\n' "$olx_version" "$data_hash" \
+        > "$ANDROID_DIR/output/assets/gamedir.version"
 fi
 
 # ---------- gradle build ---------------------------------------------------


### PR DESCRIPTION
**Summery:** the "gamedir" folder does not seem to upgrade, when upgrading the Android app. This PR aims to fix that