### PR TITLE
Simplify package name to just windows.

### DIFF
--- a/.github/workflows/package-windows.sh
+++ b/.github/workflows/package-windows.sh
@@ -5,7 +5,7 @@
 # Inputs (env):
 #   BUILD_DIR - cmake build directory (default: build-cmake)
 #
-# Output: distrib/openlierox-<version>-windows-64bit/ folder.
+# Output: distrib/openlierox-<version>-windows/ folder.
 
 set -euo pipefail
 
@@ -21,7 +21,7 @@ fi
 
 REPO_ROOT="$(pwd)"
 
-PACKAGE_NAME="openlierox-$(./get_version.sh)-windows-64bit"
+PACKAGE_NAME="openlierox-$(./get_version.sh)-windows"
 PACKAGE_DIR="$REPO_ROOT/distrib/$PACKAGE_NAME"
 rm -rf "$PACKAGE_DIR"
 mkdir -p "$PACKAGE_DIR"

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -62,13 +62,13 @@ jobs:
         run: |
           set -euo pipefail
           cd distrib
-          dir="$(basename openlierox-*-windows-64bit)"
+          dir="$(basename openlierox-*-windows)"
           zip -r -q "${dir}.zip" "$dir"
           echo "name=${dir}.zip" >> "$GITHUB_OUTPUT"
 
-      - name: Upload openlierox-windows-64bit
+      - name: Upload openlierox-windows
         uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.bundle.outputs.name }}
-          path: distrib/openlierox-*-windows-64bit.zip
+          path: distrib/openlierox-*-windows.zip
           if-no-files-found: error


### PR DESCRIPTION
Simplify name to just 'windows'. No other platforms specify number of bits in the package name, so it does not make sense that windows do it that have the least technical users

Also only 64 bit windows are sold in recent 10 years anyway

<img width="923" height="502" alt="Screenshot from 2026-06-27 20-08-20" src="https://github.com/user-attachments/assets/3a2d3e1c-d16d-4172-bfdf-ccf93c5f72ec" />
