### PR TITLE
Fix crash on exit (#961): race-free ThreadPool shutdown

### DIFF
--- a/include/AuxLib.h
+++ b/include/AuxLib.h
@@ -24,6 +24,7 @@
 
 
 #include "SmartPointer.h"
+#include "ThreadPool.h" // for Action
 
 
 // Routines

--- a/include/Debug.h
+++ b/include/Debug.h
@@ -15,7 +15,7 @@
 #include "CodeAttributes.h"
 #include "util/StringConv.h"
 #include "util/IPrintOutFct.h"
-#include "ThreadPool.h" // ThreadId
+#include "ThreadId.h" // ThreadId
 
 // { these function should be safe to be called from everywhere, also from signalhandlers
 bool AmIBeingDebugged();

--- a/include/FileDownload.h
+++ b/include/FileDownload.h
@@ -147,7 +147,7 @@ public:
 private:
 	std::list<CHttpDownloader *> tDownloads;
 	std::vector<std::string>	 tDownloadServers;
-	ThreadPoolItem					*tThread;
+	SmartPointer<ThreadPoolItem>	tThread;
 	SDL_mutex					*tMutex;
 	size_t						 iActiveDownloads;
 

--- a/include/SmartPointer.h
+++ b/include/SmartPointer.h
@@ -17,7 +17,6 @@
 #endif
 
 #include "Functors.h"
-#include "ThreadPool.h"
 
 template < typename _Type, typename _SpecificInitFunctor >
 class SmartPointer;

--- a/include/TaskManager.h
+++ b/include/TaskManager.h
@@ -82,7 +82,7 @@ private:
 	bool quitSignal;
 	std::set<Task*> runningTasks;
 	std::list<Action*> queuedTasks;
-	ThreadPoolItem* queueThread;
+	SmartPointer<ThreadPoolItem> queueThread;
 
 	ScopedTask haveTaskOfType__unsafe(const std::type_info& taskType);
 public:

--- a/include/ThreadId.h
+++ b/include/ThreadId.h
@@ -1,0 +1,18 @@
+/*
+ *  ThreadId.h
+ *  OpenLieroX
+ *
+ *  code under LGPL
+ *
+ */
+
+#ifndef __OLX__THREADID_H__
+#define __OLX__THREADID_H__
+
+#include <stdint.h>
+
+// Under Win, it's HANDLE (which is void*).
+// Otherwise, it's pthread_t, which is also a ptr-type.
+typedef uintptr_t ThreadId;
+
+#endif

--- a/include/ThreadPool.h
+++ b/include/ThreadPool.h
@@ -69,9 +69,8 @@ public:
 	~ThreadPool();
 
 	SmartPointer<ThreadPoolItem> start(ThreadFunc fct, void* param = NULL, const std::string& name = "unknown worker");
-	// headless is only informational now; the returned handle can always be waited on, or discarded.
-	SmartPointer<ThreadPoolItem> start(Action* act, const std::string& name = "unknown worker", bool headless = false); // ThreadPool will own and free the Action
-	SmartPointer<ThreadPoolItem> start(boost::function<Result()> fct, const std::string& name = "unknown worker", bool headless = false);
+	SmartPointer<ThreadPoolItem> start(Action* act, const std::string& name = "unknown worker"); // ThreadPool will own and free the Action
+	SmartPointer<ThreadPoolItem> start(boost::function<Result()> fct, const std::string& name = "unknown worker");
 	bool wait(const SmartPointer<ThreadPoolItem>& item, int* status = NULL);
 	bool waitAll();
 	void dumpState(CmdLineIntf& cli) const;

--- a/include/ThreadPool.h
+++ b/include/ThreadPool.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <boost/function.hpp>
 #include "util/Result.h"
+#include "SmartPointer.h"
 
 // Under Win, it's HANDLE (which is void*).
 // Otherwise, it's pthread_t, which is also a ptr-type.
@@ -33,42 +34,46 @@ struct Action {
 	virtual Result handle() = 0;
 };
 
+// The handle returned by ThreadPool::start(). It represents one task
+// (one start() call), not the reused worker thread that runs it.
+// It is reference counted (held via SmartPointer),
+// so it stays alive as long as the caller or the running worker holds it,
+// and it can never be freed or reused under the caller.
+// wait() waits on this, so it is always safe, even at shutdown.
 struct ThreadPoolItem {
-	ThreadPool* pool;
-	SDL_Thread* thread;
-	ThreadId nativeThreadId;
 	std::string name;
-	bool working;
 	bool finished;
-	bool headless;
-	SDL_cond* finishedSignal;
-	SDL_cond* readyForNewWork;
 	int ret;
+	ThreadPoolItem() : finished(false), ret(0) {}
 };
+
+// The reused worker thread, internal to the pool. Defined in ThreadPool.cpp.
+struct ThreadWorker;
 
 class ThreadPool {
 private:
 	SDL_mutex* mutex;
 	SDL_cond* awakeThread;
 	SDL_cond* threadStartedWork;
-	SDL_cond* threadStatusChanged;
-	Action* nextAction; bool nextIsHeadless; std::string nextName;
-	ThreadPoolItem* nextData;
+	SDL_cond* threadStatusChanged; // a worker became idle (for waitAll)
+	SDL_cond* taskFinished;        // a task finished (for wait)
+	Action* nextAction; std::string nextName;
+	SmartPointer<ThreadPoolItem> nextTask;
 	bool quitting;
-	std::set<ThreadPoolItem*> availableThreads;
-	std::set<ThreadPoolItem*> usedThreads;
+	std::set<ThreadWorker*> availableThreads;
+	std::set<ThreadWorker*> usedThreads;
 	void prepareNewThread();
 	static int threadWrapper(void* param);
 	SDL_mutex* startMutex;
 public:
 	ThreadPool(unsigned int size = 5);
 	~ThreadPool();
-	
-	ThreadPoolItem* start(ThreadFunc fct, void* param = NULL, const std::string& name = "unknown worker");
-	// WARNING: if you set headless, you cannot use wait() and you should not save the returned ThreadPoolItem*
-	ThreadPoolItem* start(Action* act, const std::string& name = "unknown worker", bool headless = false); // ThreadPool will own and free the Action
-	ThreadPoolItem* start(boost::function<Result()> fct, const std::string& name = "unknown worker", bool headless = false);
-	bool wait(ThreadPoolItem* thread, int* status = NULL);
+
+	SmartPointer<ThreadPoolItem> start(ThreadFunc fct, void* param = NULL, const std::string& name = "unknown worker");
+	// headless is only informational now; the returned handle can always be waited on, or discarded.
+	SmartPointer<ThreadPoolItem> start(Action* act, const std::string& name = "unknown worker", bool headless = false); // ThreadPool will own and free the Action
+	SmartPointer<ThreadPoolItem> start(boost::function<Result()> fct, const std::string& name = "unknown worker", bool headless = false);
+	bool wait(const SmartPointer<ThreadPoolItem>& item, int* status = NULL);
 	bool waitAll();
 	void dumpState(CmdLineIntf& cli) const;
 	void getAllWorkingThreads(std::map<ThreadId, std::string>& threads);
@@ -98,8 +103,8 @@ struct _ThreadFuncWrapper {
 			static Result wrapper(void* obj) {
 				return (((_T*)obj) ->* _func)();
 			}
-			
-			static ThreadPoolItem* startThread(_T* const obj, const std::string& name) {
+
+			static SmartPointer<ThreadPoolItem> startThread(_T* const obj, const std::string& name) {
 				return threadPool->start((ThreadFunc)&wrapper, (void*)obj, name);
 			}
 		};
@@ -110,4 +115,3 @@ _ThreadFuncWrapper<T>::Wrapper<&memberfunc>::startThread(this, name)
 
 
 #endif
-

--- a/include/ThreadPool.h
+++ b/include/ThreadPool.h
@@ -16,11 +16,8 @@
 #include <string>
 #include <boost/function.hpp>
 #include "util/Result.h"
+#include "ThreadId.h"
 #include "SmartPointer.h"
-
-// Under Win, it's HANDLE (which is void*).
-// Otherwise, it's pthread_t, which is also a ptr-type.
-typedef uintptr_t ThreadId;
 
 struct SDL_mutex;
 struct SDL_cond;

--- a/include/ThreadPool.h
+++ b/include/ThreadPool.h
@@ -31,8 +31,9 @@ struct Action {
 	virtual Result handle() = 0;
 };
 
-// The handle returned by ThreadPool::start(). It represents one task
-// (one start() call), not the reused worker thread that runs it.
+// The handle returned by ThreadPool::start().
+// It represents one task (one start() call),
+// not the reused worker thread that runs it.
 // It is reference counted (held via SmartPointer),
 // so it stays alive as long as the caller or the running worker holds it,
 // and it can never be freed or reused under the caller.

--- a/include/ThreadPool.h
+++ b/include/ThreadPool.h
@@ -60,6 +60,7 @@ private:
 	Action* nextAction; std::string nextName;
 	SmartPointer<ThreadPoolItem> nextTask;
 	bool quitting;
+	int aliveWorkers; // worker threads that have entered threadWrapper and not yet returned
 	std::set<ThreadWorker*> availableThreads;
 	std::set<ThreadWorker*> usedThreads;
 	void prepareNewThread();

--- a/src/MainLoop.cpp
+++ b/src/MainLoop.cpp
@@ -254,7 +254,7 @@ void startMainLockDetector() {
 			return true;
 		}
 	};
-	threadPool->start(new MainLockDetector(), "main lock detector", true);
+	threadPool->start(new MainLockDetector(), "main lock detector");
 }
 
 
@@ -347,7 +347,7 @@ void doMainLoop() {
 			break;
 	}
 #else
-	SmartPointer<ThreadPoolItem> mainLoopThread = threadPool->start(new MainLoopTask(), "main loop", false);
+	SmartPointer<ThreadPoolItem> mainLoopThread = threadPool->start(new MainLoopTask(), "main loop");
 
 	startMainLockDetector();
 

--- a/src/MainLoop.cpp
+++ b/src/MainLoop.cpp
@@ -347,7 +347,7 @@ void doMainLoop() {
 			break;
 	}
 #else
-	ThreadPoolItem* mainLoopThread = threadPool->start(new MainLoopTask(), "main loop", false);
+	SmartPointer<ThreadPoolItem> mainLoopThread = threadPool->start(new MainLoopTask(), "main loop", false);
 
 	startMainLockDetector();
 

--- a/src/breakpad/ExtractInfo.cpp
+++ b/src/breakpad/ExtractInfo.cpp
@@ -13,6 +13,7 @@
 
 #include "ExtractInfo.h"
 #include "Debug.h"
+#include "ThreadPool.h" // InitThreadPool, threadPool, UnInitThreadPool
 #include "Networking.h"
 #include "Options.h"
 #include "Version.h"

--- a/src/client/CGameSkin.cpp
+++ b/src/client/CGameSkin.cpp
@@ -125,7 +125,7 @@ struct CGameSkin::Thread {
 				return lastRet;
 			}
 		};
