### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,9 @@ Markdown/READMEs and commit messages alike.
 
 - Headless test suite: [`tests/headless/`](tests/headless/) (see its README); runs in CI via `./tests/headless/run.sh`.
 - Add or adjust tests together with your change.
-- A known critical bug should fail loudly: a plain failing test, not `xfail`.
+- Fail loudly, don't hide:
+  a known critical bug is a plain failing test (not `xfail`),
+  and a missing prerequisite fails rather than skips.
 
 ## Resources
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to OpenLieroX
+
+## Workflow
+
+- Build and run the game first: see [README](README.md) (dependencies in [`DEPS`](DEPS)); the build is CMake-based.
+- Report bugs and request features as GitHub issues.
+- Contribute via a branch and a pull request against `master`; another developer reviews before merge.
+- Discuss large or risky changes before you start.
+- Code must compile and pass the tests before you push.
+
+## Commits
+
+- One logical change per commit.
+- Subject: imperative mood, <= 50 chars, capitalized, no trailing period.
+- Then a blank line and a body wrapped at ~72, explaining what and why.
+- Keep commits small and focused — it makes review and later bisecting easy.
+- Don't force-push a published commit; a new change is a new commit.
+  Only rewrite/force-push your own not-yet-merged commits (or when asked to).
+
+## C++ style
+
+- Standard C++ and the STL (`std::string`, `std::vector`, ...); no C-isms (`strcpy`, C strings, `int` for `bool`).
+- Clean, robust, general code — no hacks or workarounds; fix the real cause instead.
+- Small functions, few locals.
+- Prefer type/logic checks over error-prone patterns; avoid broad catch-all error handling.
+- Indent with tabs; put spaces between tokens; two spaces before `{` after `if`/`for`/`while`.
+- Comment only non-obvious code; mark incomplete or temporary code with `TODO`.
+- No leftover debug/test code, and no new option for every tweak — discuss first.
+- Match the surrounding file's conventions.
+
+## Comments, doc strings, prose and commit messages
+
+Break lines at clause boundaries — sentence end, comma, conjunction, end of a phrase —
+not at a fixed column.
+Each line should read as one logical unit;
+lengths vary, so the right edge is ragged, not straight.
+This applies to `//` and `/* */` comments, multi-line string literals,
+Markdown/READMEs and commit messages alike.
+
+- Keep comments tight: compress to the essential signal.
+  A comment longer than the code it explains is usually too long.
+- A trailing inline comment is fine only while the whole line stays within the column limit;
+  otherwise move it to its own line(s) above.
+
+## Tests
+
+- Headless test suite: [`tests/headless/`](tests/headless/) (see its README); runs in CI via `./tests/headless/run.sh`.
+- Add or adjust tests together with your change.
+- A known critical bug should fail loudly — a plain failing test, not `xfail`.
+
+## Code map
+
+- `src/main.cpp` — entry point and game loop.
+- `src/client/*` — menu and client; `src/server/*` — server and the game itself.
+- `src/common/*` — core structures (worm, map, ...); `include/*` — headers.
+- Key types: `CMap`, `CWorm`, `CServer`, `CClient`, `CGameScript`, `LieroX`.
+- Physics: `Physics*`, `CProjectile`, `CNinjaRope`; net: `Networking`, `CBytestream`, `CChannel`; files/cache: `FindFile`, `Cache`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,11 +53,11 @@ Markdown/READMEs and commit messages alike.
 
 ## Resources
 
