### PR TITLE
[work in progress] docker-dev-container

### DIFF
--- a/build/dev-docker/Dockerfile
+++ b/build/dev-docker/Dockerfile
@@ -1,0 +1,115 @@
+# OpenLieroX development / build base image.
+#
+# Purpose: a single image that carries every build dependency needed to
+# compile OpenLieroX from *any* of the currently-maintained branches:
+#
+#   * 0.58   -> SDL 1.2 stack (libsdl1.2 / SDL_mixer 1.2 / SDL_image 1.2)
+#   * 0.59   -> SDL2 stack + boost + OpenAL/ALUT + vorbis + yaml-cpp + libbfd
+#   * master -> same as 0.59
+#
+# Because we occasionally backport fixes to the older lines, this image
+# deliberately installs BOTH the SDL 1.2 and the SDL2 dev stacks so the same
+# container can build every branch without swapping images.
+#
+# Debian 11 (bullseye) is the base on purpose: it is the last Debian release
+# that still ships python2 (2.7.18) in its archive. OpenLieroX's dedicated
+# server control scripts (dedicated_control, cfg/*.py) require Python 2, and
+# bullseye lets us "apt-get install python2" instead of building CPython 2.7
+# from source (which is what the Ubuntu 24.04 runtime image has to do).
+#
+# This is a BASE image, not a build of OLX itself. It intentionally contains
+# no source. Mount your checkout at /src and run cmake+make inside it:
+#
+#   docker build -t openlierox-dev:bullseye build/dev-docker
+#   docker run --rm -it -v "$PWD":/src openlierox-dev:bullseye
+#   # then, inside the container, for a 0.59 / master build:
+#   cmake -DHAWKNL_BUILTIN=Yes -DDEBUG=No -DCMAKE_BUILD_TYPE=Release .
+#   make -j"$(nproc)"
+#
+#   # for a 0.58 build, the SDL 1.2 stack above is already present.
+#
+# To match host file ownership on bind mounts, pass your UID/GID at build:
+#   docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) ...
+
+FROM debian:11
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# --- toolchain + all OLX build dependencies (0.58, 0.59, master) -----------
+#
+# Notes on a few choices:
+#  * libgd-dev            -- modern name for the old libgd2-noxpm-dev in DEPS.
+#  * NO libboost-signals-dev -- Boost.Signals v1 was removed upstream (>=1.69)
+#    and is absent from bullseye. OLX only needs the header-only Boost.Signals2
+#    plus a few utility headers, all provided by libboost-dev.
+#  * binutils-dev + libiberty-dev -- provide libbfd for the crash/backtrace
+#    handler (0.59 / master).
+#  * both SDL 1.2 and SDL2 dev stacks are installed side by side.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        # --- core toolchain ---
+        build-essential \
+        cmake \
+        make \
+        pkg-config \
+        ca-certificates \
+        git \
+        wget \
+        curl \
+        ccache \
+        gdb \
+        # patchelf: rewrites rpaths when assembling the self-contained
+        # Linux bundle (.github/workflows/package-linux-bundle.sh).
+        patchelf \
+        zip \
+        # --- Python 2 (dedicated_control + cfg/*.py, build-time detection) ---
+        python2 \
+        python2-dev \
+        python2.7 \
+        python2.7-dev \
+        python-is-python2 \
+        # --- SDL 1.2 stack (branch 0.58) ---
+        libsdl1.2-dev \
+        libsdl-mixer1.2-dev \
+        libsdl-image1.2-dev \
+        # --- SDL2 stack (branch 0.59 / master) ---
+        libsdl2-dev \
+        libsdl2-mixer-dev \
+        libsdl2-image-dev \
+        # --- shared graphics / xml / net / archive deps (all branches) ---
+        libxml2-dev \
+        libgd-dev \
+        zlib1g-dev \
+        libzip-dev \
+        libx11-dev \
+        libcurl4-openssl-dev \
+        libboost-dev \
+        libboost-system-dev \
+        # --- audio (0.59 / master) ---
+        libopenal-dev \
+        libalut-dev \
+        libvorbis-dev \
+        # --- misc (0.59 / master) ---
+        libyaml-cpp-dev \
+        binutils-dev \
+        libiberty-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# ccache on PATH so repeated dev builds are fast.
+ENV PATH=/usr/lib/ccache:${PATH}
+ENV CCACHE_DIR=/ccache
+RUN mkdir -p /ccache && chmod 777 /ccache
+
+# --- non-root dev user, UID/GID overridable to match the host -------------
+# Keeps bind-mounted source files owned by your host user instead of root.
+ARG UID=1000
+ARG GID=1000
+RUN groupadd --gid "${GID}" dev 2>/dev/null || true \
+    && useradd --create-home --uid "${UID}" --gid "${GID}" --shell /bin/bash dev 2>/dev/null || true \
+    && mkdir -p /src \
+    && chown "${UID}:${GID}" /src /ccache
+
+USER ${UID}:${GID}
+WORKDIR /src
+
+CMD ["/bin/bash"]

