### PR TITLE
Fix laser (beam weapon) not being drawn

### DIFF
--- a/src/client/CClient_Game.cpp
+++ b/src/client/CClient_Game.cpp
@@ -502,10 +502,25 @@ void CClient::PlayerShoot(CWorm *w)
 	if(Slot->Reloading)
 		return;
 
-	if(Slot->LastFire>0)
+	if(!Slot->weapon())
 		return;
 
-	if(!Slot->weapon())
+	// Beam weapons get processed differently.
+	// Beam weapons have no rate of fire, they fire continuously until out of ammo,
+	// but we don't know when they are out of ammo, because the server won't tell us,
+	// so we'll draw it for some short time after each 'shoot' packet from the server.
+	// ProcessShot_Beam() sets LastFire when such a packet arrives; here we draw the
+	// beam every frame while it counts down. This must happen before the generic
+	// LastFire rate-of-fire gate below (otherwise DrawBeam would never be reached).
+	if(Slot->weapon()->Type == WPN_BEAM) {
+		if(Slot->LastFire > 0) {
+			DrawBeam(w);
+			Slot->LastFire -= tLX->fDeltaTime.seconds();
+		}
+		return;
+	}
+
+	if(Slot->LastFire>0)
 		return;
 
 	// Safe the ROF time (Rate of Fire). That's the pause time after each shot.
@@ -516,12 +531,6 @@ void CClient::PlayerShoot(CWorm *w)
 	// Special weapons get processed differently
 	if(Slot->weapon()->Type == WPN_SPECIAL) {
 		ShootSpecial(w);
-		return;
-	}
-
-	// Beam weapons get processed differently
-	if(Slot->weapon()->Type == WPN_BEAM) {
-		DrawBeam(w);
 		return;
 	}
 
@@ -916,11 +925,26 @@ void CClient::ProcessShot(shoot_t *shot, AbsTime fSpawnTime)
 // Process a shot - Beam
 void CClient::ProcessShot_Beam(shoot_t *shot)
 {
+	const weapon_t *wpn = game.gameScript()->GetWeapons() + shot->nWeapon;
+
 	if(shot->nWormID >= 0 && shot->nWormID < MAX_WORMS) {
 		CWorm *w = game.wormById(shot->nWormID, false);
 		if(!w) return;
+		// The selected weapon for a worm is sent in an unreliable packet, so it may
+		// differ from the weapon actually used for this shot. The shot data itself
+		// came in reliably, so use it to select the matching slot as current.
+		if(w->getCurWeapon()->weapon() != wpn) {
+			for(int i = 0; i < w->getWeaponSlotsCount(); i++) {
+				if(w->getWeapon(i)->weapon() == wpn) {
+					w->setCurrentWeapon(i);
+					break;
+				}
+			}
+		}
+		// Draw the beam for a short time after receiving the packet. PlayerShoot()
+		// draws it every frame while this counts down (see there).
+		w->writeCurWeapon()->LastFire = 0.3f;
 	}
-	const weapon_t *wpn = game.gameScript()->GetWeapons() + shot->nWeapon;
 
 	// Trace a line from the worm to length or until it hits something
 	CVec dir;


### PR DESCRIPTION
TL;DR: Bug fix for drawing the Laser weapon. It has been broken for a while

See demo:

https://github.com/user-attachments/assets/944905fd-66ca-41a6-9b02-b524e5b7c74f

# Problem

The laser — and any `WPN_BEAM` weapon — carved terrain and dealt damage, but the red beam was never rendered. It already was being drawn correctly on the 0.58 branch.

## Root cause

A refactor of `CClient_Game.cpp` broke the client-side beam-visual path (the SDL2 port is *not* involved — the drawing primitives are byte-identical to 0.58):

- `CClient::PlayerShoot()` was reordered so the generic rate-of-fire gate (`if(LastFire > 0) return;`) now runs *before* the `WPN_BEAM` branch, and the old "draw the beam every frame while `LastFire` counts down" logic was lost.
- `CClient::ProcessShot_Beam()` no longer set `LastFire`.

Together, `CClient::DrawBeam()` (which spawns the visible beam entity) was never reached during continuous fire, while the server-side beam processing still carved the map. Hence: damage/carving worked, no visuals.

## Fix

Restore the pre-refactor (0.58) behaviour:

- `PlayerShoot()`: handle `WPN_BEAM` before the rate-of-fire gate and draw the beam each frame while `LastFire > 0`, decrementing it by the frame time. (Tying the draw to `LastFire` rather than the `bShoot` button state is deliberate — it keeps the beam from showing while the button is held but the worm is out of ammo, since the server only emits shoot-packets while actually firing.)
- `ProcessShot_Beam()`: after a shoot packet, select the matching weapon slot as current and set `LastFire = 0.3s`. The slot reconciliation matters for non-local worms (bots / network players), whose selected weapon is synced unreliably — without it their beam would draw with the wrong colour or not at all.

## Testing

Reproduced and verified on Linux/X11 with the **Liero v1.11** mod on a dirt level: before the fix, firing the laser carves tunnels but shows no beam; after the fix, the red beam renders correctly while firing.