### PR TITLE
Linux-bundle: never bundle glibc, only external libs

### DIFF
--- a/.github/workflows/package-linux-bundle.sh
+++ b/.github/workflows/package-linux-bundle.sh
@@ -11,9 +11,25 @@ mkdir -p $PACKAGE_DIR
 cp build-output/bin/openlierox $PACKAGE_DIR
 cp -av share/gamedir $PACKAGE_DIR/gamedir
 
-# Copy all .so files this binary was built for, to make a self contained bundle
+# Copy all .so files this binary was built for, to make a self contained bundle.
+#
+# We must NOT bundle any part of glibc. glibc's sub-libraries (libpthread,
+# libm, libdl, librt, libresolv, ...) share internal GLIBC_PRIVATE symbols
+# with libc.so.6 and are only ABI-compatible with the exact libc.so.6 they
+# shipped with. The final binary always loads the *host's* libc.so.6 and
+# dynamic loader (their path is baked into the ELF interpreter / NEEDED and
+# can't be overridden by rpath), so bundling e.g. Debian's libpthread.so.0
+# next to a host libc.so.6 breaks with
+#   undefined symbol: __libc_pthread_init, version GLIBC_PRIVATE
+# Because we build against an older glibc than the deploy targets, letting the
+# whole glibc family resolve from the host is both correct and forward-safe.
+#
+# The exclusion list below is the glibc-provided set only; genuinely external
+# libraries with confusingly similar names (libcurl, libmikmod, libnsl,
+# libtirpc, ...) are still bundled.
+GLIBC_EXCLUDE='/(ld-linux[^/]*|libc|libpthread|libm|libmvec|libdl|librt|libresolv|libutil|libanl|libBrokenLocale|libnss_[^/]*|libcrypt)\.so'
 mkdir -p $PACKAGE_DIR/lib
-ldd $PACKAGE_DIR/openlierox | grep -v "libc.so*" | grep "=> /" | awk '{print $3}' | xargs -I '{}' cp -v '{}' $PACKAGE_DIR/lib/
+ldd $PACKAGE_DIR/openlierox | grep "=> /" | awk '{print $3}' | grep -vE "$GLIBC_EXCLUDE" | xargs -I '{}' cp -v '{}' $PACKAGE_DIR/lib/
 
 cd $PACKAGE_DIR
 


### PR DESCRIPTION
**TL;DR:** The Linux Bundle script copied too many .so files, including some of glibcs sublibraries that could not be moved between systems. This PR corrects it by not including only .so files that can be moved 

**Details:**
The Linux bundle packaging script copied every shared library reported by `ldd` except `libc.so*`. That meant glibc's own sub-libraries (libpthread, libm, libdl, librt, libresolv, ...) were bundled and, via the `$ORIGIN/lib` rpath, forced to load at runtime.

glibc is not relocatable this way. Its sub-libraries share internal GLIBC_PRIVATE symbols with libc.so.6 and are only ABI-compatible with the exact libc.so.6 they were built against. The final binary always loads the host's libc.so.6 and dynamic loader — those paths live in the ELF interpreter / NEEDED entries and cannot be overridden by rpath. So a bundle built on one glibc and run on another (e.g. built on Debian 11 / glibc 2.31, run on Ubuntu 24.04 / glibc 2.39) crashes immediately with:

    ./openlierox: symbol lookup error: .../lib/libpthread.so.0:
    undefined symbol: __libc_pthread_init, version GLIBC_PRIVATE

Fix: exclude the whole glibc-provided set from the bundle (libc, libpthread, libm, libmvec, libdl, librt, libresolv, libutil, libanl, libBrokenLocale, libnss_*, libcrypt, ld-linux) and let it all resolve from the host. Because we build against an older glibc than our deploy targets, this is both correct and forward-safe: glibc is backwards compatible, so the binary plus its non-glibc libraries run on any host with a glibc at least as new as the build environment. The exclusion is anchored on `.so` so similarly named external libraries (libcurl, libmikmod, libnsl, libtirpc, libcrypto, ...) continue to be bundled.

Verified: a bundle built in the Debian 11 dev container now starts cleanly on Ubuntu 24.04, and the bundled lib/ no longer contains any glibc component.