### PR TITLE
Fix misleading indentation warnings

### DIFF
--- a/src/common/Debug_extended_backtrace.cpp
+++ b/src/common/Debug_extended_backtrace.cpp
@@ -251,7 +251,8 @@ struct BfdSession {
 	BfdSession() : abfd(NULL), syms(NULL) {}
 	~BfdSession() {
 		free(syms); syms = NULL;
-		if(abfd) bfd_close(abfd); abfd = NULL;
+		if(abfd) bfd_close(abfd);
+		abfd = NULL;
 	}
 };
 typedef std::map<std::string, boost::shared_ptr<BfdSession> > BfdSessionMap;

--- a/src/common/MapLoader_CommanderKeen123.cpp
+++ b/src/common/MapLoader_CommanderKeen123.cpp
@@ -167,7 +167,8 @@ private:
 		
 		LatchReader(ML_CommanderKeen123* p) : parent(p), RawData(NULL) {}
 		~LatchReader() {
-			if(RawData) delete[] RawData; RawData = NULL;
+			if(RawData) delete[] RawData;
+			RawData = NULL;
 		}
 		
 		// initilizes the positions getbit will retrieve data from

--- a/src/common/TeeStdoutHandler.cpp
+++ b/src/common/TeeStdoutHandler.cpp
@@ -44,7 +44,8 @@ static void teeOlxOutputToFileHandler(int c) {
 	static FILE* out = NULL;
 	
 	if(c == EOF) {
-		if(out) fclose(out); out = NULL;
+		if(out) fclose(out);
+		out = NULL;
 		return;
 	}
 	
@@ -55,7 +56,8 @@ static void teeOlxOutputToFileHandler(int c) {
 		buffer += c;
 	
 	if(ch == '\n' && currentOlxOutputFilename != teeOlxOutputFile) {
-		if(out) fclose(out); out = NULL;
+		if(out) fclose(out);
+		out = NULL;
 		currentOlxOutputFilename = teeOlxOutputFile;
 		if(currentOlxOutputFilename != "") {
 			out = fopen(currentOlxOutputFilename.c_str(), "a");

--- a/src/gusanos/base_worm.cpp
+++ b/src/gusanos/base_worm.cpp
@@ -798,6 +798,8 @@ void CWorm::finalize()
 	game.onRemoveWorm(this);
 	thisRef.obj.overwriteShared(NULL);
 
-	if(m_node) delete m_node; m_node = 0;
-	if(m_interceptor) delete m_interceptor; m_interceptor = 0;
+	if(m_node) delete m_node;
+	m_node = 0;
+	if(m_interceptor) delete m_interceptor;
+	m_interceptor = 0;
 }

--- a/src/gusanos/net_worm.cpp
+++ b/src/gusanos/net_worm.cpp
@@ -98,8 +98,10 @@ void CWorm::NetWorm_Init()
 
 void CWorm::NetWorm_Shutdown()
 {
-	if(m_node) delete m_node; m_node = NULL;
-	if(m_interceptor) delete m_interceptor; m_interceptor = NULL;
+	if(m_node) delete m_node;
+	m_node = NULL;
+	if(m_interceptor) delete m_interceptor;
+	m_interceptor = NULL;
 }
 
 void CWorm::addEvent(BitStream* data, CWorm::NetEvents event)


### PR DESCRIPTION
The Linux CI build (GCC) emits `-Wmisleading-indentation` for several lines written as `if(x) foo(); bar();`, where `bar()` sits on the same line after the guarded statement but always runs. (AppleClang, which the earlier warning-cleanup used, does not emit this, so these were missed.)

In every case the behaviour is correct -- the trailing statement (`ptr = NULL;`, `out = NULL;`, `abfd = NULL;`) is meant to run unconditionally after the guarded `delete`/`fclose`. This just splits each onto its own line to match the intent and clear the warning; no behaviour change.

Files:
- `src/common/TeeStdoutHandler.cpp` (2 spots)
- `src/gusanos/net_worm.cpp`
- `src/gusanos/base_worm.cpp`
- `src/common/Debug_extended_backtrace.cpp`
- `src/common/MapLoader_CommanderKeen123.cpp`
