### PR TITLE
[not for merging, diagnosttics only] add gamepad diagnostics page

### DIFF
--- a/include/GamepadDiagnostics.h
+++ b/include/GamepadDiagnostics.h
@@ -60,6 +60,9 @@ const GamepadDbStatus& GetGamepadDbStatus();
 // Returns an empty string if the file can't be read.
 std::string ComputeFileCrc32(const std::string& path, size_t* outSize = NULL);
 
+// Compute a CRC32 checksum (lower-case hex) of an in-memory buffer.
+std::string ComputeBufferCrc32(const void* data, size_t len);
+
 // Enumerate the controllers SDL currently sees. This is a live query, so it
 // reflects hot-plugged pads each time it is called.
 std::vector<GamepadControllerInfo> GetDetectedControllers();

--- a/include/GamepadDiagnostics.h
+++ b/include/GamepadDiagnostics.h
@@ -1,0 +1,68 @@
+/////////////////////////////////////////
+//
+//             OpenLieroX
+//
+//   code under LGPL
+//
+/////////////////////////////////////////
+
+
+// Gamepad diagnostics
+//
+// Collects information about the bundled SDL game controller mapping
+// database (gamecontrollerdb.txt) and the controllers SDL currently
+// recognises. Surfaced in the Options -> Controls -> "Gamepad diagnostics"
+// sub-tab so users can quickly tell whether the mapping database loaded and
+// which pads were picked up.
+
+
+#ifndef __GAMEPAD_DIAGNOSTICS_H__
+#define __GAMEPAD_DIAGNOSTICS_H__
+
+#include <string>
+#include <vector>
+
+
+// Result of trying to load the bundled SDL game controller mapping database.
+// Filled in once at startup (see InitializeAuxLib) and read back by the
+// diagnostics page.
+struct GamepadDbStatus {
+	bool		attempted = false;	// did we try to load the bundled db at all?
+	bool		fileFound = false;	// was gamecontrollerdb.txt located in the gamedir?
+	bool		loaded = false;		// did SDL accept the file (added >= 0)?
+	int			mappingsAdded = -1;	// number of mappings SDL added (>= 0 on success)
+	size_t		fileSize = 0;		// size of the db file in bytes
+	std::string	path;				// resolved full path of the db file
+	std::string	checksum;			// CRC32 checksum of the db file (hex), empty if unknown
+	std::string	error;				// SDL error message if loading failed
+};
+
+
+// One currently-connected controller as seen by SDL, with the info that
+// tells us whether the mapping database recognised it.
+struct GamepadControllerInfo {
+	int			deviceIndex = -1;		// SDL joystick device index
+	std::string	name;					// human-readable name
+	std::string	guid;					// joystick GUID string
+	bool		isGameController = false;	// true if SDL has a GameController mapping for it
+	bool		hasMapping = false;		// true if a mapping string is available
+};
+
+
+// Record the outcome of loading the bundled mapping database. Called from
+// InitializeAuxLib; safe to call once.
+void SetGamepadDbStatus(const GamepadDbStatus& status);
+
+// Read back the recorded database load status.
+const GamepadDbStatus& GetGamepadDbStatus();
+
+// Compute a CRC32 checksum (lower-case hex) of the file at the given path.
+// Returns an empty string if the file can't be read.
+std::string ComputeFileCrc32(const std::string& path, size_t* outSize = NULL);
+
+// Enumerate the controllers SDL currently sees. This is a live query, so it
+// reflects hot-plugged pads each time it is called.
+std::vector<GamepadControllerInfo> GetDetectedControllers();
+
+
+#endif  //  __GAMEPAD_DIAGNOSTICS_H__

--- a/src/client/AuxLib.cpp
+++ b/src/client/AuxLib.cpp
@@ -143,28 +143,41 @@ bool InitializeAuxLib()
 			// https://github.com/mdqinc/SDL_GameControllerDB at build time and
 			// shipped in the gamedir, augmenting SDL's built-in mappings so
 			// that many more gamepads are recognised out of the box.
