### PR TITLE
Add committed CLAUDE.md for Claude Code sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,6 @@ distrib
 build/android/deps
 build/android/output/
 *.claude
-CLAUDE.md
 
 __pycache__
 *.pyc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# Guidance for Claude Code
+
+Claude Code auto-loads this file at the start of every session.
+It does not add new rules;
+it points at the ones every contributor already follows,
+so they are in context before any code, commit or pull request.
+
+Read and follow @AGENTS.md and @CONTRIBUTING.md.
+
+Rules that are easy to miss when working as an AI agent:
+
+- No `Co-authored-by:` lines, and no LLM or AI attribution of any kind,
+  in commit messages or in pull request descriptions.
+- Commit subject: imperative mood, <= 50 chars, capitalized, no trailing period.
+- Wrap commit messages, comments and prose at clause boundaries,
+  not at a fixed column.
+- Code must build and pass the headless tests (`./tests/headless/run.sh`) before you push,
+  and a change is verified by running it, not only by reading the diff.
+- Don't force-push a published commit;
+  a new change is a new commit.


### PR DESCRIPTION
Claude Code auto-loads `CLAUDE.md` at the start of every session, so it is the reliable place to put the contributor rules in front of an AI agent before it writes code, commits, or opens a pull request.

`CLAUDE.md` was gitignored (alongside `*.claude`), so those rules never entered a session's context. An agent that does not happen to open `AGENTS.md` misses them -- which is exactly how a recent set of PRs ended up with `Co-authored-by:` trailers that `CONTRIBUTING.md` forbids.

This:
- removes the `CLAUDE.md` line from `.gitignore` (the `*.claude` ignore stays), and
- adds a short `CLAUDE.md` that imports `@AGENTS.md` and `@CONTRIBUTING.md` and highlights the rules easiest to miss (no AI attribution, subject <= 50 chars, wrap at clause boundaries, build/test before push).

It adds no new rules; it just makes the existing ones load automatically.