### PR TITLE
Fix joining a running game (#973)

### DIFF
--- a/include/CServer.h
+++ b/include/CServer.h
@@ -231,10 +231,7 @@ public:
 	void		SendEmptyWeaponsOnRespawn( CWorm * Worm );
 	bool		SendUpdate();
 	void		SendGameStateUpdates();
-	// Send the pending attribute-state delta to one client (>=0.59.10) now.
-	// Returns whether anything was sent.
-	// Also used to give a mid-game joiner its full snapshot before PrepareGame.
-	bool		SendGameStateUpdates(CServerConnection* cl);
+	bool		SendGameStateUpdates(CServerConnection* cl); // for one client; returns whether it sent anything
 	void		SendWeapons(CServerConnection* cl = NULL, CWorm* w = NULL); // if NULL, send globally, else only to that client
 	void		SendWormTagged(CWorm *w);
 	void		SendTeamScoreUpdate();

--- a/include/CServer.h
+++ b/include/CServer.h
@@ -231,6 +231,10 @@ public:
 	void		SendEmptyWeaponsOnRespawn( CWorm * Worm );
 	bool		SendUpdate();
 	void		SendGameStateUpdates();
+	// Send the pending attribute-state delta to one client (>=0.59.10) now.
+	// Returns whether anything was sent.
+	// Also used to give a mid-game joiner its full snapshot before PrepareGame.
+	bool		SendGameStateUpdates(CServerConnection* cl);
 	void		SendWeapons(CServerConnection* cl = NULL, CWorm* w = NULL); // if NULL, send globally, else only to that client
 	void		SendWormTagged(CWorm *w);
 	void		SendTeamScoreUpdate();

--- a/src/client/CClient_Parse.cpp
+++ b/src/client/CClient_Parse.cpp
@@ -782,9 +782,6 @@ bool CClientNetEngine::ParsePrepareGame(CBytestream *bs)
 	}
 	if(game.isClient() && client->getServerVersion() < OLXBetaVersion(0,59,10))
 		client->getGameLobby().overwrite[FT_Map] = infoForLevel(GetBaseFilename(sMapFilename));
