### PR TITLE
Replace deprecated std::auto_ptr with std::unique_ptr

### DIFF
--- a/src/game/Level.cpp
+++ b/src/game/Level.cpp
@@ -33,7 +33,7 @@ LevelInfo infoForLevel(const std::string& f, bool absolute) {
 SmartPointer<SDL_Surface> minimapForLevel(const std::string& f, bool absolute) {
 	LevelInfo info = infoForLevel(f, absolute);
 	
-	std::auto_ptr<MapLoad> loader( MapLoad::open(absolute ? f : ("levels/" + f), absolute, false) );
+	std::unique_ptr<MapLoad> loader( MapLoad::open(absolute ? f : ("levels/" + f), absolute, false) );
 	if(!loader.get()) {
 		SmartPointer<SDL_Surface> minimap = gfxCreateSurface(128,96);
 		DrawCross(minimap.get(), 0, 0, 128, 96, Color(0,0,255));

--- a/src/gusanos/netstream.cpp
+++ b/src/gusanos/netstream.cpp
@@ -183,7 +183,7 @@ struct NetNodeIntern {
 	Net_NodeID nodeId;
 	eNet_NodeRole role;
 	bool eventForInit, eventForRemove;
-	std::auto_ptr<BitStream> announceData;
+	std::unique_ptr<BitStream> announceData;
 	Net_ConnID ownerConn;
 	
 	typedef std::list< std::pair<Net_Replicator*,bool> > ReplicationSetup;
@@ -935,7 +935,7 @@ Net_Node::~Net_Node() {
 
 eNet_NodeRole Net_Node::getRole() { return intern->role; }
 void Net_Node::setOwner(Net_ConnID cid) { intern->ownerConn = cid; }
-void Net_Node::setAnnounceData(BitStream* s) { intern->announceData = std::auto_ptr<BitStream>(s); }
+void Net_Node::setAnnounceData(BitStream* s) { intern->announceData = std::unique_ptr<BitStream>(s); }
 Net_NodeID Net_Node::getNetworkID() { return intern->nodeId; }
 
 static void tellAllClientsAboutNode(Net_Node* node) {

--- a/src/gusanos/network.cpp
+++ b/src/gusanos/network.cpp
@@ -416,7 +416,7 @@ void Network::sendEncodedLuaEvents(Net_ConnID cid) {
 	}
 	
 	// on the client side, this is handled in Client::Net_cbDataReceived
-	std::auto_ptr<BitStream> data(new BitStream);
+	std::unique_ptr<BitStream> data(new BitStream);
 	Encoding::encode(*data, Network::ClientEvents::LuaEvents, Network::ClientEvents::Max);
 	network.encodeLuaEvents(data.get());
 	m_control->Net_sendData(cid, data.release(), eNet_ReliableOrdered);		

--- a/src/gusanos/omfgscript/omfg_script.cpp
+++ b/src/gusanos/omfgscript/omfg_script.cpp
@@ -10,7 +10,7 @@
 #include "util/text.h"
 #include "gusanos/allegro.h"
 #include <boost/crc.hpp>
-using std::auto_ptr;
+using std::unique_ptr;
 using std::cout;
 using std::endl;
 
@@ -65,7 +65,7 @@ struct Parameters
 		}
 	}
 	
-	void addParam(std::string const& name, auto_ptr<OmfgScript::TokenBase> v, Location loc_)
+	void addParam(std::string const& name, unique_ptr<OmfgScript::TokenBase> v, Location loc_)
 	{
 		size_t i = 0;
 		for(; i < paramDef->params.size(); ++i)
@@ -108,7 +108,7 @@ struct Parameters
 		cur = -1;
 	}
 	
-	void addParam(auto_ptr<OmfgScript::TokenBase> v, Location loc_)
+	void addParam(unique_ptr<OmfgScript::TokenBase> v, Location loc_)
 	{
 		if(cur < 0 && !(flags & PosParamAfterNamed))
 		{
@@ -228,7 +228,7 @@ struct List : public TokenBase
 	{
 	}
 	
-	void add(std::auto_ptr<TokenBase> el)
+	void add(std::unique_ptr<TokenBase> el)
 	{
 		elements.push_back(el.release());
 	}
@@ -310,7 +310,7 @@ struct Func : public Function
 	{
 	}
 	
-	void add(std::auto_ptr<TokenBase> el)
+	void add(std::unique_ptr<TokenBase> el)
 	{
 		params.push_back(el.release());
 	}
@@ -673,13 +673,13 @@ struct ParserImpl : public TGrammar<ParserImpl>
 		return 0;
 	}
 	
-	BaseAction* createAction(ActionDef* action, std::auto_ptr<Parameters> params)
+	BaseAction* createAction(ActionDef* action, std::unique_ptr<Parameters> params)
 	{
 		params->calcCRC(crc);
 		return action->create(params->params);
 	}
 	
-	void addEvent(GameEventDef* event, std::auto_ptr<Parameters> params, std::vector< boost::shared_ptr<BaseAction> >& actions)
+	void addEvent(GameEventDef* event, std::unique_ptr<Parameters> params, std::vector< boost::shared_ptr<BaseAction> >& actions)
 	{
 		params->calcCRC(crc);
 		events.push_back(new GameEvent(event, params.release(), actions));

--- a/src/gusanos/omfgscript/omfg_script.h
+++ b/src/gusanos/omfgscript/omfg_script.h
@@ -41,7 +41,7 @@ struct Function;
 
 struct TokenBase
 {
-	typedef std::auto_ptr<TokenBase> ptr;
+	typedef std::unique_ptr<TokenBase> ptr;
 	
 	TokenBase(Location loc_)
 	: loc(loc_) 

--- a/src/gusanos/omfgscript/omfg_script_parser.h
+++ b/src/gusanos/omfgscript/omfg_script_parser.h
@@ -5,7 +5,7 @@
 #include <cstring>
 #include <iostream>
 #include "gusanos/base_action.h"
-using std::auto_ptr;
+using std::unique_ptr;
 
 #include <boost/lexical_cast.hpp>
 using boost::lexical_cast;
@@ -49,7 +49,7 @@ template<class T>
 struct TGrammar {
 #define self (static_cast<T *>(this))
 ~TGrammar() { free(buffer); }
-struct Token : public  TokenBase  { typedef std::auto_ptr<Token> ptr;
+struct Token : public  TokenBase  { typedef std::unique_ptr<Token> ptr;
 
 	Token(T& g_) : TokenBase(g_.getLoc()), g(g_) {}
 	
@@ -59,7 +59,7 @@ virtual ~Token() {}
 };
 
 struct STRING : public Token {
-typedef std::auto_ptr<STRING> ptr;
+typedef std::unique_ptr<STRING> ptr;
 #define CONSTRUCT(b_, e_) STRING(T& g, char const* b_, char const* e_)
 
 	CONSTRUCT(b, e) : Token(g), str(b, e) { }
@@ -81,7 +81,7 @@ typedef std::auto_ptr<STRING> ptr;
 #undef CONSTRUCT
 };
 struct INTEGER : public Token {
-typedef std::auto_ptr<INTEGER> ptr;
+typedef std::unique_ptr<INTEGER> ptr;
 #define CONSTRUCT(b_, e_) INTEGER(T& g, char const* b_, char const* e_)
 
 	CONSTRUCT(b, e) : Token(g) { v = lexical_cast<int>(std::string(b, e)); }
@@ -111,7 +111,7 @@ typedef std::auto_ptr<INTEGER> ptr;
 #undef CONSTRUCT
 };
 struct NUMBER : public Token {
-typedef std::auto_ptr<NUMBER> ptr;
+typedef std::unique_ptr<NUMBER> ptr;
 #define CONSTRUCT(b_, e_) NUMBER(T& g, char const* b_, char const* e_)
 
 	CONSTRUCT(b, e) : Token(g) { v = lexical_cast<double>(std::string(b, e)); }
@@ -935,7 +935,7 @@ return true; }
 bool full() { return cur == 0 && !error; }
 void rule_action(GameEventDef* event, std::vector< boost::shared_ptr<BaseAction> >& actions) {
 if(!matchToken(16)) return;
-std::auto_ptr<STRING> name(static_cast<STRING*>(curData.release()));
+std::unique_ptr<STRING> name(static_cast<STRING*>(curData.release()));
 next();
 
 		ActionDef* action(self->getAction(name->str));
@@ -956,7 +956,7 @@ next();
 		}
 		else
 		{
-			auto_ptr<Parameters> param(new Parameters(action->paramDef, self->getLoc()));
+			unique_ptr<Parameters> param(new Parameters(action->paramDef, self->getLoc()));
 	
 if(!matchToken(5)) return;
 next();
@@ -970,7 +970,7 @@ next();
 			if(param->flags & Parameters::Error)
 				semanticError("Malformed parameters", param->loc);
 			else
-				actions.push_back( boost::shared_ptr<BaseAction>( self->createAction(action, param) ) );
+				actions.push_back( boost::shared_ptr<BaseAction>( self->createAction(action, std::move(param)) ) );
 		}
 	
 }
@@ -978,7 +978,7 @@ void rule_event() {
 if(!matchToken(3)) return;
 next();
 if(!matchToken(16)) return;
-std::auto_ptr<STRING> name(static_cast<STRING*>(curData.release()));
+std::unique_ptr<STRING> name(static_cast<STRING*>(curData.release()));
 next();
 
 		GameEventDef* event(self->getEventDef(name->str));
@@ -990,7 +990,7 @@ while(cur != 3 && cur != 0) next();
 		}
 		else
 		{
-			auto_ptr<Parameters> param(new Parameters(event->paramDef, self->getLoc()));
+			unique_ptr<Parameters> param(new Parameters(event->paramDef, self->getLoc()));
 	
 if(!matchToken(5)) return;
 next();
@@ -1008,7 +1008,7 @@ rule_action(event, actions);
 			if(param->flags & Parameters::Error)
 				semanticError("Malformed parameters", param->loc);
 			else
-				self->addEvent(event, param, actions);
+				self->addEvent(event, std::move(param), actions);
 		}
 	
 }
@@ -1046,24 +1046,24 @@ next();
  a.reset(new INTEGER(*self, 0)); 
 }
 else if(cur == 16) {
-std::auto_ptr<STRING> x(static_cast<STRING*>(curData.release()));
+std::unique_ptr<STRING> x(static_cast<STRING*>(curData.release()));
 next();
 if(cur == 5) {
- auto_ptr<Func> l(new Func(self->getLoc(), x->str)); TokenBase::ptr el; 
+ unique_ptr<Func> l(new Func(self->getLoc(), x->str)); TokenBase::ptr el; 
 next();
 rule_leaf(el);
- l->add(el); 
+ l->add(std::move(el));
 while(cur == 11) {
 next();
 rule_leaf(el);
- l->add(el); 
+ l->add(std::move(el));
 }
 if(!matchToken(6)) return;
 next();
- a = l; 
+ a = std::move(l);
 }
 else if(true) {
- a = x; 
+ a = std::move(x);
 }
 else { syntaxError(); return; }
 }
@@ -1076,18 +1076,18 @@ a.reset(curData.release());
 next();
 }
 else if(cur == 7) {
- auto_ptr<List> l(new List(self->getLoc())); TokenBase::ptr el; 
+ unique_ptr<List> l(new List(self->getLoc())); TokenBase::ptr el; 
 next();
 rule_expr(el);
- l->add(el); 
+ l->add(std::move(el));
 while(cur == 11) {
 next();
 rule_expr(el);
- l->add(el); 
+ l->add(std::move(el));
 }
 if(!matchToken(8)) return;
 next();
- a = l; 
+ a = std::move(l);
 }
 else if(cur == 5) {
 next();
@@ -1109,21 +1109,21 @@ void rule_parameter(Parameters& params) {
  TokenBase::ptr v; 
 Location paramLoc(self->getLoc());
 if(cur == 16) {
-std::auto_ptr<STRING> name(static_cast<STRING*>(curData.release()));
+std::unique_ptr<STRING> name(static_cast<STRING*>(curData.release()));
 next();
 if(cur == 4) {
 next();
 rule_expr(v);
- params.addParam(name->str, v, paramLoc); 
+ params.addParam(name->str, std::move(v), paramLoc);
 }
 else if(true) {
- params.addParam(TokenBase::ptr(name), paramLoc); 
+ params.addParam(TokenBase::ptr(std::move(name)), paramLoc);
 }
 else { syntaxError(); return; }
 }
 else if(set_1[cur]) {
 rule_expr(v);
- params.addParam(v, paramLoc); 
+ params.addParam(std::move(v), paramLoc);
 }
 else { syntaxError(); return; }
 }
@@ -1138,7 +1138,7 @@ void rule_prop(std::string const& prefix = "") {
  TokenBase::ptr v; 
 Location propLoc(self->getLoc());
 if(!matchToken(16)) return;
-std::auto_ptr<STRING> name(static_cast<STRING*>(curData.release()));
+std::unique_ptr<STRING> name(static_cast<STRING*>(curData.release()));
 next();
 if(cur == 4) {
 next();
@@ -1199,7 +1199,7 @@ set_17[14] = true;
 set_17[15] = true;
 }
 int cur;
-std::auto_ptr<Token> curData;
+std::unique_ptr<Token> curData;
 char* curp;
 char* limit;
 char* marker;

--- a/src/gusanos/omfgscript/omfg_script_parser.pg
+++ b/src/gusanos/omfgscript/omfg_script_parser.pg
@@ -150,23 +150,23 @@ leaf<TokenBase::ptr& a> = (
 	| TRUE $( a.reset(new INTEGER(*self, 1)); )
 	| FALSE $( a.reset(new INTEGER(*self, 0)); )
 	| STRING<x> (
-		$( auto_ptr<Func> l(new Func(self->getLoc(), x->str)); TokenBase::ptr el; )
+		$( unique_ptr<Func> l(new Func(self->getLoc(), x->str)); TokenBase::ptr el; )
 		LPARAN (
-			leaf<el> $( l->add(el); )
-			( COMMA leaf<el> $( l->add(el); ) )*
+			leaf<el> $( l->add(std::move(el)); )
+			( COMMA leaf<el> $( l->add(std::move(el)); ) )*
 		) RPARAN
-		$( a = l; )
+		$( a = std::move(l); )
 		
-		| $( a = x; )
+		| $( a = std::move(x); )
 	)
 	| INTEGER<=a>
 	| NUMBER<=a>
-	| $( auto_ptr<List> l(new List(self->getLoc())); TokenBase::ptr el; )
+	| $( unique_ptr<List> l(new List(self->getLoc())); TokenBase::ptr el; )
 		LBRACKET (
-			expr<el> $( l->add(el); )
-			( COMMA expr<el> $( l->add(el); ) )*
+			expr<el> $( l->add(std::move(el)); )
+			( COMMA expr<el> $( l->add(std::move(el)); ) )*
 		) RBRACKET
-	  $( a = l; )
+	  $( a = std::move(l); )
 	| LPARAN expr<a> RPARAN
 	) ;
 
@@ -225,10 +225,10 @@ parameter<Parameters& params> = $( TokenBase::ptr v; )
 	( 
 	| STRING<name>
 		(
-		| EQUAL expr<v> $( params.addParam(name->str, v, paramLoc); )
-		| $( params.addParam(TokenBase::ptr(name), paramLoc); )
+		| EQUAL expr<v> $( params.addParam(name->str, std::move(v), paramLoc); )
+		| $( params.addParam(TokenBase::ptr(std::move(name)), paramLoc); )
 		)
-	| expr<v> $( params.addParam(v, paramLoc); )
+	| expr<v> $( params.addParam(std::move(v), paramLoc); )
 	) ;
 	
 parameters<Parameters& params> = parameter<params> (COMMA parameter<params>)* ;
@@ -252,7 +252,7 @@ action<EventDef* event, std::vector<BaseAction*>& actions> =
 		}
 		else
 		{
-			auto_ptr<Parameters> param(new Parameters(action->paramDef, self->getLoc()));
+			unique_ptr<Parameters> param(new Parameters(action->paramDef, self->getLoc()));
 	)
 	
 	LPARAN [parameters<*param>] RPARAN
@@ -261,7 +261,7 @@ action<EventDef* event, std::vector<BaseAction*>& actions> =
 			if(param->flags & Parameters::Error)
 				semanticError("Malformed parameters", param->loc);
 			else
-				actions.push_back(self->createAction(action, param));
+				actions.push_back(self->createAction(action, std::move(param)));
 		}
 	)
 	;
@@ -277,7 +277,7 @@ event<> = ON STRING<name>
 		}
 		else
 		{
-			auto_ptr<Parameters> param(new Parameters(event->paramDef, self->getLoc()));
+			unique_ptr<Parameters> param(new Parameters(event->paramDef, self->getLoc()));
 	)
 	
 	LPARAN [parameters<*param>] RPARAN
@@ -288,7 +288,7 @@ event<> = ON STRING<name>
 			if(param->flags & Parameters::Error)
 				semanticError("Malformed parameters", param->loc);
 			else
-				self->addEvent(event, param, actions);
+				self->addEvent(event, std::move(param), actions);
 		}
 	) ;
 


### PR DESCRIPTION
`std::auto_ptr` is deprecated in C++11 and removed in C++17. It produces `-Wdeprecated-declarations` warnings throughout the gusanos `omfgscript` parser (and a few other spots). This replaces it with `std::unique_ptr`.

Since `unique_ptr` doesn't implicitly move on copy the way `auto_ptr` did, every place that relied on that ownership transfer now uses an explicit `std::move`:
- `createAction(action, ...)` / `addEvent(event, ...)` parameter passing,
- the `Func`/`List` token building in `rule_leaf` (`l->add(...)`, `a = l`, `a = x`),
- the `addParam(...)` calls in `rule_parameter`.

The owning method bodies (`add`, `addParam`, `createAction`, `addEvent`) already used `.release()`, so they're unchanged — the transformation is semantically identical to the old `auto_ptr` behavior, and the compiler enforces that no accidental copies remain.

`omfg_script_parser.h` is generated from `omfg_script_parser.pg` by re2c (which is **not** run during the build — the committed header is used directly). Both files are updated so they stay in sync.

### Verification
- Full build is clean; all `auto_ptr` deprecation warnings are gone.
- The full headless test suite passes (7/7).
- A dedicated game start was run manually: `GusGame::loadModWithoutMap: Gusanos` parses the bundled Gusanos mod's `.obj`/`.exp` scripts (which are omfgscript) with no parse errors and the game reaches the `Playing` state — exercising every `std::move` transfer path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)