### PR TITLE
Exclude openlierox-release.aab from GitHub releases

### DIFF
--- a/.github/workflows/master-release.yaml
+++ b/.github/workflows/master-release.yaml
@@ -101,6 +101,13 @@ jobs:
           shopt -s nullglob
           ASSETS=()
           for entry in dist/*; do
+            # The Android App Bundle (.aab) is a Google Play upload format,
+            # not a user-installable artifact (the .apk covers that). It is
+            # built only to hand off to the Play Store publish workflow, so
+            # keep it out of the public GitHub release.
+            case "$entry" in
+              *.aab) continue ;;
+            esac
             if [ -d "$entry" ]; then
               ( cd dist && zip -r -q "$(basename "$entry").zip" "$(basename "$entry")" )
               ASSETS+=("${entry}.zip")


### PR DESCRIPTION
The master-release job downloads every CI artifact and publishes them all as release assets. This swept in openlierox-release.aab, but an .aab is a Google Play *upload* format, not a user-installable artifact: it can't be sideloaded or 'adb install'ed, requires bundletool to turn into APKs, and is signed with the upload key that Google re-signs. The installable .apk is already published, so the .aab was just confusing noise in the release.

The bundle is only built to hand off to the publish-to-google-play workflow, so skip *.aab when assembling release assets. The AAB is still uploaded as a CI artifact, leaving Play Store publishing unaffected.