### PR TITLE
Fix worm removal not reaching clients on leave (#978)

### DIFF
--- a/src/common/Command.cpp
+++ b/src/common/Command.cpp
@@ -2025,8 +2025,6 @@ void Cmd_privateMsg::exec(CmdLineIntf* caller, const std::vector<std::string>& p
 COMMAND(getWormList, "get worm list", "", 0, 0);
 void Cmd_getWormList::exec(CmdLineIntf* caller, const std::vector<std::string>& params)
 {
-	if(game.isClient() || !cServer || !cServer->isServerRunning()) { caller->writeMsg(name + " works only as server"); return; }
-	
 	for_each_iterator(CWorm*, w, game.worms())
 		caller->pushReturnArg(itoa(w->get()->getID()));
 }

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -1132,6 +1132,7 @@ void Game::onUnprepareWorm(CWorm* w) {
 }
 
 void Game::onRemoveWorm(CWorm* w) {
+	notes << "removing worm " << w->getID() << " '" << w->getName() << "'" << endl;
 	if(w->isPrepared())
 		w->Unprepare(); // also to call onUnprepareWorm and to unlink it
 	std::map<int,CWorm*>::iterator i = m_worms.find(w->getID());

--- a/src/game/GameState.cpp
+++ b/src/game/GameState.cpp
@@ -329,8 +329,9 @@ void GameStateUpdates::diffFromStateToCurrent(const GameState& s) {
 	}
 	foreach(o, game.gameStateUpdates->objDeletions) {
 		if(game.isClient()) continue; // see obj-creations
-		if(!o->obj) continue;
-		if(!o->obj.get()->weOwnThis()) continue;
+		// Unlike a creation, the object is already gone here, so we must not
+		// require o->obj to resolve; the ObjRef alone tells clients it left.
+		// Send it to any client that still has the object (#978).
 		if(s.haveObject(*o))
 			pushObjDeletion(*o);
 	}

--- a/src/game/GameState.cpp
+++ b/src/game/GameState.cpp
@@ -329,8 +329,9 @@ void GameStateUpdates::diffFromStateToCurrent(const GameState& s) {
 	}
 	foreach(o, game.gameStateUpdates->objDeletions) {
 		if(game.isClient()) continue; // see obj-creations
-		// Unlike a creation, the object is already gone here, so we must not
-		// require o->obj to resolve; the ObjRef alone tells clients it left.
+		// Unlike a creation, the object is already gone here,
+		// so we must not require o->obj to resolve;
+		// the ObjRef alone tells clients it left.
 		// Send it to any client that still has the object (#978).
 		if(s.haveObject(*o))
 			pushObjDeletion(*o);

--- a/tests/headless/control/client_control.py
+++ b/tests/headless/control/client_control.py
@@ -8,10 +8,11 @@ It emits ``CLIENT[<name>] PLAYING`` once the client has joined the running game.
 
 Environment variables:
 
-===========================  =========================================
-``OLX_CLIENT_NAME``          short label used in the emitted markers
-``OLX_RUN_SECONDS``          how long to keep observing
-===========================  =========================================
+====================================  =========================================
+``OLX_CLIENT_NAME``                   short label used in the emitted markers
+``OLX_RUN_SECONDS``                   how long to keep observing
+``OLX_LEAVE_SIGNAL_FILE``             once this file exists, disconnect and quit
+====================================  =========================================
 """
 
 import os
@@ -19,17 +20,30 @@ import sys
 import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _olx_pipe import emit, game_state, worm_ids  # noqa: E402
+from _olx_pipe import command, emit, game_state, worm_ids  # noqa: E402
 
 
 def main():
     name = os.environ.get("OLX_CLIENT_NAME", "client")
+    leave_signal = os.environ.get("OLX_LEAVE_SIGNAL_FILE")
     reached_playing = False
+    prev_worms = set()
     deadline = time.time() + int(os.environ.get("OLX_RUN_SECONDS", "60"))
     while time.time() < deadline:
+        if leave_signal and os.path.exists(leave_signal):
+            emit("CLIENT[%s] LEAVING" % name)
+            command("disconnect")
+            break
         state = game_state()
-        worms = worm_ids()
-        emit("CLIENT[%s] state=%s worms=%s" % (name, state, ",".join(worms)))
+        worms = set(worm_ids())
+        emit("CLIENT[%s] state=%s worms=%s" % (name, state, ",".join(sorted(worms))))
+        # Emit an event for each worm that appeared or disappeared,
+        # so tests can wait on a specific join/leave rather than a whole-list state.
+        for gone in sorted(prev_worms - worms):
+            emit("CLIENT[%s] WORM_LEFT %s" % (name, gone))
+        for joined in sorted(worms - prev_worms):
+            emit("CLIENT[%s] WORM_JOINED %s" % (name, joined))
+        prev_worms = worms
         if state == "Playing" and not reached_playing:
             emit("CLIENT[%s] PLAYING" % name)
             reached_playing = True

--- a/tests/headless/harness.py
+++ b/tests/headless/harness.py
@@ -144,11 +144,14 @@ class NetworkGame:
         ).start()
         return self.server
 
-    def add_client(self, name):
+    def add_client(self, name, env=None):
+        client_env = {"OLX_CLIENT_NAME": name}
+        if env:
+            client_env.update(env)
         client = OlxInstance(
             self.binary, name, os.path.join(self.base_home, name),
             CLIENT_CONTROL, connect="127.0.0.1:" + self.PORT,
-            env={"OLX_CLIENT_NAME": name},
+            env=client_env,
         ).start()
         self.clients.append(client)
         return client

--- a/tests/headless/test_network.py
+++ b/tests/headless/test_network.py
@@ -88,3 +88,27 @@ def test_two_clients_in_lobby_see_each_other(network_game):
             "%s never received the other client's worm:\n%s"
             % (client.name, client.read_log())
         )
+
+
+def test_worm_removed_when_client_leaves(network_game, tmp_path):
+    """When a client leaves a running game, the others drop its worm (#978)."""
+    server = network_game.start_server(OLX_START_WHEN_WORMS=2)
+    assert server.wait_for("SERVER_LOBBY", timeout=30), server.read_log()
+
+    leave_signal = str(tmp_path / "c1_leave")
+    c1 = network_game.add_client("c1", env={"OLX_LEAVE_SIGNAL_FILE": leave_signal})
+    c2 = network_game.add_client("c2")
+
+    assert server.wait_for("SERVER_PLAYING", timeout=40), server.read_log()
+    assert c2.wait_for("CLIENT[c2] PLAYING", timeout=30), c2.read_log()
+
+    # Wait until c2 sees both worms (ids 0 and 1; which client got which is racy).
+    assert c2.wait_for("CLIENT[c2] state=Playing worms=0,1", timeout=20), (
+        "c2 never received both worms:\n" + c2.read_log()
+    )
+
+    # Tell c1 to leave; c2 must then drop c1's worm (whichever id it has).
+    open(leave_signal, "w").close()
+    assert c2.wait_for("CLIENT[c2] WORM_LEFT ", timeout=30), (
+        "c2 still lists c1's worm after c1 left:\n" + c2.read_log()
+    )


### PR DESCRIPTION
Fixes #978, the mirror of #973 (fixed in #977) on the leaving side.

## The bug

When a player leaves a running game,
other >=0.59.10 clients keep a stale worm for that player;
it is never removed.

## Root cause

Since 0.59.10, worm removal reaches other clients only through
the attribute deletion loop in `GameStateUpdates::diffFromStateToCurrent`.
That loop dropped every worm deletion, for two reasons:

- The `weOwnThis()` gate (== `getLocal()`) skipped worms owned by another client
  (on a dedicated server, every worm),
  the same gate as the creation bug in #973.
- An `if(!o->obj) continue` guard skipped any object whose ref no longer resolves.
  But a removed worm is destroyed before the diff runs,
  so its ref never resolves, and every deletion was silently skipped.

The legacy `S2C_WORMSOUT` path is also disabled for >=0.59.10,
so nothing else covered it.

## The fix

In the deletion loop, send a deletion for any object the client still has,
without requiring the already-gone object to resolve.
Mirrors the creation fix from #977 (`GameState.cpp`).

## Also in this PR

- `getWormList` now works on a client too
  (it just reads `game.worms()`, which a client maintains);
  needed so a headless client can report its worm set.
- `onRemoveWorm` now logs the removal
  (add was already logged, remove was not);
  this is what made the bug obvious.

## Test

`tests/headless/test_network.py::test_worm_removed_when_client_leaves`:
two clients join a running game,
one leaves gracefully (a signal file triggers a `disconnect`),
and the other must drop its worm.
It is committed before the fix, so it demonstrates the bug,
and the fix turns it green.
Full suite: 7 passed.
