### PR TITLE
Fix class-memaccess warning on gs_header_t

### DIFF
--- a/include/CGameScript.h
+++ b/include/CGameScript.h
@@ -56,8 +56,8 @@ static_assert(GS_VERSION - GS_FIRST_SUPPORTED_VERSION + 1 == sizeof(GS_MinLxVers
 // WARNING: never change this!
 // it's used in CGameScript.cpp and it represents
 // the original file format
+// Trivially copyable POD read from / written to the mod file as a raw block.
 struct gs_header_t {
-	gs_header_t() { ID[0] = 0; Version = 0; ModName[0] = 0; }
 	char	ID[18];
 	Uint32	Version;
 	char	ModName[64];
@@ -98,7 +98,7 @@ private:
 
 	// Header
 	bool loaded;
-	gs_header_t	Header;
+	gs_header_t	Header = {};
 	std::string modname;
 	bool m_gusEngineUsed;
 

--- a/src/common/CGameScript.cpp
+++ b/src/common/CGameScript.cpp
@@ -480,8 +480,7 @@ static bool checkLXBinMod(const std::string& dir, bool abs_filename, ModInfo& in
 	if(!fp) return false;
 	
 	// Header
-	gs_header_t head;
-	memset(&head,0,sizeof(gs_header_t));
+	gs_header_t head = {};
 	fread_compat(head,sizeof(gs_header_t),1,fp);
 	fclose(fp);
 	


### PR DESCRIPTION
The Linux CI build (GCC) emits `-Wclass-memaccess` for `memset(&head, 0, sizeof(gs_header_t))` in `CGameScript`:

```
warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct gs_header_t'; use assignment or value-initialization instead
```

`gs_header_t` only became non-trivial because of its hand-written constructor. But it is a raw header block read from and written to the mod file via `fread`/`fwrite`, so it should be a trivial POD.

This removes the constructor and value-initializes instead:
- `gs_header_t head = {};` at the read site (replaces the `memset`, still zero-initializes every byte),
- a default member initializer on `CGameScript::Header` so it is zero-initialized as the constructor used to do.

The type is now trivially copyable, which also makes the `fread`/`fwrite` on it well-defined. (AppleClang, used in the earlier warning cleanup, does not emit `-Wclass-memaccess`, so this was missed.)
