### PR TITLE
Rename Windows release from win64 to windows-64bit

### DIFF
--- a/.github/workflows/package-windows.sh
+++ b/.github/workflows/package-windows.sh
@@ -5,7 +5,7 @@
 # Inputs (env):
 #   BUILD_DIR - cmake build directory (default: build-cmake)
 #
-# Output: distrib/openlierox-<version>-win64/ folder.
+# Output: distrib/openlierox-<version>-windows-64bit/ folder.
 
 set -euo pipefail
 
@@ -21,7 +21,7 @@ fi
 
 REPO_ROOT="$(pwd)"
 
-PACKAGE_NAME="openlierox-$(./get_version.sh)-win64"
+PACKAGE_NAME="openlierox-$(./get_version.sh)-windows-64bit"
 PACKAGE_DIR="$REPO_ROOT/distrib/$PACKAGE_NAME"
 rm -rf "$PACKAGE_DIR"
 mkdir -p "$PACKAGE_DIR"

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -62,13 +62,13 @@ jobs:
         run: |
           set -euo pipefail
           cd distrib
-          dir="$(basename openlierox-*-win64)"
+          dir="$(basename openlierox-*-windows-64bit)"
           zip -r -q "${dir}.zip" "$dir"
           echo "name=${dir}.zip" >> "$GITHUB_OUTPUT"
 
-      - name: Upload openlierox-win64
+      - name: Upload openlierox-windows-64bit
         uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.bundle.outputs.name }}
-          path: distrib/openlierox-*-win64.zip
+          path: distrib/openlierox-*-windows-64bit.zip
           if-no-files-found: error


### PR DESCRIPTION
Renames the Windows release archive from `openlierox-<version>-win64.zip` to `openlierox-<version>-windows-64bit.zip` to make it clearer for non-technical users who may not know what "win64" means.

## Changes
- `.github/workflows/package-windows.sh` — `PACKAGE_NAME` suffix (and the header comment)
- `.github/workflows/package-windows.yml` — archive glob and upload step

The `WIN64` occurrences in `src/` and `libs/` are left untouched — those are C/C++ compiler macros, not the release name.