### PR TITLE
Remove dead port extraction in ParseQuery

### DIFF
--- a/src/server/CServer_Parse.cpp
+++ b/src/server/CServer_Parse.cpp
@@ -1802,14 +1802,6 @@ void GameServer::ParseQuery(const SmartPointer<NetworkSocket>& tSocket, CBytestr
 	bytestr.writeInt(-1, 4);
 	bytestr.writeString("lx::queryreturn");
 
-	// Get Port
-	size_t pos = ip.rfind(':');
-	if (pos != std::string::npos)
-		ip.substr(pos);
-	
-	//if(ip == "23401")
-	//	bytestr.writeString(OldLxCompatibleString(sName+" (private)")); // Not used anyway
-	//else
 	bytestr.writeString(OldLxCompatibleString(tLXOptions->sServerName));
 	bytestr.writeByte(game.worms()->size());
 	bytestr.writeByte(tLXOptions->iMaxPlayers);


### PR DESCRIPTION
The MinGW/GCC CI build emits `-Wunused-result` in `GameServer::ParseQuery`:

```
warning: ignoring return value of '... std::string::substr(...) const', declared with attribute 'nodiscard'
```

The offending line:

```cpp
// Get Port
size_t pos = ip.rfind(':');
if (pos != std::string::npos)
    ip.substr(pos);
```

`ip` is a `const std::string&`, and the `substr()` result is discarded, so this does nothing at runtime. The extracted port was only ever used by the adjacent commented-out branch (`//if(ip == "23401") ...`, marked "Not used anyway").

This removes the dead port extraction and that abandoned commented-out branch, leaving the active `writeString(... sServerName ...)`. No behaviour change.

Found while auditing the Windows/MinGW CI warnings (a newer GCC than the Linux CI), which surface a few classes AppleClang and the Linux GCC build don't.
