### PR TITLE
Remove unused variables, function and dead code

### DIFF
--- a/src/client/CFont.cpp
+++ b/src/client/CFont.cpp
@@ -90,7 +90,6 @@ bool CFont::IsColumnFree(int x) {
 // Calculate character widths, number of characters and offsets
 void CFont::Parse() {
 	int x;
-	UnicodeChar CurChar = FIRST_CHARACTER;
 	int cur_w;
 
 	// Lock the surface
@@ -141,7 +140,6 @@ void CFont::Parse() {
 		FontWidth.push_back(cur_w);
 		CharacterOffset.push_back(char_start);
 		NumCharacters++;
-		CurChar++;
 	}
 
 

--- a/src/client/DeprecatedGUI/CListview.cpp
+++ b/src/client/DeprecatedGUI/CListview.cpp
@@ -1096,12 +1096,9 @@ int	CListview::MouseDown(mouse_t *tMouse, int nDown)
 
 		// Is any of the columns grabbed? Move it
 		if (iGrabbed > 0)  {
-			int x = iX+4;
-
 			// Get the column
 			for (i=0;i != iGrabbed && col;i++) {
 				prev = col;
-				x+=col->iWidth-2;
 				col = col->tNext;
 			}
 

--- a/src/client/DeprecatedGUI/Graphics.cpp
+++ b/src/client/DeprecatedGUI/Graphics.cpp
@@ -39,22 +39,6 @@ static SmartPointer<SDL_Surface> getAlternativeCommandButtonGfx() {
 	return gfx;
 }
 
-static SmartPointer<SDL_Surface> getAlternativeProgressGfx() {
-	int w = 360;
-	int h = 20;
-
-	SmartPointer<SDL_Surface> gfx = gfxCreateSurface(w, 2 * h);
-	if(!gfx.get()) return NULL;
-
-	DrawRectFill(gfx.get(), 0, 0, w - 1, h - 1, tLX->clProgress);
-	DrawRect(gfx.get(), 0, 0, w - 1, h - 2, tLX->clBoxDark);
-
-	DrawRect(gfx.get(), 0, h - 1, w - 1, 2 * h - 2, tLX->clBoxDark);
-
-	return gfx;
-}
-
-	
 static SmartPointer<SDL_Surface> getAlternativeClockGfx() {
 	SmartPointer<SDL_Surface> gfx = gfxCreateSurface(12, 12);
 	if(!gfx.get()) return NULL;

--- a/src/common/CMap.cpp
+++ b/src/common/CMap.cpp
@@ -1115,7 +1115,7 @@ int CMap::PlaceDirt(int size, CVec pos)
 {
 	SmartPointer<SDL_Surface> hole;
 	int dx,dy, sx,sy;
-	int x,y;
+	int y;
 	int w,h;
 	int ix,iy;
 	Uint32 pixel, pixel2;
@@ -1173,7 +1173,7 @@ int CMap::PlaceDirt(int size, CVec pos)
 			uchar* px = &material->line[dy][clip_x];
 			Uint8* p2 = (Uint8 *)bmpDrawImage.get()->pixels + dy * 2 * bmpDrawImage.get()->pitch + clip_x * 2 * bmpDrawImage.get()->format->BytesPerPixel;
 
-			for(x=hole_clip_x,dx=clip_x;dx<clip_w;x++,dx++) {
+			for(dx=clip_x;dx<clip_w;dx++) {
 
 				pixel = GetPixelFromAddr(p, screenbpp);
 				uchar flag = m_materialList[*px].toLxFlags();
@@ -1236,7 +1236,7 @@ int CMap::PlaceGreenDirt(CVec pos)
 	}
 	
  	int dx,dy, sx,sy;
-	int x,y;
+	int y;
 	int w,h;
 	Uint32 pixel;
     const Uint32 green = MakeColour(0,255,0);
@@ -1289,7 +1289,7 @@ int CMap::PlaceGreenDirt(CVec pos)
 			uchar* px = &material->line[dy][clip_x];
 			Uint8* p2 = (Uint8 *)bmpDrawImage.get()->pixels + dy * 2 * bmpDrawImage.get()->pitch + clip_x * 2 * bmpDrawImage.get()->format->BytesPerPixel;
 
-			for(x = green_clip_x, dx=clip_x; dx < clip_w; x++, dx++) {
+			for(dx=clip_x; dx < clip_w; dx++) {
 
 				pixel = GetPixelFromAddr(p,screenbpp);
 				uchar flag = m_materialList[*px].toLxFlags();

--- a/src/common/MapLoader_LieroX.cpp
+++ b/src/common/MapLoader_LieroX.cpp
@@ -134,7 +134,6 @@ class ML_LieroX : public MapLoad {
 		
 		
 		// Load the pixel flags and calculate dirt count
-		Uint64 n=0;
 		m->nTotalDirtCount = 0;
 		
 		m->lockFlags();
@@ -147,7 +146,6 @@ class ML_LieroX : public MapLoad {
 					CopyPixel2x2_SameFormat(m->bmpDrawImage.get(), m->bmpBackImageHiRes.get(), (int)x*2, (int)y*2);
 				if(lxflag & PX_DIRT)
 					m->nTotalDirtCount++;
-				n++;
 			}
 		}
 		m->unlockFlags();
@@ -351,8 +349,7 @@ class ML_LieroX : public MapLoad {
 		}
 		
 		// Update image according to the pixel flags
-		Uint64 n=0;
-		
+
 		curpixel = (Uint8 *)m->bmpDrawImage.get()->pixels;
 		PixelRow = curpixel;
 		Uint8 *backpixel = (Uint8 *)m->bmpBackImageHiRes.get()->pixels;
@@ -372,7 +369,6 @@ class ML_LieroX : public MapLoad {
 					memcpy(curpixel, backpixel, bppX2);
 					memcpy(curpixel+pitch, backpixel+pitch, bppX2);
 				}
-				n++;
 			}
 		}
 		m->unlockFlags();

--- a/src/common/MapLoader_Teeworlds.cpp
+++ b/src/common/MapLoader_Teeworlds.cpp
@@ -515,10 +515,8 @@ struct ML_Teeworlds : MapLoad {
 
 	void debugPrint(TWLayer& l) {
 		notes << "  layer type: " << l.type << endl;
-		bool isGameLayer = false;
 		if(l.type == LAYERTYPE_TILES && l.tileLayer.game) {
 			notes << "  - is game layer" << endl;
-			isGameLayer = true;
 		}
 		if(l.type == LAYERTYPE_TILES) {
 			notes << "  - tiles layer, w: " << l.tileLayer.width << ", h: " << l.tileLayer.height << ", image_id: " << l.tileLayer.image_id << endl;

--- a/src/common/SystemFunctions.cpp
+++ b/src/common/SystemFunctions.cpp
@@ -182,13 +182,12 @@ size_t GetFreeSysMemory() {
 	vm_statistics_data_t page_info;
 	vm_size_t pagesize;
 	mach_msg_type_number_t count;
-	kern_return_t kret;
-	
+
 	pagesize = 0;
-	kret = host_page_size (mach_host_self(), &pagesize);
+	host_page_size (mach_host_self(), &pagesize);
 	count = HOST_VM_INFO_COUNT;
-	
-	kret = host_statistics (mach_host_self(), HOST_VM_INFO,(host_info_t)&page_info, &count);
+
+	host_statistics (mach_host_self(), HOST_VM_INFO,(host_info_t)&page_info, &count);
 	return page_info.free_count * pagesize;
 #elif defined(__WIN64__)
 	MEMORYSTATUSEX memStatex;

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -823,7 +823,6 @@ void Game::frameInner()
 	}
 
 	if(state >= Game::S_Preparing && gameWasPrepared && !cClient->bWaitingForMod) {
-		bool update = false;
 		bool updateLocal = false;
 
 		// Prepare worms if needed
@@ -870,8 +869,6 @@ void Game::frameInner()
 					cServer->getClients()[i].getNetEngine()->SendWormProperties(w->get()); // if we have changed them in prepare or so
 				}
 			}
-
-			update = true;
 		}
 
 		if(updateLocal)

--- a/src/server/CServer_Parse.cpp
+++ b/src/server/CServer_Parse.cpp
@@ -1124,7 +1124,6 @@ void GameServer::ParseGetChallenge(const SmartPointer<NetworkSocket>& tSocket, C
 void GameServer::ParseConnect(const SmartPointer<NetworkSocket>& net_socket, CBytestream *bs) {
 	NetworkAddr		adrFrom;
 	int				p;
-	int				player = -1;
 	CServerConnection	*newcl = NULL;
 
 
@@ -1700,25 +1699,6 @@ void GameServer::ParseConnect(const SmartPointer<NetworkSocket>& net_socket, CBy
 		m_flagInfo->sendCurrentState(newcl);
 				
 		newcl->getNetEngine()->SendWormProperties(true); // send new client other non-default worm properties
-	}
-	
-	
-	
-	// Share reliable channel bandwidth equally between all clients - 
-	// the amount of reliable data that should be transmitted is more-less the same for each client
-	// But we finetuning the delay between reliable packets
-	int clientsAmount = 0;
-	for(int c = 0; c < MAX_CLIENTS; c++) 
-	{
-		if(cClients[c].getStatus() != NET_CONNECTED) 
-			continue;
-		if( !cClients[c].isLocalClient() )
-			clientsAmount ++;
-	}
-	for(int c = 0; c < MAX_CLIENTS; c++) 
-	{
-		if(cClients[c].getStatus() != NET_CONNECTED) 
-			continue;
 	}
 }
 


### PR DESCRIPTION
Clears the `-Wunused-but-set-variable`, `-Wunused-variable` and `-Wunused-function` warnings by removing dead code that has no runtime effect:

- **CFont::Parse** — drop the `CurChar` counter (never read; `NumCharacters` is the real count).
- **CListview / CMap::PlaceDirt / CMap::PlaceGreenDirt** — drop the leftover loop variable `x` that was incremented but never used (the pixel pointers are advanced by pointer arithmetic instead).
- **MapLoader_LieroX** — drop the unused dirt-pixel counter `n` (two spots).
- **MapLoader_Teeworlds::debugPrint** — drop the write-only `isGameLayer` flag.
- **SystemFunctions::GetFreeSysMemory** (Apple path) — drop the ignored `kret` return values.
- **Game.cpp** — drop the write-only `update` flag; `updateLocal` is the one actually used.
- **CServer_Parse::ParseConnect** — drop the unused `player` variable and the vestigial "share reliable channel bandwidth" block, which computed an unused count and then ran a second loop with an empty body.
- **Graphics.cpp** — drop the never-referenced `getAlternativeProgressGfx`.

Two related warnings were left untouched on purpose:
- `p` in `bindings-gui.cpp` (two `LMETHODC` methods) — `p` is declared by the `LMETHODC` macro itself (`if(type_* p = ...)`), so it can't be removed without changing the macro for all callers.
- `HealthLabelY` in `CClient_Draw.cpp` — unused only because the "Health:" text-label drawing is commented out; removing it would cascade into the surrounding HUD-positioning code, so it's best handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)