-		threadPool->start(new SkinActionHandler(skin), "CGameSkin handler", true);
+		threadPool->start(new SkinActionHandler(skin), "CGameSkin handler");
 		ready = false;
 	}
 	

--- a/src/client/GfxUtils.cpp
+++ b/src/client/GfxUtils.cpp
@@ -55,7 +55,7 @@ void DrawLoadingAni(SDL_Surface* bmpDest, int x, int y, int rx, int ry, Color fg
 
 
 struct ScopedBackgroundLoadingAni::Data {
-	ThreadPoolItem* thread;
+	SmartPointer<ThreadPoolItem> thread;
 	Mutex mutex;
 	bool quit;
 	Condition breakSig;

--- a/src/common/CWormBot.cpp
+++ b/src/common/CWormBot.cpp
@@ -518,14 +518,14 @@ public:
 		break_thread_signal(0),
 		restart_thread_searching_signal(0) {
 		thread = threadPool->start(threadSearch, this, "AI worm pathfinding");
-		if(!thread)
+		if(!thread.get())
 			errors << "could not create AI thread" << endl;
 	}
 
 	~searchpath_base() {
 		// thread cleaning up
 		breakThreadSignal();
-		if(thread) threadPool->wait(thread, NULL);
+		if(thread.get()) threadPool->wait(thread, NULL);
 		else warnings << "AI thread already uninitialized" << endl;
 		thread = NULL;
 		
@@ -773,7 +773,7 @@ public:
 
 private:
 	NEW_ai_node_t* resulted_path;
-	ThreadPoolItem* thread;
+	SmartPointer<ThreadPoolItem> thread;
 	Mutex mutex;
 	bool thread_is_ready;
 	int break_thread_signal;

--- a/src/common/Command.cpp
+++ b/src/common/Command.cpp
@@ -966,7 +966,7 @@ void Cmd_wait::exec(CmdLineIntf* caller, const std::vector<std::string>& params)
 		}
 	};
 	
-	threadPool->start( new WaitThread(params), "Cmd_wait() command thread", true );
+	threadPool->start( new WaitThread(params), "Cmd_wait() command thread" );
 }
 
 COMMAND(setViewport, "Set viewport mode", "mode=follow|cycle|freelook|actioncam [wormID] [mode2] [wormID2]", 1, 4);

