### PR TITLE
AGENTS.md: also avoid wildcards and brace expansion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ To keep commands auto-approved, write them plain and literal:
 
 - No variable or command substitution (`$VAR`, `` $(...) ``);
   hardcode the value instead.
+- No wildcards or brace expansion (`*.cpp`, `build*`, `{a,b}`);
+  they expand to whatever is on disk, so pass the exact paths.
 - No `for`/`while` loops;
   run separate commands, or issue parallel tool calls.
 - Don't combine `cd` with a write in one compound command


### PR DESCRIPTION
The "Running shell commands" list in AGENTS.md tells agents to avoid
the forms of shell expansion that break sandbox auto-approval, but it
omitted filename wildcards and brace expansion. Those expand to
whatever happens to be on disk and are flagged the same way, so add a
bullet for them.
