### PR TITLE
Fix CWidgetList::getName returning NULL for std::string

### DIFF
--- a/src/client/DeprecatedGUI/CWidgetList.cpp
+++ b/src/client/DeprecatedGUI/CWidgetList.cpp
@@ -73,7 +73,7 @@ std::string CWidgetList::getName(int ID)
 {
 	// The list is empty
 	if (!tItems)
-		return NULL;
+		return "";
 
 	// Go through the items
 	widget_item_t *item = tItems;
@@ -84,7 +84,7 @@ std::string CWidgetList::getName(int ID)
 	}
 
 	// Not found
-	return NULL;
+	return "";
 }
 
 ////////////////


### PR DESCRIPTION
`CWidgetList::getName(int ID)` returns a `std::string` but returned `NULL` in two places — when the widget list is empty and when the ID is not found. Constructing a `std::string` from a null `char*` is undefined behavior (it can crash or assert depending on the standard library).

This returns an empty string instead, which is the intended "not found" result and clears the two `-Wnonnull` warnings the compiler emits here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)