+			//
+			// Read the file through OLX's own game-file resolution (the same
+			// path every other gamedir resource uses) and feed the bytes to
+			// SDL from memory, rather than handing a path to
+			// SDL_GameControllerAddMappingsFromFile. On Android the gamedir
+			// lives in app-internal storage; GetFullFileName returns a path
+			// constructed from the last search root (external storage) when the
+			// lookup misses, and SDL's own file opener then can't read it
+			// ("Invalid RWops"). Reading the bytes ourselves resolves the file
+			// from the gamedir exactly like fonts and other data, on every
+			// platform.
 			GamepadDbStatus dbStatus;
 			dbStatus.attempted = true;
-			const std::string gcdbPath = GetFullFileName("gamecontrollerdb.txt");
-			if(gcdbPath.empty()) {
+			dbStatus.path = GetFullFileName("gamecontrollerdb.txt"); // informational
+			const std::string gcdbData = GetFileContents("gamecontrollerdb.txt");
+			if(gcdbData.empty()) {
 				notes << "no bundled gamecontrollerdb.txt found - using SDL's built-in mappings only" << endl;
 				dbStatus.fileFound = false;
 			} else {
 				dbStatus.fileFound = true;
-				dbStatus.path = gcdbPath;
-				// Checksum the file before handing it to SDL so the diagnostics
-				// page can confirm exactly which database is bundled.
-				dbStatus.checksum = ComputeFileCrc32(gcdbPath, &dbStatus.fileSize);
+				dbStatus.fileSize = gcdbData.size();
+				// Checksum the exact bytes we hand to SDL so the diagnostics
+				// page can confirm which database is bundled.
+				dbStatus.checksum = ComputeBufferCrc32(gcdbData.data(), gcdbData.size());
 
-				const int added = SDL_GameControllerAddMappingsFromFile(gcdbPath.c_str());
+				SDL_RWops* rw = SDL_RWFromConstMem(gcdbData.data(), (int)gcdbData.size());
+				const int added = rw ? SDL_GameControllerAddMappingsFromRW(rw, 1 /*freesrc: SDL closes the RWops*/) : -1;
 				dbStatus.mappingsAdded = added;
 				dbStatus.loaded = (added >= 0);
 				if(added < 0) {
 					dbStatus.error = SDL_GetError();
-					warnings << "WARNING: couldn't load gamecontroller mappings from " << gcdbPath << ": " << SDL_GetError() << endl;
+					warnings << "WARNING: couldn't load gamecontroller mappings from bundled gamecontrollerdb.txt: " << SDL_GetError() << endl;
 				}
 				else
-					notes << "loaded " << added << " gamecontroller mappings from " << gcdbPath << endl;
+					notes << "loaded " << added << " gamecontroller mappings from bundled gamecontrollerdb.txt" << endl;
 			}
 			SetGamepadDbStatus(dbStatus);
 		}

--- a/src/client/AuxLib.cpp
+++ b/src/client/AuxLib.cpp
@@ -67,6 +67,7 @@
 #include "DeprecatedGUI/Menu.h"
 #include "GfxPrimitives.h"
 #include "FindFile.h"
+#include "GamepadDiagnostics.h"
 #include "InputEvents.h"
 #include "StringUtils.h"
 #include "sound/SoundsBase.h"
@@ -142,16 +143,30 @@ bool InitializeAuxLib()
 			// https://github.com/mdqinc/SDL_GameControllerDB at build time and
 			// shipped in the gamedir, augmenting SDL's built-in mappings so
 			// that many more gamepads are recognised out of the box.
+			GamepadDbStatus dbStatus;
+			dbStatus.attempted = true;
 			const std::string gcdbPath = GetFullFileName("gamecontrollerdb.txt");
 			if(gcdbPath.empty()) {
 				notes << "no bundled gamecontrollerdb.txt found - using SDL's built-in mappings only" << endl;
+				dbStatus.fileFound = false;
 			} else {
+				dbStatus.fileFound = true;
+				dbStatus.path = gcdbPath;
+				// Checksum the file before handing it to SDL so the diagnostics
+				// page can confirm exactly which database is bundled.
+				dbStatus.checksum = ComputeFileCrc32(gcdbPath, &dbStatus.fileSize);
+
 				const int added = SDL_GameControllerAddMappingsFromFile(gcdbPath.c_str());
-				if(added < 0)
+				dbStatus.mappingsAdded = added;
+				dbStatus.loaded = (added >= 0);
+				if(added < 0) {
+					dbStatus.error = SDL_GetError();
 					warnings << "WARNING: couldn't load gamecontroller mappings from " << gcdbPath << ": " << SDL_GetError() << endl;
+				}
 				else
 					notes << "loaded " << added << " gamecontroller mappings from " << gcdbPath << endl;
 			}