--- a/build/dev-docker/README.md
+++ b/build/dev-docker/README.md
@@ -1,0 +1,111 @@
+# OpenLieroX dev base image
+
+A Docker image that carries **every build dependency needed to compile
+OpenLieroX from any of the maintained branches** — `0.58`, `0.59`, and
+`master` — in a single environment. It is meant for development and for
+building/backporting across versions, not for shipping a server.
+
+## Why this exists
+
+We sometimes have to backport fixes to older release lines, and those lines
+don't all build against the same libraries:
+
+| Branch   | SDL stack | Extra deps                                          |
+|----------|-----------|-----------------------------------------------------|
+| `0.58`   | SDL **1.2** (`libsdl1.2`, `SDL_mixer 1.2`, `SDL_image 1.2`) | — |
+| `0.59`   | **SDL2**  | boost, OpenAL/ALUT, vorbis, yaml-cpp, libbfd (binutils) |
+| `master` | **SDL2**  | same as `0.59`                                      |
+
+Rather than juggle one image per branch, this image installs **both** the
+SDL 1.2 and the SDL2 dev stacks (plus everything the newer branches need)
+side by side, so the same container builds all three.
+
+## Why Debian 11 (bullseye)
+
+OpenLieroX's dedicated-server control scripts (`share/gamedir/dedicated_control`
+and `share/gamedir/cfg/*.py`) are **Python 2**. Bullseye is the last Debian
+release that still ships `python2` (2.7.18) in its archive, so we can just
+`apt-get install python2` instead of compiling CPython 2.7 from source (which
+is what the Ubuntu 24.04 dedicated-server runtime image has to do — see the
+`dockerize-dedicated-server` branch). `python-is-python2` provides
+`/usr/bin/python`, which the `#!/usr/bin/python -u` shebang in the control
+scripts relies on.
+
+## What's inside
+
+- **Toolchain:** `build-essential`, `cmake`, `make`, `pkg-config`, `git`,
+  `ccache` (on `PATH` at `/usr/lib/ccache`), `gdb`.
+- **Python 2:** `python2`, `python2-dev`, `python2.7`, `python2.7-dev`,
+  `python-is-python2`.
+- **SDL 1.2 stack** (for `0.58`) and **SDL2 stack** (for `0.59`/`master`).
+- **Shared libs:** libxml2, libgd, zlib, libzip, libX11, libcurl, boost
+  (headers + system), OpenAL, ALUT, vorbis, yaml-cpp, binutils/libbfd.
+- A non-root **`dev`** user (UID/GID overridable) so bind-mounted source
+  keeps host ownership. Default working directory is `/src`.
+
+### Two intentional substitutions vs. the `DEPS` file
+
+- `DEPS` lists `libgd2-noxpm-dev` → we install **`libgd-dev`** (the old
+  name no longer exists in Debian).
+- `DEPS` lists `libboost-signals-dev` → **omitted**. Boost.Signals v1 was
+  removed upstream (Boost ≥ 1.69) and isn't in bullseye. OLX only needs the
+  header-only Boost.Signals2, which comes with `libboost-dev`.
+
+## Build the image
+
+```sh
+# from the repo root
+docker build -t openlierox-dev:bullseye build/dev-docker
+
+# match your host user so mounted files aren't owned by root:
+docker build \
+  --build-arg UID=$(id -u) --build-arg GID=$(id -g) \
+  -t openlierox-dev:bullseye build/dev-docker
+```
+
+## Use it to build OLX
+
+Mount your checkout at `/src` and run the build inside the container:
+
+```sh
+docker run --rm -it -v "$PWD":/src openlierox-dev:bullseye
+```
+
+Then, inside the container:
+
+```sh
+# 0.59 / master (SDL2)
+cmake -DHAWKNL_BUILTIN=Yes -DDEBUG=No -DCMAKE_BUILD_TYPE=Release .
+make -j"$(nproc)"
+
+# 0.58 (SDL 1.2) — the SDL 1.2 stack is already present, same commands
+cmake -DHAWKNL_BUILTIN=Yes -DDEBUG=No .
+make -j"$(nproc)"
+```
+
+`-DDEBUG=No` matters: the project's CMake defines `OPTION(DEBUG ... Yes)` and
+overrides `CMAKE_BUILD_TYPE`, so without it you get a debug build with
+`assert()` active. `-DHAWKNL_BUILTIN=Yes` uses the bundled HawkNL instead of a
+system package.
+
+### Persisting the ccache across runs
+
+`ccache` speeds up repeated builds. Mount a volume at `/ccache` to keep the
+cache between container runs:
+
+```sh
+docker run --rm -it \
+  -v "$PWD":/src \
+  -v olx-ccache:/ccache \
+  openlierox-dev:bullseye
+```
+
+## Notes
+
+- This image contains **no OpenLieroX source** — mount it. That keeps the
+  image branch-agnostic and small to rebuild.
+- The container runs as a non-root user by default. If you need to install
+  extra packages ad hoc, run with `--user root` (or add them to the
+  Dockerfile).
+- This host has known Docker DNS quirks; if `apt-get` fails during the build,
+  build with `--network=host`.


### PR DESCRIPTION
A container with all dependencies needed that can be used as a dev-container to build OpenLieroX inside, without having to install anything on the base machine

Can be useful in some situations for example if running a distro where dependencies are not available, or the user just have technical problems getting all the build tools to work

This Docker container is based on Debian 11 with Python2, and can build OpenLieroX 0.58, 0.59 and 2026x with its included tooling

To try it out
```
docker run --rm -it --user $(id -u):$(id -g) -v $HOME:$HOME   -w $(pwd)  klirktag/openlierox-dev-container:latest
```