### PR TITLE
Fix broken wiki links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Jason B. has released his work in 2006 under the zlib-licence and after some mon
 
 ## Compilation
 
-For more details, read here: <http://www.openlierox.net/wiki/index.php/Compile_OpenLieroX>
+For more details, read here: <https://github.com/openlierox/openlierox/wiki/Compile-OpenLieroX>
 
 ### Linux/Unix
 
@@ -89,11 +89,11 @@ The game searches the paths `~/.OpenLieroX`, `./` and `/usr/share/games/OpenLier
 You can also add more searchpathes and change this in `cfg/options.cfg`.
 Own modified configs, screenshots and other stuff always will be stored in `~/.OpenLieroX`.
 
-More details: <http://www.openlierox.net/wiki/index.php/Virtual_File_System>
+More details: <https://github.com/openlierox/openlierox/wiki/Virtual-File-System>
 
 ## Development
 
-If you are interested in the development, either in how we work, the work / source code itself or if you want to support us in any way, read here: <http://www.openlierox.net/wiki/index.php/Development>
+If you are interested in the development, either in how we work, the work / source code itself or if you want to support us in any way, read here: <https://github.com/openlierox/openlierox/wiki/Development>
 
 ## Report bugs / feature requests
 


### PR DESCRIPTION
The three wiki links in the README pointed at the old MediaWiki
(`openlierox.net/wiki/index.php/...`), which is now dead
(the server returns a PHP parse error).

The pages were already restored from the Wayback Machine into the
GitHub Wiki as part of the website migration (#891), so this repoints
the links there:

- Compile_OpenLieroX -> [Compile-OpenLieroX](https://github.com/openlierox/openlierox/wiki/Compile-OpenLieroX)
- Virtual_File_System -> [Virtual-File-System](https://github.com/openlierox/openlierox/wiki/Virtual-File-System)
- Development -> [Development](https://github.com/openlierox/openlierox/wiki/Development)

Docs-only change; the other README links still resolve and were left as-is.