### PR TITLE
Publish a release only when the tests pass

### DIFF
--- a/.github/workflows/headless-tests.yml
+++ b/.github/workflows/headless-tests.yml
@@ -2,9 +2,8 @@ name: Headless tests
 
 on:
   pull_request:
-  push:
-    branches:
-      - master
+  # Called by master-release.yaml so a release is only published when the tests pass.
+  workflow_call:
 
 jobs:
   linux:

--- a/.github/workflows/master-release.yaml
+++ b/.github/workflows/master-release.yaml
@@ -46,9 +46,14 @@ jobs:
     uses: ./.github/workflows/package-wasm.yml
     secrets: inherit
 
+  # Gate the release on the tests: a build with failing tests is not published;
+  # its artifacts still upload to this run for manual testing.
+  headless-tests:
+    uses: ./.github/workflows/headless-tests.yml
+
   release:
     name: Publish latest master release
-    needs: [android, linux-bundle, linux-deb, mac, windows, wasm]
+    needs: [android, linux-bundle, linux-deb, mac, windows, wasm, headless-tests]
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout


### PR DESCRIPTION
Stops a build with failing tests from being published as a release.

## Problem

The master-release pipeline builds every platform and publishes a GitHub
release, but it never ran the test suite,
so a build whose tests failed still ended up on the
[releases page](https://github.com/openlierox/openlierox/releases).

## Change

The `release` job now also `needs` the headless tests.
If the tests fail, the release is not published.
The per-platform build jobs still run and upload their artifacts to the run,
so a build can still be downloaded from the Actions run and tested manually;
it just does not become an official release.

To make this possible, `headless-tests.yml` gains a `workflow_call` trigger
(and drops its own push-on-master trigger, now that the release pipeline runs it),
matching how the `package-*` pipelines are already reused.

## Testing note

The release gating only runs on a push to `master`,
so it cannot be exercised by this PR directly.
This PR does still run the headless tests via the `pull_request` trigger,
which confirms the workflow itself is valid.
The gating takes effect on the next merge to `master`.