+			SetGamepadDbStatus(dbStatus);
 		}
 	}
 

--- a/src/client/DeprecatedGUI/Menu_Options.cpp
+++ b/src/client/DeprecatedGUI/Menu_Options.cpp
@@ -34,6 +34,7 @@
 #include "IpToCountryDB.h"
 #include "ConversationLogger.h"
 #include "TouchControls.h"
+#include "GamepadDiagnostics.h"
 
 
 namespace DeprecatedGUI {
@@ -44,6 +45,7 @@ CGuiLayout	cOpt_Controls;        // Player 1 controls   (sub-tab 0)
 CGuiLayout	cOpt_Controls2;       // Player 2 controls   (sub-tab 1)
 CGuiLayout	cOpt_ControlsGen;     // General controls    (sub-tab 2)
 CGuiLayout	cOpt_ControlsTouch;   // Touch-screen layout (sub-tab 3, only shown on touch devices)
+CGuiLayout	cOpt_ControlsGamepad; // Gamepad diagnostics (sub-tab 4, info only)
 CGuiLayout	cOpt_System;
 CGuiLayout	cOpt_Game;
 
@@ -56,10 +58,11 @@ enum {
 	ct_Player2,
 	ct_General,
 	ct_Touchscreen,
+	ct_Gamepad,
 	ct__Count
 };
 int ControlsSubTab = ct_Player1;
-static const char* ControlsTabNames[ct__Count] = { "Player 1", "Player 2", "General", "Touchscreen" };
+static const char* ControlsTabNames[ct__Count] = { "Player 1", "Player 2", "General", "Touchscreen", "Gamepad diagnostics" };
 
 // True if the given tab should appear in the tab bar. All control tabs,
 // including Touchscreen, are always available — the touch layout can be
@@ -342,6 +345,9 @@ bool Menu_OptionsInitialize()
 	cOpt_ControlsTouch.Shutdown();
 	cOpt_ControlsTouch.Initialize();
 
+	cOpt_ControlsGamepad.Shutdown();
+	cOpt_ControlsGamepad.Initialize();
+
 	cOpt_Game.Shutdown();
 	cOpt_Game.Initialize();
 
@@ -615,6 +621,90 @@ void Menu_OptionsUpdateUpload(float speed)
 
 
 ///////////////////
+// Draw the "Gamepad diagnostics" sub-tab. This is an info-only page: it
+// reports whether the bundled SDL game controller mapping database loaded,
+// its checksum, and the controllers SDL currently recognises. No widgets,
+// just text drawn straight onto the menu (like the touch tiles).
+static void Menu_OptionsDrawGamepadDiagnostics(SDL_Surface* dest)
+{
+	// Restore the page background below the sub-tab bar each frame so that a
+	// changed controller list (hot-plug) doesn't leave stale text behind.
+	DrawImageAdv(dest, tMenu->bmpBuffer, 20,170, 20,170, 620,295);
+
+	const int x = kControlLabelX;
+	const int lineH = tLX->cFont.GetHeight() + 2;
+	int y = 175;
+
+	// Colours for ok / warning states.
+	const Color colOk   = Color(80, 220, 80);
+	const Color colBad  = tLX->clError;
+	const Color colHead = tLX->clHeading;
+	const Color colNorm = tLX->clNormalLabel;
+	const Color colDim  = tLX->clDisabled;
+
+	// --- Section 1: mapping database status --------------------------------
+	tLX->cFont.Draw(dest, x, y, colHead, "SDL controller mapping database"); y += lineH;
+
+	const GamepadDbStatus& db = GetGamepadDbStatus();
+	if(!bJoystickSupport) {
+		tLX->cFont.Draw(dest, x, y, colBad, "Joystick/gamepad support is disabled."); y += lineH;
+	}
+	else if(!db.attempted) {
+		tLX->cFont.Draw(dest, x, y, colDim, "Database load was not attempted."); y += lineH;
+	}
+	else if(!db.fileFound) {
+		tLX->cFont.Draw(dest, x, y, colBad, "Status: bundled gamecontrollerdb.txt NOT found"); y += lineH;
+		tLX->cFont.Draw(dest, x, y, colDim, "Using SDL's built-in mappings only."); y += lineH;
+	}
+	else if(!db.loaded) {
+		tLX->cFont.Draw(dest, x, y, colBad, "Status: FAILED to load"); y += lineH;
+		tLX->cFont.Draw(dest, x, y, colDim, "Path: " + db.path); y += lineH;
+		if(!db.error.empty()) {
+			tLX->cFont.Draw(dest, x, y, colBad, "Error: " + db.error); y += lineH;
+		}
+	}
+	else {
+		tLX->cFont.Draw(dest, x, y, colOk, "Status: loaded OK"); y += lineH;
+		tLX->cFont.Draw(dest, x, y, colNorm, "Mappings added: " + itoa(db.mappingsAdded)); y += lineH;
+		tLX->cFont.Draw(dest, x, y, colDim, "Path: " + db.path); y += lineH;
+	}
+
+	// Checksum + size (shown whenever we have a file).
+	if(db.fileFound) {
+		const std::string sum = db.checksum.empty() ? std::string("(unavailable)") : ("CRC32 " + db.checksum);
+		tLX->cFont.Draw(dest, x, y, colNorm, "Checksum: " + sum); y += lineH;
+		tLX->cFont.Draw(dest, x, y, colDim, "File size: " + itoa((int)db.fileSize) + " bytes"); y += lineH;
+	}
+
+	y += lineH / 2;
+
+	// --- Section 2: detected controllers -----------------------------------
+	const std::vector<GamepadControllerInfo> pads = GetDetectedControllers();
+	tLX->cFont.Draw(dest, x, y, colHead, "Detected controllers: " + itoa((int)pads.size())); y += lineH;
+
+	if(pads.empty()) {
+		tLX->cFont.Draw(dest, x, y, colDim, bJoystickSupport ? "No controllers connected." : "(support disabled)"); y += lineH;
+	}
+	else {
+		// Keep within the page box (bottom is ~440); leave room for the footer.
+		const int maxY = 410;
+		for(size_t i = 0; i < pads.size(); ++i) {
+			if(y > maxY) {
+				tLX->cFont.Draw(dest, x, y, colDim, "... " + itoa((int)(pads.size() - i)) + " more"); y += lineH;
+				break;
+			}
+			const GamepadControllerInfo& p = pads[i];
+			const Color nameCol = p.isGameController ? colOk : colBad;
+			tLX->cFont.Draw(dest, x, y, nameCol,
+				itoa(p.deviceIndex) + ": " + p.name +
+				(p.isGameController ? "  [mapped]" : "  [no mapping]"));
+			y += lineH;
+			tLX->cFont.Draw(dest, x + 16, y, colDim, "GUID " + p.guid); y += lineH;
+		}
+	}
+}
+
+///////////////////
 // Returns the gui layout for the currently selected Controls sub-tab
 static CGuiLayout& Menu_OptionsControlsLayout()
 {
@@ -622,6 +712,7 @@ static CGuiLayout& Menu_OptionsControlsLayout()
 		case ct_Player2:     return cOpt_Controls2;
 		case ct_General:     return cOpt_ControlsGen;
 		case ct_Touchscreen: return cOpt_ControlsTouch;
+		case ct_Gamepad:     return cOpt_ControlsGamepad;
 		default:             return cOpt_Controls;
 	}
 }