-	else if(game.isClient() && client->getGameLobby()[FT_Map].as<LevelInfo>()->name == "")
-		// Mid-game joiner without the synced map yet: take it from here (see the mod handling below, #973).
-		client->getGameLobby().overwrite[FT_Map] = infoForLevel(GetBaseFilename(sMapFilename));
 
 	// Other game details
 	if(game.isClient() && client->getServerVersion() < OLXBetaVersion(0,59,10)) {
@@ -810,20 +807,9 @@ bool CClientNetEngine::ParsePrepareGame(CBytestream *bs)
 	// Set the gamescript
 	if(game.isClient() && client->getServerVersion() < OLXBetaVersion(0,59,10))
 		client->getGameLobby().overwrite[FT_Mod] = infoForMod(bs->readString());
-	else {
-		// Since 0.59.10 the mod (like the map) is normally synced via the
-		// attribute system, so here we would just skip it.
-		// But a client joining a game in progress has not had that sync yet,
-		// and without the mod it rejects the game ("invalid mod name (none)")
-		// and gets kicked (#973).
-		// The server still writes the mod here, so use it when we have none yet.
-		const std::string modPath = bs->readString();
-		if(game.isClient() && client->getGameLobby()[FT_Mod].as<ModInfo>()->name == "") {
-			notes << "ParsePrepareGame: joining game in progress; taking mod from PrepareGame" << endl;
-			client->getGameLobby().overwrite[FT_Mod] = infoForMod(modPath);
-		}
-	}
-
+	else
+		bs->SkipString();
+	
 	// Bad packet
 	if (client->getGameLobby()[FT_Mod].as<ModInfo>()->name == "")  {
 		hints << "CClientNetEngine::ParsePrepareGame: invalid mod name (none)" << endl;

--- a/src/client/CClient_Parse.cpp
+++ b/src/client/CClient_Parse.cpp
@@ -782,6 +782,9 @@ bool CClientNetEngine::ParsePrepareGame(CBytestream *bs)
 	}
 	if(game.isClient() && client->getServerVersion() < OLXBetaVersion(0,59,10))
 		client->getGameLobby().overwrite[FT_Map] = infoForLevel(GetBaseFilename(sMapFilename));
+	else if(game.isClient() && client->getGameLobby()[FT_Map].as<LevelInfo>()->name == "")
+		// Mid-game joiner without the synced map yet: take it from here (see the mod handling below, #973).
+		client->getGameLobby().overwrite[FT_Map] = infoForLevel(GetBaseFilename(sMapFilename));
 
 	// Other game details
 	if(game.isClient() && client->getServerVersion() < OLXBetaVersion(0,59,10)) {
@@ -807,9 +810,20 @@ bool CClientNetEngine::ParsePrepareGame(CBytestream *bs)
 	// Set the gamescript
 	if(game.isClient() && client->getServerVersion() < OLXBetaVersion(0,59,10))
 		client->getGameLobby().overwrite[FT_Mod] = infoForMod(bs->readString());
-	else
-		bs->SkipString();
-	
+	else {
+		// Since 0.59.10 the mod (like the map) is normally synced via the
+		// attribute system, so here we would just skip it.
+		// But a client joining a game in progress has not had that sync yet,
+		// and without the mod it rejects the game ("invalid mod name (none)")
+		// and gets kicked (#973).
+		// The server still writes the mod here, so use it when we have none yet.
+		const std::string modPath = bs->readString();
+		if(game.isClient() && client->getGameLobby()[FT_Mod].as<ModInfo>()->name == "") {
+			notes << "ParsePrepareGame: joining game in progress; taking mod from PrepareGame" << endl;
+			client->getGameLobby().overwrite[FT_Mod] = infoForMod(modPath);
+		}
+	}
+
 	// Bad packet
 	if (client->getGameLobby()[FT_Mod].as<ModInfo>()->name == "")  {
 		hints << "CClientNetEngine::ParsePrepareGame: invalid mod name (none)" << endl;

--- a/src/game/GameState.cpp
+++ b/src/game/GameState.cpp
@@ -301,12 +301,9 @@ void GameStateUpdates::diffFromStateToCurrent(const GameState& s) {
 	foreach(o, game.gameStateUpdates->objCreations) {
 		if(game.isClient()) continue; // none-at-all right now... worm-creation is handled independently atm
 		if(!o->obj) continue;
-		// Emit a creation for any object this client does not have yet.
-		// This used to be gated on weOwnThis() (worm->getLocal()),
-		// but on a dedicated server no worm is local,
-		// so no worm creation was ever sent
-		// and a joining client never learned about the other clients' worms (#973).
-		// The attr-update loop below is already ungated, so this keeps them consistent.
+		// Create any object this client does not have yet.
+		// Was gated on weOwnThis() (== getLocal()), false for a worm owned by
+		// another client, so a client never learned the other clients' worms (#973).
 		if(!s.haveObject(*o))
 			pushObjCreation(*o);
 	}

--- a/src/game/GameState.cpp
+++ b/src/game/GameState.cpp
@@ -301,7 +301,12 @@ void GameStateUpdates::diffFromStateToCurrent(const GameState& s) {
 	foreach(o, game.gameStateUpdates->objCreations) {
 		if(game.isClient()) continue; // none-at-all right now... worm-creation is handled independently atm
 		if(!o->obj) continue;
-		if(!o->obj.get()->weOwnThis()) continue;
+		// Emit a creation for any object this client does not have yet.
+		// This used to be gated on weOwnThis() (worm->getLocal()),
+		// but on a dedicated server no worm is local,
+		// so no worm creation was ever sent
+		// and a joining client never learned about the other clients' worms (#973).
+		// The attr-update loop below is already ungated, so this keeps them consistent.
 		if(!s.haveObject(*o))
 			pushObjCreation(*o);
 	}

--- a/src/server/CServer_Parse.cpp
+++ b/src/server/CServer_Parse.cpp
@@ -1655,14 +1655,9 @@ void GameServer::ParseConnect(const SmartPointer<NetworkSocket>& net_socket, CBy
 		}
 		newcl->setGameReady(false);
 
-		// A client joining a game in progress must already know the game state
-		// (above all the mod) when it parses PrepareGame,
-		// or it rejects the game ("invalid mod name (none)") and gets kicked (#973).
-		// Since 0.59.10 the settings and worms reach the client only through the
-		// attribute sync, which SendGameStateUpdates() would otherwise send only
-		// on a later server frame, i.e. too late.
-		// A lobby joiner accumulates this over the lobby frames;
-		// push the full snapshot to a mid-game joiner now, before PrepareGame.
+		// A mid-game joiner has none of the synced state yet
+		// (a lobby joiner accumulates it over the lobby frames);
+		// send it now, before PrepareGame, so the client knows the mod (#973).
 		notes << "connect during game: " << newcl->debugName() << ", sending game state then PrepareGame" << endl;
 		SendGameStateUpdates(newcl);
 

--- a/src/server/CServer_Parse.cpp
+++ b/src/server/CServer_Parse.cpp
@@ -1654,7 +1654,18 @@ void GameServer::ParseConnect(const SmartPointer<NetworkSocket>& net_socket, CBy
 			newcl->getUdpFileDownloader()->allowFileRequest(false);
 		}
 		newcl->setGameReady(false);
-		
+
+		// A client joining a game in progress must already know the game state
+		// (above all the mod) when it parses PrepareGame,
+		// or it rejects the game ("invalid mod name (none)") and gets kicked (#973).
+		// Since 0.59.10 the settings and worms reach the client only through the
+		// attribute sync, which SendGameStateUpdates() would otherwise send only
+		// on a later server frame, i.e. too late.
+		// A lobby joiner accumulates this over the lobby frames;
+		// push the full snapshot to a mid-game joiner now, before PrepareGame.
+		notes << "connect during game: " << newcl->debugName() << ", sending game state then PrepareGame" << endl;
+		SendGameStateUpdates(newcl);
+
 		if(newcl->getClientVersion() <= OLXBetaVersion(0,57,8))
 			// HINT: this is necessary because of beta8 which doesn't update all its state variables from preparegame
 			newcl->getNetEngine()->SendUpdateLobbyGame();

--- a/src/server/CServer_Send.cpp
+++ b/src/server/CServer_Send.cpp
@@ -609,19 +609,8 @@ void GameServer::SendGameStateUpdates() {
 		if(cl->getChannel()->getBufferFull())
 			continue;
 
-		GameState& state = *cl->gameState;
-		GameStateUpdates updates;
-		updates.diffFromStateToCurrent(state);
-		if(!updates) continue;
-
-		{
-			CBytestream bs;
-			bs.writeByte(S2C_GAMEATTRUPDATE);
-			updates.writeToBs(&bs, state);
-			cl->getChannel()->AddReliablePacketToSend(bs);
-		}
-
-		cl->gameState->updateToCurrent();
+		if(!SendGameStateUpdates(cl))
+			continue;
 
 		lastClientSendData = int(cl - cServer->getClients());
 		if(cl == firstNonlocalClientConnection()) counter.addData(1);
@@ -635,6 +624,28 @@ void GameServer::SendGameStateUpdates() {
 		CClient::addHudDebugInfo("Update FPS: " + ftoa(counter.getRate()));
 		CClient::addHudDebugInfo("BandwdthHit FPS: " + ftoa(bandwidthHitCounter.getRate()));
 	}
+}
+
+bool GameServer::SendGameStateUpdates(CServerConnection* cl) {
+	// The attribute sync is a >=0.59.10 feature;
+	// older clients get their state through the legacy packets instead.
+	if(cl->isLocalClient()) return false;
+	if(!cl->isConnected()) return false;
+	if(cl->getClientVersion() < OLXBetaVersion(0,59,10)) return false;
+	if(!cl->gameState) return false;
+
+	GameState& state = *cl->gameState;
+	GameStateUpdates updates;
+	updates.diffFromStateToCurrent(state);
+	if(!updates) return false;
+
+	CBytestream bs;
+	bs.writeByte(S2C_GAMEATTRUPDATE);
+	updates.writeToBs(&bs, state);
+	cl->getChannel()->AddReliablePacketToSend(bs);
+
+	cl->gameState->updateToCurrent();
+	return true;
 }
 
 void CServerNetEngine::SendWeapons(CWorm* specificW)

--- a/tests/headless/control/server_control.py
+++ b/tests/headless/control/server_control.py
@@ -16,6 +16,7 @@ so one script serves every scenario:
 ``OLX_MAP``                  level file (default "Dirt Level.lxl")
 ``OLX_MOD``                  mod name (default "Classic")
 ``OLX_WEAPON_SEL_TIME``      seconds before unready clients are kicked
+``OLX_START_WHEN_WORMS``     worms that must be in the lobby before we start (default 1)
 ``OLX_RUN_SECONDS``          how long to keep the server loop alive
 ===========================  =========================================
 """
@@ -55,6 +56,7 @@ def main():
     command("startlobby " + port)
     emit("SERVER_LOBBY")
 
+    start_when = int(os.environ.get("OLX_START_WHEN_WORMS", "1"))
     started = False
     playing = False
     deadline = time.time() + int(os.environ.get("OLX_RUN_SECONDS", "90"))
@@ -62,7 +64,7 @@ def main():
         state = game_state()
         worms = worm_ids()
         emit("SERVER_POLL state=%s worms=%s" % (state, ",".join(worms)))
-        if state == "Lobby" and len(worms) >= 1 and not started:
+        if state == "Lobby" and len(worms) >= start_when and not started:
             command("startgame")
             emit("SERVER_STARTGAME")
             started = True

--- a/tests/headless/test_network.py
+++ b/tests/headless/test_network.py
@@ -59,3 +59,32 @@ def test_client_can_join_running_game(network_game):
         "invalid-mod-name seen: %s\n%s"
         % ("invalid mod name" in c2.read_log(), c2.read_log())
     )
+
+
+def test_two_clients_in_lobby_see_each_other(network_game):
+    """Two clients that both join in the lobby must both play and see each other.
+
+    Separate from #973's mid-game timing:
+    a >=0.59.10 server never tells a client about *another* client's worm
+    (the attribute creation is limited to local worms,
+    and the legacy worm-info send is disabled).
+    So on master a client is missing the peer's worm
+    and logs "object for attr update not found".
+    """
+    # Wait for both worms to be in the lobby before starting.
+    server = network_game.start_server(OLX_START_WHEN_WORMS=2)
+    assert server.wait_for("SERVER_LOBBY", timeout=30), server.read_log()
+
+    c1 = network_game.add_client("c1")
+    c2 = network_game.add_client("c2")
+
+    assert server.wait_for("SERVER_PLAYING", timeout=40), server.read_log()
+    assert c1.wait_for("CLIENT[c1] PLAYING", timeout=30), c1.read_log()
+    assert c2.wait_for("CLIENT[c2] PLAYING", timeout=30), c2.read_log()
+
+    # Each client must have received the other's worm.
+    for client in (c1, c2):
+        assert "object for attr update not found" not in client.read_log(), (
+            "%s never received the other client's worm:\n%s"
+            % (client.name, client.read_log())
+        )


### PR DESCRIPTION
Fixes #973. A proper fix, not the protocol revert of #966.

## The bug

On a >=0.59.10 server, a client could not properly join a running game, and even
two clients both joining in the lobby did not work; only the first player worked.
0.58 servers are unaffected (clients auto-fall-back to the 0.58 protocol), which
is why it went unnoticed.

It is not specific to dedicated servers. On a dedicated server every worm is
affected (no worm is local), so it always breaks; on a listen (host) server a
joiner still misses the other clients' worms.

## Root cause

Since 0.59.10, game state replicates via the attribute system (GameState/Attr),
and the old explicit sends were disabled for >=0.59.10 clients. Two gaps in that
migration:

1. **Timing.** The attribute snapshot (which carries the mod, map and all
   settings) is sent by the per-frame loop, but PrepareGame is sent synchronously
   in ParseConnect, before that loop runs for the new client. A lobby joiner
   accumulates the settings over the lobby frames; a mid-game joiner had none, so
   it rejected the game ("invalid mod name (none)") and got kicked.

2. **Worm creation.** The attribute diff only emitted creations for worms the
   server "owns" (`weOwnThis()` == `getLocal()`). On a dedicated server no worm
   is local, so no worm creation was ever sent, and a client never learned about
   the other clients' worms.

## The fix

1. When a client joins a game in progress, push it the full attribute snapshot
   (settings and worms) before PrepareGame, i.e. the same state a lobby joiner
   accumulates over the lobby frames. (`CServer_Parse.cpp`, `CServer_Send.cpp`)

2. Emit a creation for any object the client does not have yet, consistent with
   the already-ungated attribute updates. (`GameState.cpp`)

## Tests (tests/headless)

- `test_client_can_join_running_game`: a client joins an already-running game.
- `test_two_clients_in_lobby_see_each_other`: two clients both join in the lobby.

Both fail on master and pass with the fix; full headless suite is green.

## Scope

- master-only, client and server side; unmodified clients and 0.58 servers are
  unaffected.
- Focused on joining. The symmetric leaving path (worm removal to >=0.59.10
  clients) has the same latent flaw and is tracked separately in #978.
