### PR TITLE
[work in progress] Backport of 0.58 docker support for dedicated server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# 0.58 embeds its version from the committed VERSION file (no git needed at
+# build time), so .git can be excluded from the build context.
+.git
+
+# Exclude build artifacts so a build done on the host can't leak into / poison
+# the in-container build.
+build-output/
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+bin/
+*.o

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,85 @@
+# OpenLieroX 0.58 dedicated server — Debian 11 "bullseye"
+#
+# This is the 0.58 backport of the dedicated-server Docker support. Two reasons
+# the base is debian:bullseye-slim:
+#   * The dedicated-server control scripts (share/gamedir/scripts/
+#     dedicated_control*) are written in Python 2; bullseye is the last Debian
+#     release that still ships python2.7.
+#   * OpenLieroX 0.58 is built against SDL 1.2 (not SDL2 — that's the master
+#     branch). bullseye still provides the SDL 1.2 dev/runtime packages.
+#
+# Built in two stages: a build stage compiles a -DDEDICATED_ONLY binary, and a
+# slim runtime stage ships only the binary, game data, shared libraries and
+# python2.7.
+
+# ---------- build stage ----------
+FROM debian:bullseye-slim AS build
+
+ENV DEBIAN_FRONTEND=noninteractive
+# Dependencies for a DEDICATED_ONLY build of 0.58 (derived from debian/control,
+# minus SDL_mixer/gd which the dedicated build does not link). HawkNL and LibZIP
+# are built from the bundled libs/ sources, so they need no -dev packages.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        libsdl1.2-dev \
+        libsdl-image1.2-dev \
+        libxml2-dev \
+        zlib1g-dev \
+        libcurl4-openssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+# DEDICATED_ONLY=Yes  -> headless build (no gfx/sound), drops SDL_mixer/gd/X11.
+# HAWKNL_BUILTIN=Yes   -> use the bundled HawkNL networking lib.
+# LIBZIP_BUILTIN=Yes   -> use the bundled LibZIP (libs/libzip). On Linux this
+#                         option defaults Off (links system libzip), but 0.58
+#                         ships no libzip-dev dependency, so the official deb
+#                         build (debian/rules) enables the builtin — we match it.
+# DEBUG=No             -> 0.58's DEBUG option defaults to Yes and overrides
+#                         CMAKE_BUILD_TYPE, so it must be turned off explicitly
+#                         to get a Release build.
+# Out-of-source build into build-output/ (mirrors .github/workflows/
+# build-linux.sh); the target's OUTPUT_NAME is "bin/openlierox", so the bin/
+# subdir must exist first. Leaves one core free during the build (floors at 1).
+RUN cmake -S . -B build-output -DDEBUG=No -DHAWKNL_BUILTIN=Yes -DLIBZIP_BUILTIN=Yes -DDEDICATED_ONLY=Yes \
+    && mkdir -p build-output/bin \
+    && n="$(nproc)" \
+    && { [ "$n" -gt 1 ] && n="$((n - 1))" || true; } \
+    && cmake --build build-output -j"$n"
+
+# ---------- runtime stage ----------
+FROM debian:bullseye-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python2.7 \
+        libsdl1.2debian \
+        libsdl-image1.2 \
+        libxml2 \
+        zlib1g \
+        libcurl4 \
+    && ln -sf /usr/bin/python2.7 /usr/bin/python \
+    && ln -sf /usr/bin/python2.7 /usr/bin/python2 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /src/build-output/bin/openlierox /usr/local/bin/openlierox
+COPY --from=build /src/share/gamedir /opt/openlierox
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# Run as a non-root user. ~/.OpenLieroX (under HOME) is where OLX writes its
+# own configs, logs and rankings — mount a volume there to persist them.
+RUN chmod +x /usr/local/bin/entrypoint.sh \
+    && useradd -r -m -d /home/olx olx \
+    && chown -R olx:olx /opt/openlierox
+
+USER olx
+ENV HOME=/home/olx
+WORKDIR /opt/openlierox
+
+# OpenLieroX dedicated servers listen on UDP 23400 by default.
+EXPOSE 23400/udp
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,105 @@
+# Running an OpenLieroX 0.58 dedicated server with Docker
+
+This directory contains everything needed to run a headless OpenLieroX **0.58
+dedicated server** (e.g. on your LAN) inside Docker. The image is built from this
+source tree and runs the game in `-dedicated` mode with the Python automation
+scripts that cycle games, rotate maps/mods, and handle voting.
+
+> This is the **0.58** backport of the dedicated-server Docker support. The
+> equivalent on `master` targets the current SDL2 codebase; this one targets the
+> still-popular 0.58 release (SDL 1.2).
+
+## Why Debian 11 (bullseye)?
+
+Two reasons:
+
+- The dedicated-server control scripts (`share/gamedir/scripts/dedicated_control*`)
+  are written in **Python 2**, and bullseye is the last Debian release that ships
+  `python2.7`.
+- OpenLieroX 0.58 is built against **SDL 1.2** (the master branch uses SDL2).
+  bullseye still provides the SDL 1.2 dev and runtime packages
+  (`libsdl1.2-dev`, `libsdl1.2debian`, …).
+
+So the image uses `debian:bullseye-slim` for both the build and runtime stages.
+
+## Quick start (docker compose)
+
+From this `docker/` directory:
+
+```sh
+docker compose up -d --build      # build the image and start the server
+docker compose logs -f            # watch the server log
+docker compose down               # stop and remove the container
+```
+
+The server listens on **UDP 23400** (the OLX default). With the default
+`network_mode: host`, it is reachable on your LAN immediately and shows up in the
+in-game **Local network** server list. Other players can also connect directly
+to the host machine's IP.
+
+## Quick start (plain docker)
+
+From the repository root (one level up from here):
+
+```sh
+docker build -f docker/Dockerfile -t openlierox-server:0.58 .
+
+docker run -d --name olx-server \
+  --network host \
+  -v olx-data:/home/olx/.OpenLieroX \
+  openlierox-server:0.58
+```
+
+If you can't use host networking (e.g. on Docker Desktop / macOS / Windows), map
+the port instead — but note LAN broadcast discovery may not work through the
+bridge, so clients would connect to the host IP directly:
+
+```sh
+docker run -d --name olx-server \
+  -p 23400:23400/udp \
+  -v olx-data:/home/olx/.OpenLieroX \
+  openlierox-server:0.58
+```
+
+## Configuring the server
+
+Server name, port, level/mod rotation, voting, team rules, etc. live in the
+control config `share/gamedir/cfg/dedicated_config.py` (baked into the image at
+`/opt/openlierox/cfg/dedicated_config.py`). Two ways to customize:
+
+- **Edit + rebuild:** change `dedicated_config.py` in the source tree and rebuild.
+- **Mount an override (no rebuild):** put your edited copy on the host and mount
+  it over the one in the image:
+
+  ```sh
+  docker run -d --name olx-server --network host \
+    -v "$PWD/my_dedicated_config.py:/opt/openlierox/cfg/dedicated_config.py:ro" \
+    -v olx-data:/home/olx/.OpenLieroX \
+    openlierox-server:0.58
+  ```
+
+To load an entirely different config file, set `OLX_DED_CONFIG` (a gamedir-relative
+path, **without** the `.py` suffix), e.g. `-e OLX_DED_CONFIG=cfg/dedicated_config_lx56`.
+
+Key settings in `dedicated_config.py`:
+
+| Setting | Meaning |
+| --- | --- |
+| `SERVER_PORT` | UDP port (default `23400`). If you change it, update the published port too when using bridge networking. |
+| `GLOBAL_SETTINGS["GameOptions.Network.ServerName"]` | Name shown in the server browser. |
+| `LEVELS` / `SMALL_LEVELS` | Map rotation (`SMALL_LEVELS` is used when there are `MAX_PLAYERS_SMALL_LEVELS` players or fewer). |
+| `PRESETS` / `MODS` | Mod/preset rotation. |
+| `MIN_PLAYERS` | Players required before a round starts. |
+
+## Notes
+
+- The build uses `-DDEDICATED_ONLY=Yes`, so no graphics/sound subsystems are
+  initialized (SDL_mixer and gd are not even linked) — it runs fine without a
+  display.
+- 0.58 embeds its version from the committed `VERSION` file, so unlike the master
+  build no git history is needed in the build context (`.git` is excluded via
+  `.dockerignore`).
+- Persistent data (rankings, logs, generated config) is written to
+  `~/.OpenLieroX` inside the container; the compose file maps that to the
+  `olx-data` volume.
+- The container runs as a non-root `olx` user.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  olx-server:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: openlierox-server:0.58
+    container_name: olx-server
+    restart: unless-stopped
+
+    # Host networking is the simplest setup for a LAN game server: OpenLieroX's
+    # UDP port is bound directly on the host, and the in-game LAN server browser
+    # (which relies on UDP broadcast) can discover this server automatically.
+    network_mode: host
+
+    # Persist OLX's runtime data (rankings, logs, generated config).
+    volumes:
+      - olx-data:/home/olx/.OpenLieroX
+
+    # Optional: load a different control config (no .py suffix, gamedir-relative).
+    # environment:
+    #   OLX_DED_CONFIG: cfg/dedicated_config
+
+    # If you would rather use bridge networking than host mode, delete the
+    # "network_mode: host" line above and uncomment the mapping below. Note that
+    # LAN auto-discovery via broadcast may not work through the bridge — clients
+    # would then need to connect to the host's IP directly.
+    # ports:
+    #   - "23400:23400/udp"
+
+volumes:
+  olx-data:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# Path (relative to the gamedir, WITHOUT the .py suffix) of the dedicated-server
+# control config. Override at run time, e.g.:
+#   docker run -e OLX_DED_CONFIG=cfg/dedicated_config_lx56 ...
+: "${OLX_DED_CONFIG:=cfg/dedicated_config}"
+
+cd /opt/openlierox
+
+# -dedicated : headless server mode (no graphics, no sound)
+# -exec      : run a console command at startup. Here it loads the Python
+#              automation script, which cycles lobby -> game, rotates levels and
+#              mods, handles voting and admin/user chat commands, etc.
+exec openlierox -dedicated -exec "script dedicated_control ${OLX_DED_CONFIG}"


### PR DESCRIPTION
I think our client (when you run it as a player) our latest master is better than 0.58 in almost every way

But for hosting a server I found the latest master to be more buggy than 0.58... I think that is something we have to work on

To make it still easy to host 0.58 servers (which can be connected to by 2026x clients) I also backport the docker support
```
docker run --network host klirktag/openlierox-server:0.58_rc5
```

I will probably need it to debug why 0.58 works for hosting when 2026x does not work so well