@@ -956,6 +1047,10 @@ void Menu_OptionsFrame()
 					}
 				}
 			}
+		} else if(ControlsSubTab == ct_Gamepad) {
+			// Info-only diagnostics page. No "Reset defaults" here — there's
+			// nothing to reset; we just report the mapping db + detected pads.
+			Menu_OptionsDrawGamepadDiagnostics(VideoPostProcessor::videoSurface().get());
 		} else {
 			// "Reset defaults" button (manual, so it can show that exact label)
 			Menu_OptionsDrawResetButton(VideoPostProcessor::videoSurface().get());
@@ -1415,6 +1510,7 @@ void Menu_OptionsShutdown()
 	cOpt_Controls2.Shutdown();
 	cOpt_ControlsGen.Shutdown();
 	cOpt_ControlsTouch.Shutdown();
+	cOpt_ControlsGamepad.Shutdown();
 	cOpt_System.Shutdown();
 	cOpt_Game.Shutdown();
 }

--- a/src/client/GamepadDiagnostics.cpp
+++ b/src/client/GamepadDiagnostics.cpp
@@ -63,6 +63,20 @@ std::string ComputeFileCrc32(const std::string& path, size_t* outSize)
 }
 
 
+std::string ComputeBufferCrc32(const void* data, size_t len)
+{
+	if(!data || len == 0)
+		return "";
+
+	boost::crc_32_type crc;
+	crc.process_bytes(data, len);
+
+	std::ostringstream ss;
+	ss << std::hex << std::setw(8) << std::setfill('0') << crc.checksum();
+	return ss.str();
+}
+
+
 std::vector<GamepadControllerInfo> GetDetectedControllers()
 {
 	std::vector<GamepadControllerInfo> result;

--- a/src/client/GamepadDiagnostics.cpp
+++ b/src/client/GamepadDiagnostics.cpp
@@ -1,0 +1,100 @@
+/////////////////////////////////////////
+//
+//             OpenLieroX
+//
+//   code under LGPL
+//
+/////////////////////////////////////////
+
+
+// Gamepad diagnostics — see GamepadDiagnostics.h
+
+
+#include <SDL.h>
+#include <fstream>
+#include <sstream>
+#include <iomanip>
+#include <boost/crc.hpp>
+
+#include "GamepadDiagnostics.h"
+#include "LieroX.h"		// bJoystickSupport
+
+
+// Database load status, filled in once at startup by InitializeAuxLib.
+static GamepadDbStatus gGamepadDbStatus;
+
+
+void SetGamepadDbStatus(const GamepadDbStatus& status)
+{
+	gGamepadDbStatus = status;
+}
+
+const GamepadDbStatus& GetGamepadDbStatus()
+{
+	return gGamepadDbStatus;
+}
+
+
+std::string ComputeFileCrc32(const std::string& path, size_t* outSize)
+{
+	if(outSize) *outSize = 0;
+
+	std::ifstream f(path.c_str(), std::ios::binary);
+	if(!f.is_open())
+		return "";
+
+	boost::crc_32_type crc;
+	char buf[16 * 1024];
+	size_t total = 0;
+	while(f) {
+		f.read(buf, sizeof(buf));
+		const std::streamsize got = f.gcount();
+		if(got <= 0)
+			break;
+		crc.process_bytes(buf, (size_t)got);
+		total += (size_t)got;
+	}
+
+	if(outSize) *outSize = total;
+
+	std::ostringstream ss;
+	ss << std::hex << std::setw(8) << std::setfill('0') << crc.checksum();
+	return ss.str();
+}
+
+
+std::vector<GamepadControllerInfo> GetDetectedControllers()
+{
+	std::vector<GamepadControllerInfo> result;
+
+	if(!bJoystickSupport)
+		return result;
+
+	const int n = SDL_NumJoysticks();
+	for(int i = 0; i < n; ++i) {
+		GamepadControllerInfo info;
+		info.deviceIndex = i;
+
+		const char* name = SDL_GameControllerNameForIndex(i);
+		if(!name) name = SDL_JoystickNameForIndex(i);
+		info.name = name ? name : "(unknown)";
+
+		char guidStr[64] = {0};
+		SDL_JoystickGUID guid = SDL_JoystickGetDeviceGUID(i);
+		SDL_JoystickGetGUIDString(guid, guidStr, sizeof(guidStr));
+		info.guid = guidStr;
+
+		info.isGameController = SDL_IsGameController(i) == SDL_TRUE;
+
+		// A controller is "known" to the mapping database (bundled or
+		// SDL built-in) when a mapping string is available for its GUID.
+		char* mapping = SDL_GameControllerMappingForGUID(guid);
+		info.hasMapping = (mapping != NULL);
+		if(mapping)
+			SDL_free(mapping);
+
+		result.push_back(info);
+	}
+
+	return result;
+}


### PR DESCRIPTION
I have problem making OLX detect the updated gamepad database on Android (but works on other platform)

This PR is not intended to be merged, I just want to run it on Github Actions, so that I can get a build made by github that have dianostics information on what happens with the gamepad detection

Doing it locally does not work, because when I do it locally it just works all the time, so I cannot reproduce the problem with local builds