### PR TITLE
Fix: Revert network protocol version for dedicated servers, since the latest version seems broken (I don't merge without discussing this one first)

### DIFF
--- a/include/NetProtocolVersion.h
+++ b/include/NetProtocolVersion.h
@@ -1,0 +1,42 @@
+/*
+	OpenLieroX
+
+	Network-protocol version — the single source of truth for which wire
+	protocol the server speaks.
+
+	This is deliberately SEPARATE from the software version (GetGameVersion() /
+	GetFullGameName()). The software version identifies the build (shown in the
+	server browser, used for updates, crash reports, etc.). This value is used
+	ONLY to decide the network protocol.
+
+	Why it isn't just the software version:
+	Unmodified clients derive their wire protocol from the version the server
+	advertises in the connect handshake. The 0.59.10 sync protocol delivers the
+	mod to a client only via lobby updates, which a client ignores while not in
+	the lobby — so a player joining a game already in progress never learns the
+	mod and gets rejected ("invalid mod name") / kicked ("selected weapons too
+	long"). The older protocol sends the mod inside PrepareGame, so mid-game
+	joins work. This is exactly why an unmodified master client can already join
+	a 0.58 server.
+
+	So the server advertises this pre-0.59.10 protocol version (and treats
+	clients accordingly, see CServerConnection::setClientVersion) to keep every
+	connection on the join-capable protocol, while still reporting its real
+	software version everywhere else.
+
+	It is RT_RC (a release candidate), which newer clients do NOT version-ban
+	(only RT_ALPHA/RT_BETA versions older than the client are banned).
+*/
+
+#ifndef __NETPROTOCOLVERSION_H__
+#define __NETPROTOCOLVERSION_H__
+
+#include "Version.h"
+
+// The network-protocol version the server speaks / advertises.
+INLINE Version GetServerNetProtocolVersion() { return OLXRcVersion(0, 58, 5); }
+
+// Same value as the "GAMENAME/version" string put on the wire in the handshake.
+INLINE const char* GetServerNetProtocolName() { return "OpenLieroX/0.58_rc5"; }
+
+#endif

--- a/src/server/CServerConnection.cpp
+++ b/src/server/CServerConnection.cpp
@@ -25,6 +25,7 @@
 #include "MathLib.h"
 #include "EndianSwap.h"
 #include "Version.h"
+#include "NetProtocolVersion.h"
 #include "CServer.h"
 #include "AuxLib.h"
 #include "Networking.h"
@@ -170,7 +171,20 @@ void CServerConnection::Shutdown()
 
 void CServerConnection::setClientVersion(const Version& v)
 {
-	cClientVersion = v;
+	// Network-protocol compatibility (paired with the version advertised in
+	// CServer_Parse.cpp). With the 0.59.10 sync protocol, a client that joins a
+	// game already in progress never learns the mod: it is delivered only via
+	// lobby updates, which a client ignores while not in the lobby, so the late
+	// joiner is rejected and kicked ("selected weapons too long"). The older
+	// protocol sends the mod inside PrepareGame, so mid-game joins work — this
+	// is exactly why an unmodified master client can join a 0.58 server.
+	// We cap every client to our advertised network-protocol version (see
+	// NetProtocolVersion.h) so the whole connection uses the old, join-capable
+	// protocol in both directions.
+	if( v > GetServerNetProtocolVersion() )
+		cClientVersion = GetServerNetProtocolVersion();
+	else
+		cClientVersion = v;
 }
 
 void CServerConnection::resetNetEngine() {

--- a/src/server/CServer_Parse.cpp
+++ b/src/server/CServer_Parse.cpp
@@ -31,6 +31,7 @@
 #include "DedicatedControl.h"
 #include "AuxLib.h"
 #include "Version.h"
+#include "NetProtocolVersion.h"
 #include "Timer.h"
 #include "NotifyUser.h"
 #include "XMLutils.h"
@@ -1114,7 +1115,9 @@ void GameServer::ParseGetChallenge(const SmartPointer<NetworkSocket>& tSocket, C
 	bs.writeString("lx::challenge");
 	bs.writeInt(tChallenges[i].iNum, 4);
 	if( client_version != "" )
-		bs.writeString(GetFullGameName());
+		// Advertise the network-protocol version (not our real software
+		// version) so clients use the mid-game-join-capable protocol.
+		bs.writeString(GetServerNetProtocolName());
 	bs.Send(tSocket.get());
 }
 
@@ -1588,7 +1591,8 @@ void GameServer::ParseConnect(const SmartPointer<NetworkSocket>& net_socket, CBy
 		// we are sending the version string already in the challenge
 		bytestr.writeInt(-1, 4);
 		bytestr.writeString("lx::version");
-		bytestr.writeString(GetFullGameName());
+		// Advertise the network-protocol version (see NetProtocolVersion.h).
+		bytestr.writeString(GetServerNetProtocolName());
 		bytestr.Send(net_socket.get());
 	}
 	


### PR DESCRIPTION
Fix #973.

The latest Server network protocol version is broken, and seems to be have been broken for a while

The reason it works in practice is because all servers run 0.58, so the protocol is automatically down-graded to this older 0.58 version, which makes the networking work. master-branch and 0.59-branch are both broken for hosting servers.

**How to reproduce the problem:**
1. Set up a dedicated server running the latest master
2. Make TWO clients join it. The first client will be successful, the second one will always fail, because the broken-ness is related to joining a running game

**This fix:** Reverts the network protocol used by the dedicated server to the last not broken version
 
**Technical specification:**
With the 0.59.10 sync protocol, a client joining a game already in progress never learns the mod (it is delivered only via lobby updates, which a client ignores while not in the lobby), so it is rejected ("invalid mod name") and kicked ("selected weapons too long").

Fix, server-side only (unmodified clients keep working): advertise a distinct network-protocol version (pre-0.59.10) so clients use the older, mid-game-join-capable protocol where the mod is sent inside PrepareGame — the same protocol that already lets an unmodified master client join a 0.58 server. The real software version is unchanged and still used everywhere else.

  - include/NetProtocolVersion.h: single source of truth for the wire protocol, separate from the software version
  - CServer_Parse.cpp: advertise the net-protocol version in the connect handshake
  - CServerConnection::setClientVersion: cap clients to it so the server sends the old protocol too (coherent both directions)