--- a/src/common/Console.cpp
+++ b/src/common/Console.cpp
@@ -79,7 +79,7 @@ struct console_t {
 static void saveHistory();
 
 struct IngameConsole : CmdLineIntf {
-	ThreadPoolItem* thread;
+	SmartPointer<ThreadPoolItem> thread;
 	Mutex mutex;
 	Condition changeSignal;
 	PIVar(bool,false) quit;
@@ -168,7 +168,7 @@ struct IngameConsole : CmdLineIntf {
 	}
 
 	void stopThread() {
-		if(thread) {
+		if(thread.get()) {
 			{
 				Mutex::ScopedLock lock(mutex);
 				quit = true;

--- a/src/common/Debug_DumpCallstack.cpp
+++ b/src/common/Debug_DumpCallstack.cpp
@@ -8,9 +8,11 @@
  */
 
 #include "Debug.h"
+#include "ThreadPool.h" // getAllThreads, getThreadName
 #include "util/macros.h"
 #include <vector>
 #include <string>
+#include <set>
 #include <cstdio>
 #include <cstdlib>
 

--- a/src/common/HTTP.cpp
+++ b/src/common/HTTP.cpp
@@ -262,7 +262,7 @@ void CHttp::RequestData(const std::string& url, const std::string& proxy)
 {
 	CURL * curl = InitializeTransfer(url, proxy);
 	curlThread = new CurlThread(this, curl);
-	threadPool->start(curlThread, "CHttp: " + Url, true);
+	threadPool->start(curlThread, "CHttp: " + Url);
 }
 
 void CHttp::SendData(const std::list<HTTPPostField>& data, const std::string url, const std::string& proxy)
@@ -295,7 +295,7 @@ void CHttp::SendData(const std::list<HTTPPostField>& data, const std::string url
 	curl_easy_setopt(curl, CURLOPT_HTTPPOST, curlForm);
 	curlThread = new CurlThread(this, curl);
 	curlThread->curlForm = curlForm;
-	threadPool->start(curlThread, "CHttp: " + Url, true);
+	threadPool->start(curlThread, "CHttp: " + Url);
 }
 
 Result CurlThread::handle()

--- a/src/common/Networking.cpp
+++ b/src/common/Networking.cpp
@@ -653,8 +653,8 @@ NetworkSocket::EventHandler::EventHandler(NetworkSocket* sock) {
 	};
 	
 	sharedData = new SharedData(sock);
-	threadPool->start(new EventHandlerThread(sharedData, NL_READ_STATUS), "socket " + itoa(sock->m_socket->sock) + " read event checker", true);
-	threadPool->start(new EventHandlerThread(sharedData, NL_ERROR_STATUS), "socket " + itoa(sock->m_socket->sock) + " error event checker", true);
+	threadPool->start(new EventHandlerThread(sharedData, NL_READ_STATUS), "socket " + itoa(sock->m_socket->sock) + " read event checker");
+	threadPool->start(new EventHandlerThread(sharedData, NL_ERROR_STATUS), "socket " + itoa(sock->m_socket->sock) + " error event checker");
 }
 
 NetworkSocket::NetworkSocket() : m_type(NST_INVALID), m_state(NSS_NONE), m_withEvents(false), m_socket(NULL) {

--- a/src/common/TaskManager.cpp
+++ b/src/common/TaskManager.cpp
@@ -133,7 +133,7 @@ void TaskManager::start(Task* t, QueueType queue) {
 						TaskHandler* handler = new TaskHandler();
 												handler->task = task->replacingTask;
 												task->replacingTask->state = Task::TS_WAITFORIMMSTART;
-												threadPool->start(handler, task->replacingTask->name + " handler", true);
+												threadPool->start(handler, task->replacingTask->name + " handler");
 					}
 					else
 						// We were requested to quit, i.e. we should not start this queued task anymore.
@@ -156,7 +156,7 @@ void TaskManager::start(Task* t, QueueType queue) {
 	
 	if(queue == QT_NoQueue) {
 		t->state = Task::TS_WAITFORIMMSTART;
-		threadPool->start(handler, t->name + " handler", true);
+		threadPool->start(handler, t->name + " handler");
 	} else {
 		t->state = Task::TS_QUEUED;
 		queuedTasks.push_back(handler);

--- a/src/common/ThreadPool.cpp
+++ b/src/common/ThreadPool.cpp
@@ -174,7 +174,7 @@ int ThreadPool::threadWrapper(void* param) {
 	return 0;
 }
 
-SmartPointer<ThreadPoolItem> ThreadPool::start(Action* act, const std::string& name, bool headless) {
+SmartPointer<ThreadPoolItem> ThreadPool::start(Action* act, const std::string& name) {
 	SDL_mutexP(startMutex); // serialize start() so nextAction/nextTask are not clobbered
 	SDL_mutexP(mutex);
 	if(availableThreads.size() == 0) {
@@ -209,14 +209,14 @@ SmartPointer<ThreadPoolItem> ThreadPool::start(ThreadFunc fct, void* param, cons
 	return start(act, name);
 }
 
-SmartPointer<ThreadPoolItem> ThreadPool::start(boost::function<Result()> fct, const std::string& name, bool headless) {
+SmartPointer<ThreadPoolItem> ThreadPool::start(boost::function<Result()> fct, const std::string& name) {
 	struct FctPtrAction : Action {
 		boost::function<Result()> fct;
 		Result handle() { return fct(); }
 	};
 	FctPtrAction* act = new FctPtrAction();
 	act->fct = fct;
-	return start(act, name, headless);
+	return start(act, name);
 }
 
 bool ThreadPool::wait(const SmartPointer<ThreadPoolItem>& item, int* status) {

--- a/src/common/ThreadPool.cpp
+++ b/src/common/ThreadPool.cpp
@@ -74,6 +74,7 @@ struct ThreadWorker {
 ThreadPool::ThreadPool(unsigned int size) {
 	nextAction = NULL;
 	quitting = false;
+	aliveWorkers = 0;
 	mutex = SDL_CreateMutex();
 	awakeThread = SDL_CreateCond();
 	threadStartedWork = SDL_CreateCond();
@@ -89,19 +90,25 @@ ThreadPool::ThreadPool(unsigned int size) {
 ThreadPool::~ThreadPool() {
 	waitAll();
 
-	// All workers are idle now; tell them to quit, then join and free them.
+	// All workers are idle now; tell them to quit and wait until every worker
+	// has actually returned from threadWrapper before we free anything. We wait
+	// on aliveWorkers rather than relying on SDL_WaitThread to block, because a
+	// worker that is still parked in SDL_CondWait must not be left touching the
+	// mutex/conds once we destroy them.
 	SDL_mutexP(mutex);
 	nextAction = NULL;
 	quitting = true;
 	SDL_CondBroadcast(awakeThread);
+	while(aliveWorkers > 0)
+		SDL_CondWait(threadStatusChanged, mutex);
+	SDL_mutexV(mutex);
+
+	// The workers are done; reclaim their thread handles and free them.
 	for(std::set<ThreadWorker*>::iterator i = availableThreads.begin(); i != availableThreads.end(); ++i) {
-		SDL_mutexV(mutex);
 		SDL_WaitThread((*i)->thread, NULL);
-		SDL_mutexP(mutex);
 		delete *i;
 	}
 	availableThreads.clear();
-	SDL_mutexV(mutex);
 
 	SDL_DestroyMutex(startMutex);
 	SDL_DestroyCond(taskFinished);
@@ -124,6 +131,7 @@ int ThreadPool::threadWrapper(void* param) {
 	ThreadPool* pool = w->pool;
 
 	SDL_mutexP(pool->mutex);
+	pool->aliveWorkers++;
 	while(true) {
 		while(pool->nextAction == NULL && !pool->quitting)
 			SDL_CondWait(pool->awakeThread, pool->mutex);
@@ -155,6 +163,10 @@ int ThreadPool::threadWrapper(void* param) {
 		setCurThreadName("");
 	}
 
+	// Woken by ~ThreadPool: mark ourselves gone before releasing the mutex, so
+	// that once aliveWorkers hits 0 no worker can still touch the pool.
+	pool->aliveWorkers--;
+	SDL_CondSignal(pool->threadStatusChanged);
 	SDL_mutexV(pool->mutex);
 	return 0;
 }

--- a/src/common/ThreadPool.cpp
+++ b/src/common/ThreadPool.cpp
@@ -58,9 +58,10 @@ void getAllThreads(std::set<ThreadId>& ids) {
 }
 
 
-// The reused worker thread. The task it currently runs is a separate,
-// reference-counted ThreadPoolItem handle, so the caller never sees or holds
-// the worker and there is no lifetime coupling between the two.
+// The reused worker thread.
+// The task it currently runs is a separate, reference-counted ThreadPoolItem handle,
+// so the caller never sees or holds the worker
+// and there is no lifetime coupling between the two.
 struct ThreadWorker {
 	ThreadPool* pool;
 	SDL_Thread* thread;
@@ -90,11 +91,13 @@ ThreadPool::ThreadPool(unsigned int size) {
 ThreadPool::~ThreadPool() {
 	waitAll();
 
-	// All workers are idle now; tell them to quit and wait until every worker
-	// has actually returned from threadWrapper before we free anything. We wait
-	// on aliveWorkers rather than relying on SDL_WaitThread to block, because a
-	// worker that is still parked in SDL_CondWait must not be left touching the
-	// mutex/conds once we destroy them.
+	// All workers are idle now.
+	// Tell them to quit,
+	// and wait until every worker has actually returned from threadWrapper
+	// before we free anything.
+	// We wait on aliveWorkers rather than relying on SDL_WaitThread to block,
+	// because a worker still parked in SDL_CondWait
+	// must not be left touching the mutex/conds once we destroy them.
 	SDL_mutexP(mutex);
 	nextAction = NULL;
 	quitting = true;
@@ -163,8 +166,8 @@ int ThreadPool::threadWrapper(void* param) {
 		setCurThreadName("");
 	}
 
-	// Woken by ~ThreadPool: mark ourselves gone before releasing the mutex, so
-	// that once aliveWorkers hits 0 no worker can still touch the pool.
+	// Woken by ~ThreadPool: mark ourselves gone before releasing the mutex,
+	// so that once aliveWorkers hits 0 no worker can still touch the pool.
 	pool->aliveWorkers--;
 	SDL_CondSignal(pool->threadStatusChanged);
 	SDL_mutexV(pool->mutex);

--- a/src/common/ThreadPool.cpp
+++ b/src/common/ThreadPool.cpp
@@ -58,15 +58,29 @@ void getAllThreads(std::set<ThreadId>& ids) {
 }
 
 
+// The reused worker thread. The task it currently runs is a separate,
+// reference-counted ThreadPoolItem handle, so the caller never sees or holds
+// the worker and there is no lifetime coupling between the two.
+struct ThreadWorker {
+	ThreadPool* pool;
+	SDL_Thread* thread;
+	ThreadId nativeThreadId;
+	SmartPointer<ThreadPoolItem> task; // current task, or null when idle
+	Action* action;                    // current action, or null when idle
+	ThreadWorker() : pool(NULL), thread(NULL), nativeThreadId(0), action(NULL) {}
+};
+
+
 ThreadPool::ThreadPool(unsigned int size) {
-	nextAction = NULL; nextIsHeadless = false; nextData = NULL;
-	quitting = false;	
+	nextAction = NULL;
+	quitting = false;
 	mutex = SDL_CreateMutex();
 	awakeThread = SDL_CreateCond();
 	threadStartedWork = SDL_CreateCond();
 	threadStatusChanged = SDL_CreateCond();
+	taskFinished = SDL_CreateCond();
 	startMutex = SDL_CreateMutex();
-	
+
 	notes << "ThreadPool: creating " << size << " threads ..." << endl;
 	while(availableThreads.size() < size)
 		prepareNewThread();
@@ -75,23 +89,22 @@ ThreadPool::ThreadPool(unsigned int size) {
 ThreadPool::~ThreadPool() {
 	waitAll();
 
-	// this is the hint for all available threads to break
-	SDL_mutexP(mutex); // lock to be sure that every thread is outside that region, we could get crashes otherwise
+	// All workers are idle now; tell them to quit, then join and free them.
+	SDL_mutexP(mutex);
 	nextAction = NULL;
 	quitting = true;
 	SDL_CondBroadcast(awakeThread);
-	for(std::set<ThreadPoolItem*>::iterator i = availableThreads.begin(); i != availableThreads.end(); ++i) {
+	for(std::set<ThreadWorker*>::iterator i = availableThreads.begin(); i != availableThreads.end(); ++i) {
 		SDL_mutexV(mutex);
 		SDL_WaitThread((*i)->thread, NULL);
 		SDL_mutexP(mutex);
-		SDL_DestroyCond((*i)->finishedSignal);
-		SDL_DestroyCond((*i)->readyForNewWork);
 		delete *i;
 	}
 	availableThreads.clear();
 	SDL_mutexV(mutex);
-	
+
 	SDL_DestroyMutex(startMutex);
+	SDL_DestroyCond(taskFinished);
 	SDL_DestroyCond(threadStartedWork);
 	SDL_DestroyCond(threadStatusChanged);
 	SDL_DestroyCond(awakeThread);
@@ -99,64 +112,55 @@ ThreadPool::~ThreadPool() {
 }
 
 void ThreadPool::prepareNewThread() {
-	ThreadPoolItem* t = new ThreadPoolItem();
-	t->pool = this;
-	t->finishedSignal = SDL_CreateCond();
-	t->readyForNewWork = SDL_CreateCond();
-	t->finished = false;
-	t->working = false;
-	availableThreads.insert(t);
-	t->nativeThreadId = 0;
-	t->thread = SDL_CreateThread(threadWrapper, "ThreadPool worker", t);
+	ThreadWorker* w = new ThreadWorker();
+	w->pool = this;
+	availableThreads.insert(w);
+	w->thread = SDL_CreateThread(threadWrapper, "ThreadPool worker", w);
 }
 
 int ThreadPool::threadWrapper(void* param) {
-	ThreadPoolItem* data = (ThreadPoolItem*)param;
-	data->nativeThreadId = getCurrentThreadId();
+	ThreadWorker* w = (ThreadWorker*)param;
+	w->nativeThreadId = getCurrentThreadId();
+	ThreadPool* pool = w->pool;
 
-	SDL_mutexP(data->pool->mutex);
+	SDL_mutexP(pool->mutex);
 	while(true) {
-		while(data->pool->nextAction == NULL && !data->pool->quitting)
-			SDL_CondWait(data->pool->awakeThread, data->pool->mutex);
-		if(data->pool->quitting) break;
-		data->pool->usedThreads.insert(data);
-		data->pool->availableThreads.erase(data);
-		
-		Action* act = data->pool->nextAction; data->pool->nextAction = NULL;
-		data->headless = data->pool->nextIsHeadless;
-		data->name = data->pool->nextName;
-		data->finished = false;
-		data->working = true;
-		data->pool->nextData = data;
-		SDL_mutexV(data->pool->mutex);
-		
-		SDL_CondSignal(data->pool->threadStartedWork);
-		setCurThreadName(data->name);
-		data->ret = act->handle();
-		delete act;
-		setCurThreadName(data->name + " [finished]");
-		SDL_mutexP(data->pool->mutex);
-		data->finished = true;
-		SDL_CondSignal(data->pool->threadStatusChanged);
-		
-		if(!data->headless) { // headless means that we just can clean it up right now without waiting
-			SDL_CondSignal(data->finishedSignal);
-			while(data->working) SDL_CondWait(data->readyForNewWork, data->pool->mutex);
-		} else
-			data->working = false;
-		data->pool->usedThreads.erase(data);
-		data->pool->availableThreads.insert(data);
-		SDL_CondSignal(data->pool->threadStatusChanged);
+		while(pool->nextAction == NULL && !pool->quitting)
+			SDL_CondWait(pool->awakeThread, pool->mutex);
+		if(pool->quitting) break;
+
+		// Take the pending task.
+		w->action = pool->nextAction; pool->nextAction = NULL;
+		w->task = pool->nextTask; pool->nextTask = NULL;
+		pool->availableThreads.erase(w);
+		pool->usedThreads.insert(w);
+		SDL_CondSignal(pool->threadStartedWork); // let start() know we took it
+		SDL_mutexV(pool->mutex);
+
+		setCurThreadName(w->task->name);
+		int ret = w->action->handle();
+		delete w->action; w->action = NULL;
+		setCurThreadName(w->task->name + " [finished]");
+
+		SDL_mutexP(pool->mutex);
+		w->task->ret = ret;
+		w->task->finished = true;
+		w->task = NULL; // drop the worker's reference; the handle keeps the result
+		// The worker goes idle immediately: the result lives in the handle,
+		// so there is nothing to wait for a caller to "collect".
+		pool->usedThreads.erase(w);
+		pool->availableThreads.insert(w);
+		SDL_CondBroadcast(pool->taskFinished);     // wake any wait() on this task
+		SDL_CondSignal(pool->threadStatusChanged); // wake waitAll()
 		setCurThreadName("");
 	}
 
-	SDL_mutexV(data->pool->mutex);
-		
+	SDL_mutexV(pool->mutex);
 	return 0;
 }
 
-ThreadPoolItem* ThreadPool::start(Action* act, const std::string& name, bool headless) {
-	SDL_mutexP(startMutex); // If start() method will be called from different threads without mutex, hard-to-find crashes will occur
+SmartPointer<ThreadPoolItem> ThreadPool::start(Action* act, const std::string& name, bool headless) {
+	SDL_mutexP(startMutex); // serialize start() so nextAction/nextTask are not clobbered
 	SDL_mutexP(mutex);
 	if(availableThreads.size() == 0) {
 #ifndef SINGLETHREADED
@@ -165,21 +169,21 @@ ThreadPoolItem* ThreadPool::start(Action* act, const std::string& name, bool hea
 		prepareNewThread();
 	}
 	assert(nextAction == NULL);
-	assert(nextData == NULL);
+	SmartPointer<ThreadPoolItem> task = new ThreadPoolItem();
+	task->name = name;
 	nextAction = act;
-	nextIsHeadless = headless;
-	nextName = name;
-	
+	nextTask = task;
+
 	SDL_CondSignal(awakeThread);
-	while(nextData == NULL) SDL_CondWait(threadStartedWork, mutex);
-	ThreadPoolItem* data = nextData; nextData = NULL;
+	while(nextAction != NULL) SDL_CondWait(threadStartedWork, mutex); // wait until a worker took it
+	nextTask = NULL;
 	SDL_mutexV(mutex);
-		
+
 	SDL_mutexV(startMutex);
-	return data;
+	return task;
 }
 
-ThreadPoolItem* ThreadPool::start(ThreadFunc fct, void* param, const std::string& name) {
+SmartPointer<ThreadPoolItem> ThreadPool::start(ThreadFunc fct, void* param, const std::string& name) {
 	struct StaticAction : Action {
 		ThreadFunc fct; void* param;
 		Result handle() { return (*fct) (param); }
@@ -187,13 +191,10 @@ ThreadPoolItem* ThreadPool::start(ThreadFunc fct, void* param, const std::string
 	StaticAction* act = new StaticAction();
 	act->fct = fct;
 	act->param = param;
-	ThreadPoolItem* item = start(act, name);
-	if(item) return item;
-	delete act;
-	return NULL;
+	return start(act, name);
 }
 
-ThreadPoolItem* ThreadPool::start(boost::function<Result()> fct, const std::string& name, bool headless) {
+SmartPointer<ThreadPoolItem> ThreadPool::start(boost::function<Result()> fct, const std::string& name, bool headless) {
 	struct FctPtrAction : Action {
 		boost::function<Result()> fct;
 		Result handle() { return fct(); }
@@ -203,69 +204,44 @@ ThreadPoolItem* ThreadPool::start(boost::function<Result()> fct, const std::stri
 	return start(act, name, headless);
 }
 
-bool ThreadPool::wait(ThreadPoolItem* thread, int* status) {
-	if(!thread) return false;
+bool ThreadPool::wait(const SmartPointer<ThreadPoolItem>& item, int* status) {
+	if(!item.get()) return false;
 	SDL_mutexP(mutex);
-	if(!thread->working) {
-		warnings << "given thread " << thread->name << " is not working anymore" << endl;
-		SDL_mutexV(mutex);
-		return false;
-	}
-	while(!thread->finished) SDL_CondWait(thread->finishedSignal, mutex);
-	if(status) *status = thread->ret;
-	thread->working = false;
+	while(!item->finished) SDL_CondWait(taskFinished, mutex);
+	if(status) *status = item->ret;
 	SDL_mutexV(mutex);
-	
-	SDL_CondSignal(thread->readyForNewWork);
 	return true;
 }
 
 bool ThreadPool::waitAll() {
 	SDL_mutexP(mutex);
-	while(usedThreads.size() > 0) {		
-		warnings << "ThreadPool: waiting for " << usedThreads.size() << " threads to finish:" << endl;
-		for(std::set<ThreadPoolItem*>::iterator i = usedThreads.begin(); i != usedThreads.end(); ++i) {
-			if((*i)->working && (*i)->finished) {
-				warnings << "  thread " << (*i)->name << " is ready but was not cleaned up" << endl;
-				(*i)->working = false;
-				SDL_CondSignal((*i)->readyForNewWork);
-			}
-			else if((*i)->working && !(*i)->finished) {
-				warnings << "  thread " << (*i)->name << " is still working" << endl;
-			}
-			else if(!(*i)->working && !(*i)->headless && (*i)->finished) {
-				warnings << "  thread " << (*i)->name << " is cleaning itself up right now" << endl;
-			}
-			else {
-				warnings << "  thread " << (*i)->name << " is in an invalid state" << endl;
-			}
+	while(usedThreads.size() > 0) {
+		warnings << "ThreadPool: waiting for " << usedThreads.size() << " task(s) to finish:" << endl;
+		for(std::set<ThreadWorker*>::iterator i = usedThreads.begin(); i != usedThreads.end(); ++i) {
+			SmartPointer<ThreadPoolItem> t = (*i)->task;
+			warnings << "  task " << (t.get() ? t->name : std::string("?")) << " is still working" << endl;
 		}
 		SDL_CondWait(threadStatusChanged, mutex);
 	}
 	SDL_mutexV(mutex);
-	
+
 	return true;
 }
 
 void ThreadPool::dumpState(CmdLineIntf& cli) const {
 	ScopedLock lock(mutex);
-	for(std::set<ThreadPoolItem*>::const_iterator i = usedThreads.begin(); i != usedThreads.end(); ++i) {
-		if((*i)->working && (*i)->finished)
-			cli.writeMsg("thread '" + (*i)->name + "': ready but was not cleaned up");
-		else if((*i)->working && !(*i)->finished)
-			cli.writeMsg("thread '" + (*i)->name + "': working");
-		else if(!(*i)->working && !(*i)->headless && (*i)->finished)
-			cli.writeMsg("thread '" + (*i)->name + "': cleanup");
-		else
-			cli.writeMsg("thread '" + (*i)->name + "': invalid");
+	for(std::set<ThreadWorker*>::const_iterator i = usedThreads.begin(); i != usedThreads.end(); ++i) {
+		SmartPointer<ThreadPoolItem> t = (*i)->task;
+		cli.writeMsg("task '" + (t.get() ? t->name : std::string("?")) + "': working");
 	}
 }
 
 void ThreadPool::getAllWorkingThreads(std::map<ThreadId, std::string>& threads) {
 	ScopedLock lock(mutex);
-	for(std::set<ThreadPoolItem*>::const_iterator i = usedThreads.begin(); i != usedThreads.end(); ++i) {
-		if((*i)->working && !(*i)->finished)
-			threads[(*i)->nativeThreadId] = (*i)->name;
+	for(std::set<ThreadWorker*>::const_iterator i = usedThreads.begin(); i != usedThreads.end(); ++i) {
+		SmartPointer<ThreadPoolItem> t = (*i)->task;
+		if(t.get())
+			threads[(*i)->nativeThreadId] = t->name;
 	}
 }
 
@@ -289,5 +265,3 @@ void UnInitThreadPool() {
 	} else
 		errors << "ThreadPool already uninited" << endl;
 }
-
-

--- a/src/common/Timer.cpp
+++ b/src/common/Timer.cpp
@@ -147,7 +147,7 @@ struct TimerData {
 	bool				quitSignal;
 	SDL_cond*			quitCond;
 	SDL_mutex*			mutex;
-	ThreadPoolItem*		thread;
+	SmartPointer<ThreadPoolItem>	thread;
 	
 	TimerData() : timer(NULL), userData(NULL), interval(0), once(false), quitSignal(false), quitCond(NULL), mutex(NULL), thread(NULL) {
 		mutex = SDL_CreateMutex();
@@ -157,7 +157,7 @@ struct TimerData {
 	}
 	~TimerData() {
 		breakThread();
-		if(thread) threadPool->wait(thread, NULL);
+		if(thread.get()) threadPool->wait(thread, NULL);
 		thread = NULL;
 		SDL_DestroyMutex(mutex); mutex = NULL;
 		SDL_DestroyCond(quitCond); quitCond = NULL;
@@ -171,7 +171,7 @@ struct TimerData {
 	}
 
 	void startThread() {
-		assert(thread == NULL);
+		assert(thread.get() == NULL);
 		
 		struct TimerHandler : Action {
 			TimerData* data;

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -395,7 +395,7 @@ Result Game::prepareGameloop() {
 			TimeoutAvoiderAction* a = new TimeoutAvoiderAction();
 			a->chan = cClient->cNetChan;
 			a->scope = scope;
-			threadPool->start(a, "prepareGameloop timeout avoider keep-me-alive", true);
+			threadPool->start(a, "prepareGameloop timeout avoider keep-me-alive");
 		}
 		~TimeoutAvoider() { if(scope.get()) scope->write() = false; }
 	};

--- a/src/server/DedicatedControl.cpp
+++ b/src/server/DedicatedControl.cpp
@@ -78,7 +78,7 @@ void DedicatedControl::Uninit() {
 
 struct ScriptCmdLineIntf : CmdLineIntf {
 	Process pipe;
-	ThreadPoolItem* thread;
+	SmartPointer<ThreadPoolItem> thread;
 	
 
 	ScriptCmdLineIntf() : thread(NULL) {
@@ -112,13 +112,13 @@ struct ScriptCmdLineIntf : CmdLineIntf {
 	}
 	
 	bool havePipe() {
-		return thread != NULL;
+		return thread.get() != NULL;
 	}
 
 	
 	
 	bool breakCurrentScript() {
-		if(thread) {
+		if(thread.get()) {
 			notes << "waiting for pipeThread ..." << endl;
 			pipe.close();
 			threadPool->wait(thread, NULL);


### PR DESCRIPTION
Fix #961, the crash on exit.

And hardens the ThreadPool against a related use-after-free class found along the way.

## The crash (#961)

On exit, `~ThreadPool` broadcast the quit, joined the workers with
`SDL_WaitThread`, then destroyed the pool mutex and condition
variables. But `SDL_WaitThread` can return before a worker has
actually returned from `threadWrapper`, so the pool freed the mutex and
conds while a worker was still parked in `SDL_CondWait` on them, and it
faulted.

The fix tracks the number of live workers and, on teardown, waits until
every worker has decremented that count and signalled before freeing
anything. This does not depend on `SDL_WaitThread` blocking, so the
sync objects are only destroyed once no worker can still touch them.

## Related hardening: reference-counted task handles

While investigating I found a separate use-after-free class in the same
subsystem. `start()` returned a raw `ThreadPoolItem*` that was both the
caller's handle and the reused worker thread, so a caller could `wait()`
on a worker that `waitAll()` had already reaped or that had been reused
for another task. `start()` now returns a reference-counted
`SmartPointer<ThreadPoolItem>` handle for a single task, with the reused
worker thread as a separate internal type; `wait()` waits on the handle
and can never race with worker reuse.

## Verifying

The crash is an intermittent shutdown race. Locally, a dedicated-server
start/quit loop crashed on roughly three of four runs before the fix and
is clean across 50+ runs after. The headless test suite passes.

The three commits are the include-cycle break that lets ThreadPool.h use
SmartPointer, the handle refactor, and the teardown fix.
