### PR TITLE
Document shell-command rules for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,27 @@
 # AI agents
 
 Follow [CONTRIBUTING.md](CONTRIBUTING.md), the same as any contributor.
+
+## Running shell commands
+
+Sandboxed agent tooling (such as Claude Code) auto-approves a command
+only when it can statically prove the command is safe;
+anything it cannot parse falls back to a manual confirmation prompt.
+To keep commands auto-approved, write them plain and literal:
+
+- No variable or command substitution (`$VAR`, `` $(...) ``);
+  hardcode the value instead.
+- No `for`/`while` loops;
+  run separate commands, or issue parallel tool calls.
+- Don't combine `cd` with a write in one compound command
+  (`cd dir && git commit ...`);
+  the working directory already persists between calls,
+  so use an absolute path or `git -C <dir> ...`.
+- Don't use `find -exec`;
+  list with `find`, then act in a separate step.
+- Don't pass a shell script as a quoted string (`sh -c "..."`).
+- For multi-line text (a commit message, a file body),
+  write it to a file and pass the file
+  (`git commit -F msg.txt`, `gh pr create --body-file body.md`),
+  instead of an inline heredoc or a multi-line quoted argument;
+  a newline followed by `#` inside a quoted argument also trips the checker.


### PR DESCRIPTION
Sandboxed agent tooling (such as Claude Code) auto-approves a shell command only when it can statically prove the command is safe; anything it cannot parse falls back to a manual confirmation prompt. Several common command shapes break that proof and cause a prompt on every run.

This adds a "Running shell commands" section to `AGENTS.md` listing those shapes and the literal alternative for each:

- no `$VAR` / `$(...)` substitution,
- no `for`/`while` loops (separate commands or parallel calls),
- no `cd` combined with a write in one compound command (use `git -C <dir>` and the persistent working directory),
- no `find -exec`,
- no shell script passed as a quoted string (`sh -c "..."`),
- multi-line text (commit messages, file bodies) passed via a file (`git commit -F`, `gh pr create --body-file`) rather than an inline heredoc.

It adds no project rules; it just documents how to drive the sandbox without constant confirmation prompts. `CLAUDE.md` already imports `AGENTS.md`, so the section loads automatically in Claude Code sessions.
