### PR TITLE
Catch SyntaxError by const reference

### DIFF
--- a/src/gusanos/console/console.cpp
+++ b/src/gusanos/console/console.cpp
@@ -163,7 +163,7 @@ void Console::parseLine(const string &text, bool parseRelease)
 	{
 		addLogMsg(handler.block());
 	}
-	catch(SyntaxError error)
+	catch(const SyntaxError& error)
 	{
 		addLogMsg(text);
 		std::streamoff pos = handler.str.tellg();


### PR DESCRIPTION
The Linux CI build (GCC) emits `-Wcatch-value` in `console.cpp`:

```
warning: catching polymorphic type 'struct SyntaxError' by value
```

Catching a polymorphic exception by value slices it. This catches `SyntaxError` by `const` reference instead. (AppleClang, used in the earlier warning cleanup, does not emit `-Wcatch-value`, so this was missed.)
