### PR TITLE
Drop broken third-party apt repos in CI

### DIFF
--- a/.github/workflows/headless-tests.yml
+++ b/.github/workflows/headless-tests.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Drop broken pre-installed third-party apt repos (microsoft/azure); we don't use them.
+          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure*
           sudo apt-get update
           sudo apt-get install -y \
             cmake build-essential \

--- a/.github/workflows/package-android.yml
+++ b/.github/workflows/package-android.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Drop broken pre-installed third-party apt repos (microsoft/azure); we don't use them.
+          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure*
           sudo apt-get update
           sudo apt-get install -y \
             libboost-dev \

--- a/.github/workflows/package-linux-bundle.yml
+++ b/.github/workflows/package-linux-bundle.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Drop broken pre-installed third-party apt repos (microsoft/azure); we don't use them.
+          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure*
           sudo apt-get update
           sudo apt-get install -y \
             cmake \

--- a/.github/workflows/package-linux-deb.yml
+++ b/.github/workflows/package-linux-deb.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Install Debian build scripts
         run: |
+          # Drop broken pre-installed third-party apt repos (microsoft/azure); we don't use them.
+          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure*
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \

--- a/.github/workflows/package-wasm.yml
+++ b/.github/workflows/package-wasm.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Drop broken pre-installed third-party apt repos (microsoft/azure); we don't use them.
+          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure*
           sudo apt-get update
           sudo apt-get install -y \
             cmake \


### PR DESCRIPTION
Makes the Linux CI robust against a recurring infrastructure failure.

## Problem

GitHub's Ubuntu runners ship pre-installed third-party apt repos
(packages.microsoft.com: `microsoft-prod` and `azure-cli`) that we do not use.
When their signatures break (a Microsoft-side issue that has now recurred twice),
`sudo apt-get update` fails hard,
and every Linux CI job fails with it,
even though our own dependencies all come from the standard Ubuntu repos.

## Fix

Remove those repo source files before `apt-get update`,
in each Linux workflow
(headless-tests, package-android, package-linux-bundle, package-wasm, package-linux-deb).
It drops nothing we depend on;
an unmatched glob is harmless under `rm -f`.

This PR's own Linux CI is the test:
it should go green even while the Microsoft repo is broken.
