### PR TITLE
Remove unused private fields

### DIFF
--- a/include/DeprecatedGUI/CInputBox.h
+++ b/include/DeprecatedGUI/CInputBox.h
@@ -120,9 +120,6 @@ public:
 
 class CInputboxInput: public CInputbox	// InputBoxDialog.xml should contain exactly one such control at the end
 {
-	private:
-	int		iSkipFirstFrame;
-
 	public:
 	CInputboxInput();
 	~CInputboxInput();

--- a/src/gusanos/gui/detail/button.h
+++ b/src/gusanos/gui/detail/button.h
@@ -12,11 +12,8 @@ public:
 	static LuaReference metaTable;
 	
 	Button(Wnd* parent_, std::map<std::string, std::string> const& properties)
-	: Wnd(parent_, properties, "button"), m_state(false)
+	: Wnd(parent_, properties, "button")
 	{}
-		
-private:
-	bool m_state;
 };
 
 }


### PR DESCRIPTION
Clears the `-Wunused-private-field` warnings by removing two dead members:

- `OmfgGUI::Button::m_state` — initialized in the constructor but never read anywhere.
- `CInputboxInput::iSkipFirstFrame` — declared but never referenced (not even initialized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)