-- Wiki: [Development](https://github.com/openlierox/openlierox/wiki/Development),
+- [Wiki](https://github.com/openlierox/openlierox/wiki): [Development](https://github.com/openlierox/openlierox/wiki/Development),
   [Contribute](https://github.com/openlierox/openlierox/wiki/Contribute),
   [Contribute to the source code](https://github.com/openlierox/openlierox/wiki/Contribute-to-the-source-code),
   and the per-platform compile guides.
 - [`doc/`](doc/), notably [`doc/Development`](doc/Development) (code overview and style) and [`doc/TODO`](doc/TODO).
 - [Issue tracker](https://github.com/openlierox/openlierox/issues),
-  [GitHub Discussions](https://github.com/openlierox/openlierox/discussions),
-  [forum](http://openlierox.net/forum); homepage <http://openlierox.net>.
+  [GitHub Discussions](https://github.com/openlierox/openlierox/discussions) (our forum);
+  homepage <http://openlierox.net>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,8 @@
 - Build and run the game first: see [README](README.md) (dependencies in [`DEPS`](DEPS)); the build is CMake-based.
 - Report bugs and request features as GitHub issues.
 - Contribute via a branch and a pull request against `master`; another developer reviews before merge.
+- Use a short, descriptive branch name.
+  For a bug fix, first make sure an issue exists, and put its number in the name (e.g. `fix-973-mid-game-join`).
 - Discuss large or risky changes before you start.
 - Code must compile and pass the tests before you push.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,24 +13,24 @@
 - One logical change per commit.
 - Subject: imperative mood, <= 50 chars, capitalized, no trailing period.
 - Then a blank line and a body wrapped at ~72, explaining what and why.
-- Keep commits small and focused — it makes review and later bisecting easy.
+- Keep commits small and focused; it makes review and later bisecting easy.
 - Don't force-push a published commit; a new change is a new commit.
   Only rewrite/force-push your own not-yet-merged commits (or when asked to).
 
 ## C++ style
 
 - Standard C++ and the STL (`std::string`, `std::vector`, ...); no C-isms (`strcpy`, C strings, `int` for `bool`).
-- Clean, robust, general code — no hacks or workarounds; fix the real cause instead.
+- Clean, robust, general code; no hacks or workarounds; fix the real cause instead.
 - Small functions, few locals.
 - Prefer type/logic checks over error-prone patterns; avoid broad catch-all error handling.
 - Indent with tabs; put spaces between tokens; two spaces before `{` after `if`/`for`/`while`.
 - Comment only non-obvious code; mark incomplete or temporary code with `TODO`.
-- No leftover debug/test code, and no new option for every tweak — discuss first.
+- No leftover debug/test code, and no new option for every tweak; discuss first.
 - Match the surrounding file's conventions.
 
 ## Comments, doc strings, prose and commit messages
 
-Break lines at clause boundaries — sentence end, comma, conjunction, end of a phrase —
+Break lines at clause boundaries (sentence end, comma, conjunction, end of a phrase),
 not at a fixed column.
 Each line should read as one logical unit;
 lengths vary, so the right edge is ragged, not straight.
@@ -41,20 +41,14 @@ Markdown/READMEs and commit messages alike.
   A comment longer than the code it explains is usually too long.
 - A trailing inline comment is fine only while the whole line stays within the column limit;
   otherwise move it to its own line(s) above.
+- Write plainly. No em-dashes (use `--`), and skip LLM tells:
+  no "delve"/"leverage"/"seamless", no "it's worth noting", no filler.
 
 ## Tests
 
 - Headless test suite: [`tests/headless/`](tests/headless/) (see its README); runs in CI via `./tests/headless/run.sh`.
 - Add or adjust tests together with your change.
-- A known critical bug should fail loudly — a plain failing test, not `xfail`.
-
-## Code map
-
-- `src/main.cpp` — entry point and game loop.
-- `src/client/*` — menu and client; `src/server/*` — server and the game itself.
-- `src/common/*` — core structures (worm, map, ...); `include/*` — headers.
-- Key types: `CMap`, `CWorm`, `CServer`, `CClient`, `CGameScript`, `LieroX`.
-- Physics: `Physics*`, `CProjectile`, `CNinjaRope`; net: `Networking`, `CBytestream`, `CChannel`; files/cache: `FindFile`, `Cache`.
+- A known critical bug should fail loudly: a plain failing test, not `xfail`.
 
 ## Resources
 
@@ -62,5 +56,5 @@ Markdown/READMEs and commit messages alike.
   [Contribute](https://github.com/openlierox/openlierox/wiki/Contribute),
   [Contribute to the source code](https://github.com/openlierox/openlierox/wiki/Contribute-to-the-source-code),
   and the per-platform compile guides.
-- [`doc/`](doc/) — notably [`doc/Development`](doc/Development) (code overview, style) and [`doc/TODO`](doc/TODO).
+- [`doc/`](doc/), notably [`doc/Development`](doc/Development) (code overview and style) and [`doc/TODO`](doc/TODO).
 - [Issue tracker](https://github.com/openlierox/openlierox/issues); homepage <http://openlierox.net>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@
 - Keep commits small and focused; it makes review and later bisecting easy.
 - Don't force-push a published commit; a new change is a new commit.
   Only rewrite/force-push your own not-yet-merged commits (or when asked to).
+- No `Co-authored-by:` lines crediting an LLM or AI agent.
 
 ## C++ style
 
@@ -41,8 +42,8 @@ Markdown/READMEs and commit messages alike.
   A comment longer than the code it explains is usually too long.
 - A trailing inline comment is fine only while the whole line stays within the column limit;
   otherwise move it to its own line(s) above.
-- Write plainly. No em-dashes (use `--`), and skip LLM tells:
-  no "delve"/"leverage"/"seamless", no "it's worth noting", no filler.
+- Write plainly. No em-dashes (use `--`).
+  Avoid "delve", "leverage", "seamless", "utilize", "it's worth noting", and empty filler.
 
 ## Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,4 +58,6 @@ Markdown/READMEs and commit messages alike.
   [Contribute to the source code](https://github.com/openlierox/openlierox/wiki/Contribute-to-the-source-code),
   and the per-platform compile guides.
 - [`doc/`](doc/), notably [`doc/Development`](doc/Development) (code overview and style) and [`doc/TODO`](doc/TODO).
-- [Issue tracker](https://github.com/openlierox/openlierox/issues); homepage <http://openlierox.net>.
+- [Issue tracker](https://github.com/openlierox/openlierox/issues),
+  [GitHub Discussions](https://github.com/openlierox/openlierox/discussions),
+  [forum](http://openlierox.net/forum); homepage <http://openlierox.net>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,3 +55,12 @@ Markdown/READMEs and commit messages alike.
 - `src/common/*` — core structures (worm, map, ...); `include/*` — headers.
 - Key types: `CMap`, `CWorm`, `CServer`, `CClient`, `CGameScript`, `LieroX`.
 - Physics: `Physics*`, `CProjectile`, `CNinjaRope`; net: `Networking`, `CBytestream`, `CChannel`; files/cache: `FindFile`, `Cache`.
+
+## Resources
+
+- Wiki: [Development](https://github.com/openlierox/openlierox/wiki/Development),
+  [Contribute](https://github.com/openlierox/openlierox/wiki/Contribute),
+  [Contribute to the source code](https://github.com/openlierox/openlierox/wiki/Contribute-to-the-source-code),
+  and the per-platform compile guides.
+- [`doc/`](doc/) — notably [`doc/Development`](doc/Development) (code overview, style) and [`doc/TODO`](doc/TODO).
+- [Issue tracker](https://github.com/openlierox/openlierox/issues); homepage <http://openlierox.net>.


### PR DESCRIPTION
Adds a dense contributor guide covering:

- **Workflow** — build/report/branch+PR/review, discuss big changes.
- **Commits** — subject <=50 chars imperative, body ~72; small focused commits; no force-push of published commits.
- **C++ style** — STL over C-isms, clean/general (no hacks), small functions, tabs, two spaces before `{`, TODO markers.
- **Prose line breaks** — clause-boundary wrapping for comments, doc strings, Markdown and commit messages.
- **Tests** — the headless suite; critical bugs fail loudly (no xfail).
- **Code map** — where the main structures live.

Based on the project wiki (Development / Contribute / Contribute-to-the-source-code) and `doc/Development`, plus conventions agreed while adding the headless test suite. Kept intentionally short and dense.