### PR TITLE
Fix chat length check: signedness and non-positive limit

### DIFF
--- a/src/server/CServer_Parse.cpp
+++ b/src/server/CServer_Parse.cpp
@@ -441,7 +441,10 @@ void CServerNetEngine::ParseChatText(CBytestream *bs) {
 	//Resize oversized messages and optionally kick the sender
 	//TODO: Implement check at lower level to drop packets without ever passing them to chat handler? Or would this cause problems or confusion?
 	//TODO: Limit message length client side too?
-	if (tLXOptions->bCheckChatMessageLength && buf.size() > (size_t)tLXOptions->iMaxChatMessageLength){
+	// A non-positive limit is treated as "no limit" (check disabled),
+	// which also keeps the size_t cast below well-defined.
+	if (tLXOptions->bCheckChatMessageLength && tLXOptions->iMaxChatMessageLength > 0
+			&& buf.size() > (size_t)tLXOptions->iMaxChatMessageLength){
 		buf.resize(tLXOptions->iMaxChatMessageLength);
 		if (tLXOptions->bKickOversizedMsgSenders){
 			server->DropClient(cl, CLL_KICK, "Attempt to send oversized message or command");

--- a/src/server/CServer_Parse.cpp
+++ b/src/server/CServer_Parse.cpp
@@ -441,7 +441,7 @@ void CServerNetEngine::ParseChatText(CBytestream *bs) {
 	//Resize oversized messages and optionally kick the sender
 	//TODO: Implement check at lower level to drop packets without ever passing them to chat handler? Or would this cause problems or confusion?
 	//TODO: Limit message length client side too?
-	if (tLXOptions->bCheckChatMessageLength && buf.size() > tLXOptions->iMaxChatMessageLength){
+	if (tLXOptions->bCheckChatMessageLength && buf.size() > (size_t)tLXOptions->iMaxChatMessageLength){
 		buf.resize(tLXOptions->iMaxChatMessageLength);
 		if (tLXOptions->bKickOversizedMsgSenders){
 			server->DropClient(cl, CLL_KICK, "Attempt to send oversized message or command");


### PR DESCRIPTION
The Linux CI build (GCC) emits `-Wsign-compare` in `CServer_Parse.cpp`:

```
warning: comparison of integer expressions of different signedness:
'std::string::size_type' {aka 'long unsigned int'} and 'int'
```

`buf.size()` is unsigned; `iMaxChatMessageLength` is `int`.

Two commits:

1. Make the existing implicit `int -> size_t` conversion explicit with a cast, silencing the warning (behaviour-identical). (AppleClang, used in the earlier warning cleanup, doesn't enable `-Wsign-compare` under `-Wall`, so this was missed.)

2. Harden the edge case: `Network.MaxChatMessageLength` is an unbounded config option (default 800, no min validation), so a negative value would cast to a huge `size_t` and silently disable the length check -- and `buf.resize()` on the next line takes a negative length if the comparison ever came out true. Guard the check with `iMaxChatMessageLength > 0`, so a non-positive limit explicitly means "no limit" and the cast only ever applies to a positive value.

Only edge-case behaviour change: a limit of exactly `0` now means "no check" instead of "truncate every message to empty", which is the sensible reading.
