### PR TITLE
Headless gameplay test: bots play a round, state syncs to a client

### DIFF
--- a/src/common/Command.cpp
+++ b/src/common/Command.cpp
@@ -264,9 +264,9 @@ struct AutocompleteRequest {
 
 
 // TODO: Move this
-static CWorm* CheckWorm(CmdLineIntf* caller, int id, const std::string& request)
+static CWorm* CheckWorm(CmdLineIntf* caller, int id, const std::string& request, bool allowClient = false)
 {
-	if(game.isClient() || !cServer || !cServer->isServerRunning()) {
+	if(!allowClient && (game.isClient() || !cServer || !cServer->isServerRunning())) {
 		caller->writeMsg(request + " works only as server");
 		return NULL;
 	}
@@ -361,7 +361,20 @@ struct Command : CommandDesc {
 		}
 		return CheckWorm(caller, id, name);
 	}
-	
+
+	// Like getWorm(), but also allowed on a client.
+	// For read-only commands that just report a worm's (replicated) state,
+	// so a connected client can be queried the same way as the server.
+	CWorm* getWormReadonly(CmdLineIntf* caller, const std::string& param) {
+		bool fail = true;
+		int id = from_string<int>(param, fail);
+		if(fail) {
+			printUsage(caller);
+			return NULL;
+		}
+		return CheckWorm(caller, id, name, true);
+	}
+
 };
 
 typedef std::map<std::string, Command*, stringcaseless> CommandMap;
@@ -2052,7 +2065,7 @@ void Cmd_getWormTeam::exec(CmdLineIntf* caller, const std::vector<std::string>& 
 
 COMMAND(getWormScore, "get worm score", "id", 1, 1);
 void Cmd_getWormScore::exec(CmdLineIntf* caller, const std::vector<std::string>& params) {
-	CWorm* w = getWorm(caller, params[0]); if(!w) return;
+	CWorm* w = getWormReadonly(caller, params[0]); if(!w) return;
 	caller->pushReturnArg(itoa(w->getLives()));
 	caller->pushReturnArg(itoa(w->getScore()));
 	caller->pushReturnArg(ftoa(w->getDamage()));
@@ -2114,21 +2127,21 @@ void Cmd_getWormSkin::exec(CmdLineIntf* caller, const std::vector<std::string>& 
 
 COMMAND(getWormPos, "get worm position", "id", 1, 1);
 void Cmd_getWormPos::exec(CmdLineIntf* caller, const std::vector<std::string>& params) {
-	CWorm* w = getWorm(caller, params[0]); if(!w) return;	
+	CWorm* w = getWormReadonly(caller, params[0]); if(!w) return;	
 	caller->pushReturnArg(ftoa(w->getPos().x));
 	caller->pushReturnArg(ftoa(w->getPos().y));
 }
 
 COMMAND(getWormVelocity, "get worm velocity", "id", 1, 1);
 void Cmd_getWormVelocity::exec(CmdLineIntf* caller, const std::vector<std::string>& params) {
-	CWorm* w = getWorm(caller, params[0]); if(!w) return;	
+	CWorm* w = getWormReadonly(caller, params[0]); if(!w) return;	
 	caller->pushReturnArg(ftoa(w->velocity().get().x));
 	caller->pushReturnArg(ftoa(w->velocity().get().y));
 }
 
 COMMAND(getWormHealth, "get worm health", "id", 1, 1);
 void Cmd_getWormHealth::exec(CmdLineIntf* caller, const std::vector<std::string>& params) {
-	CWorm* w = getWorm(caller, params[0]); if(!w) return;	
+	CWorm* w = getWormReadonly(caller, params[0]); if(!w) return;	
 	caller->pushReturnArg(ftoa(w->getHealth()));
 }
 

--- a/tests/headless/README.md
+++ b/tests/headless/README.md
@@ -6,6 +6,8 @@ and run on a bare CI runner.
 
 - `test_smoke.py` — the game boots and hosts a lobby.
 - `test_network.py` — networked play between instances.
+- `test_gameplay.py` — bots play a real round (combat, death, respawn),
+  and the in-game state (health, kills, damage) syncs to a connected client.
 - `harness.py`, `conftest.py`, `control/` —
   helpers plus the Python 3 control scripts that drive each instance.
 

--- a/tests/headless/control/_olx_pipe.py
+++ b/tests/headless/control/_olx_pipe.py
@@ -59,3 +59,37 @@ def game_state():
 def worm_ids():
     """Return the worm ids currently known to this instance (as strings)."""
     return command("getwormlist")
+
+
+def worm_state(wid):
+    """Return a worm's replicated state as a dict, or None if unavailable.
+
+    ``getWormScore`` returns ``[lives, kills, damage, health]``
+    (health is -1 when the worm is dead), and ``getWormPos`` returns ``[x, y]``.
+    Both are read-only and work on a client as well as the server,
+    so the same view can be compared on both sides.
+    """
+    score = command("getWormScore " + str(wid))
+    if len(score) < 4:
+        return None
+    st = {"kills": int(score[1]), "dmg": float(score[2]), "hp": float(score[3])}
+    pos = command("getWormPos " + str(wid))
+    if len(pos) >= 2:
+        st["x"], st["y"] = float(pos[0]), float(pos[1])
+    return st
+
+
+def emit_worm_states(prefix):
+    """Emit one ``<prefix> STATE ...`` marker per worm; return ``{id: state}``.
+
+    The caller uses the returned states to detect combat, deaths and respawns.
+    """
+    states = {}
+    for wid in worm_ids():
+        st = worm_state(wid)
+        if st is None:
+            continue
+        emit("%s STATE id=%s hp=%g kills=%d dmg=%g"
+             % (prefix, wid, st["hp"], st["kills"], st["dmg"]))
+        states[wid] = st
+    return states

--- a/tests/headless/control/client_control.py
+++ b/tests/headless/control/client_control.py
@@ -20,13 +20,15 @@ import sys
 import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _olx_pipe import command, emit, game_state, worm_ids  # noqa: E402
+from _olx_pipe import command, emit, emit_worm_states, game_state, worm_ids  # noqa: E402
 
 
 def main():
     name = os.environ.get("OLX_CLIENT_NAME", "client")
     leave_signal = os.environ.get("OLX_LEAVE_SIGNAL_FILE")
+    emit_state = os.environ.get("OLX_EMIT_STATE")
     reached_playing = False
+    combat = False
     prev_worms = set()
     deadline = time.time() + int(os.environ.get("OLX_RUN_SECONDS", "60"))
     while time.time() < deadline:
@@ -47,6 +49,17 @@ def main():
         if state == "Playing" and not reached_playing:
             emit("CLIENT[%s] PLAYING" % name)
             reached_playing = True
+        # Report this client's own view of every worm's state, so a test can
+        # check it against the server's view and confirm the game state syncs.
+        if reached_playing and emit_state:
+            states = emit_worm_states("CLIENT[%s]" % name)
+            total_dmg = sum(s["dmg"] for s in states.values())
+            total_kills = sum(s["kills"] for s in states.values())
+            any_death = any(s["hp"] < 0 for s in states.values())
+            if not combat and (total_dmg >= 40 or total_kills > 0 or any_death):
+                emit("CLIENT[%s] COMBAT dmg=%g kills=%d death=%d"
+                     % (name, total_dmg, total_kills, int(any_death)))
+                combat = True
         time.sleep(0.5)
     emit("CLIENT[%s] DONE reached_playing=%s" % (name, reached_playing))
 

--- a/tests/headless/control/server_control.py
+++ b/tests/headless/control/server_control.py
@@ -26,7 +26,7 @@ import sys
 import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _olx_pipe import command, emit, game_state, worm_ids  # noqa: E402
+from _olx_pipe import command, emit, emit_worm_states, game_state, worm_ids  # noqa: E402
 
 
 def main():
@@ -56,9 +56,28 @@ def main():
     command("startlobby " + port)
     emit("SERVER_LOBBY")
 
+    # Optional bots, so a round can actually be played out with no human input.
+    bots = int(os.environ.get("OLX_BOTS", "0"))
+    if bots > 0:
+        # Wait for the lobby (and the server's own local client) to come up,
+        # otherwise addBots fails with "localClient not found".
+        for _ in range(25):
+            if game_state() == "Lobby":
+                break
+            time.sleep(0.2)
+        time.sleep(0.5)
+        command("addBots %d" % bots)
+        emit("SERVER_ADDBOTS %d" % bots)
+
+    emit_state = os.environ.get("OLX_EMIT_STATE")
+    spawn_close = os.environ.get("OLX_SPAWN_CLOSE")
+
     start_when = int(os.environ.get("OLX_START_WHEN_WORMS", "1"))
     started = False
     playing = False
+    combat = False
+    dead_seen = set()
+    respawn_seen = False
     deadline = time.time() + int(os.environ.get("OLX_RUN_SECONDS", "90"))
     while time.time() < deadline:
         state = game_state()
@@ -71,6 +90,28 @@ def main():
         if state == "Playing" and not playing:
             emit("SERVER_PLAYING")
             playing = True
+            # Cluster the worms at one spot so they fight at once,
+            # rather than hoping random spawns bring them into range in time.
+            if spawn_close:
+                spot = command("findSpot")
+                if len(spot) >= 2:
+                    for wid in worms:
+                        command('spawnWorm %s "%s,%s"' % (wid, spot[0], spot[1]))
+                    emit("SERVER_SPAWN_CLOSE %s,%s" % (spot[0], spot[1]))
+        if playing and emit_state:
+            states = emit_worm_states("SERVER")
+            total_dmg = sum(s["dmg"] for s in states.values())
+            total_kills = sum(s["kills"] for s in states.values())
+            for wid, s in states.items():
+                if s["hp"] < 0:
+                    dead_seen.add(wid)
+                elif wid in dead_seen and not respawn_seen:
+                    respawn_seen = True
+                    emit("SERVER_RESPAWN id=%s" % wid)
+            if not combat and (total_dmg >= 40 or total_kills > 0 or dead_seen):
+                emit("SERVER_COMBAT dmg=%g kills=%d deaths=%d"
+                     % (total_dmg, total_kills, len(dead_seen)))
+                combat = True
         time.sleep(0.5)
     emit("SERVER_DONE")
 

--- a/tests/headless/control/server_control.py
+++ b/tests/headless/control/server_control.py
@@ -59,14 +59,25 @@ def main():
     # Optional bots, so a round can actually be played out with no human input.
     bots = int(os.environ.get("OLX_BOTS", "0"))
     if bots > 0:
-        # Wait for the lobby (and the server's own local client) to come up,
-        # otherwise addBots fails with "localClient not found".
-        for _ in range(25):
-            if game_state() == "Lobby":
+        # addBots needs the server's own local client, which is not ready the
+        # instant the lobby comes up: called too early it logs
+        # "localClient not found" and silently adds nothing. So wait for the
+        # lobby, then add the bots and confirm they actually appeared
+        # (getComputerWormList counts only bots), retrying while the local
+        # client is still coming up. Give up loudly rather than starting a
+        # broken round.
+        deadline = time.time() + 15
+        while time.time() < deadline:
+            if game_state() == "Lobby" and len(command("getComputerWormList")) < bots:
+                command("addBots %d" % bots)
+            if len(command("getComputerWormList")) >= bots:
                 break
-            time.sleep(0.2)
-        time.sleep(0.5)
-        command("addBots %d" % bots)
+            time.sleep(0.3)
+        joined = len(command("getComputerWormList"))
+        if joined < bots:
+            emit("SERVER_ERROR only %d/%d bots joined (state=%s)"
+                 % (joined, bots, game_state()))
+            raise SystemExit("could not add %d bots" % bots)
         emit("SERVER_ADDBOTS %d" % bots)
 
     emit_state = os.environ.get("OLX_EMIT_STATE")

--- a/tests/headless/control/server_control.py
+++ b/tests/headless/control/server_control.py
@@ -59,24 +59,22 @@ def main():
     # Optional bots, so a round can actually be played out with no human input.
     bots = int(os.environ.get("OLX_BOTS", "0"))
     if bots > 0:
-        # addBots needs the server's own local client, which is not ready the
-        # instant the lobby comes up: called too early it logs
-        # "localClient not found" and silently adds nothing. So wait for the
-        # lobby, then add the bots and confirm they actually appeared
-        # (getComputerWormList counts only bots), retrying while the local
-        # client is still coming up. Give up loudly rather than starting a
-        # broken round.
+        # addBots adds nothing ("localClient not found") if the server's own
+        # local client is not ready yet, and it returns the ids of the bots it
+        # actually added (empty on failure). So retry until they are all in,
+        # but always ask only for the ones still missing -- that way a retry
+        # can never add too many, regardless of any delay. Give up loudly
+        # rather than starting a broken round.
+        added = set()
         deadline = time.time() + 15
-        while time.time() < deadline:
-            if game_state() == "Lobby" and len(command("getComputerWormList")) < bots:
-                command("addBots %d" % bots)
-            if len(command("getComputerWormList")) >= bots:
-                break
-            time.sleep(0.3)
-        joined = len(command("getComputerWormList"))
-        if joined < bots:
+        while len(added) < bots and time.time() < deadline:
+            if game_state() == "Lobby":
+                added.update(command("addBots %d" % (bots - len(added))))
+            if len(added) < bots:
+                time.sleep(0.3)
+        if len(added) < bots:
             emit("SERVER_ERROR only %d/%d bots joined (state=%s)"
-                 % (joined, bots, game_state()))
+                 % (len(added), bots, game_state()))
             raise SystemExit("could not add %d bots" % bots)
         emit("SERVER_ADDBOTS %d" % bots)
 

--- a/tests/headless/test_gameplay.py
+++ b/tests/headless/test_gameplay.py
@@ -1,0 +1,92 @@
+"""Headless gameplay test: bots play a real round, and the state syncs to a client.
+
+The other tests only cover the lobby and join/leave. This one plays an actual
+round with no human input: the server adds bots that move, shoot, damage each
+other, die and respawn. A separate client connects and reports its own view of
+every worm, which must match what the server produced. That exercises in-game
+state replication (health, kills, damage), which a real multiplayer session
+depends on, rather than just the lobby handshake.
+
+The simulation is not deterministic (bot AI and frame timing vary), so the
+assertions check properties and a tolerance, not exact values: combat happened,
+a worm died and respawned, the client saw the same combat and a death, and its
+damage numbers track the server's.
+"""
+
+import re
+
+
+def _states(log, prefix):
+    """Yield (worm_id, hp, kills, dmg) for each ``<prefix> STATE`` marker in *log*."""
+    pat = re.compile(
+        re.escape(prefix) + r" STATE id=(\d+) hp=(\S+) kills=(\d+) dmg=(\S+)")
+    for line in log.splitlines():
+        m = pat.search(line)
+        if m:
+            yield m.group(1), float(m.group(2)), int(m.group(3)), float(m.group(4))
+
+
+def _max_damage(log, prefix):
+    out = {}
+    for wid, _hp, _kills, dmg in _states(log, prefix):
+        out[wid] = max(out.get(wid, 0.0), dmg)
+    return out
+
+
+def _deaths(log, prefix):
+    """The set of worm ids ever seen dead (hp < 0) in *log*."""
+    return {wid for wid, hp, _k, _d in _states(log, prefix) if hp < 0}
+
+
+def test_bots_play_a_round_and_state_syncs_to_a_client(network_game):
+    server = network_game.start_server(
+        OLX_BOTS=3,              # three bots so combat is lively and reliable
+        OLX_EMIT_STATE=1,        # report every worm's state each poll
+        OLX_START_WHEN_WORMS=4,  # start once the three bots and the client are in
+        OLX_RUN_SECONDS=90,
+    )
+    assert server.wait_for("SERVER_LOBBY", timeout=30), server.read_log()
+
+    client = network_game.add_client(
+        "c1", env={"OLX_EMIT_STATE": "1", "OLX_RUN_SECONDS": "90"})
+
+    # The round starts with the client in it.
+    assert server.wait_for("SERVER_PLAYING", timeout=45), (
+        "server never started the round:\n" + server.read_log())
+    assert client.wait_for("CLIENT[c1] PLAYING", timeout=30), (
+        "client never joined the round:\n" + client.read_log())
+
+    # A real round plays out on the server: the bots fight, and a worm dies and
+    # respawns (so the whole life cycle, not just a first hit, is exercised).
+    assert server.wait_for("SERVER_COMBAT", timeout=60), (
+        "no combat happened on the server:\n" + server.read_log())
+    assert server.wait_for("SERVER_RESPAWN", timeout=60), (
+        "no worm died and respawned:\n" + server.read_log())
+
+    # The client's own replicated view shows the same combat: state syncs.
+    assert client.wait_for("CLIENT[c1] COMBAT", timeout=30), (
+        "client never observed the combat the server produced:\n" + client.read_log())
+
+    srv_log, cli_log = server.read_log(), client.read_log()
+
+    # A death is a discrete, unambiguous event that must replicate:
+    # at least one worm the server saw die was also seen dead by the client.
+    srv_deaths = _deaths(srv_log, "SERVER")
+    cli_deaths = _deaths(cli_log, "CLIENT[c1]")
+    assert srv_deaths, "no worm died on the server:\n" + srv_log
+    assert srv_deaths & cli_deaths, (
+        "client did not observe any of the server's deaths: server=%s client=%s"
+        % (sorted(srv_deaths), sorted(cli_deaths)))
+
+    # And the numbers agree: for each worm the server saw take real damage, the
+    # client independently saw it take a comparable amount (allowing for a little
+    # replication lag), rather than a stale or empty view.
+    srv_dmg = _max_damage(srv_log, "SERVER")
+    cli_dmg = _max_damage(cli_log, "CLIENT[c1]")
+    fought = {wid: d for wid, d in srv_dmg.items() if d > 30}
+    assert fought, "server never recorded meaningful damage:\n" + srv_log
+    for wid, sd in fought.items():
+        cd = cli_dmg.get(wid, 0.0)
+        assert cd >= 0.5 * sd, (
+            "client's damage for worm %s (%g) does not track the server's (%g):\n%s"
+            % (wid, cd, sd, cli_log))


### PR DESCRIPTION
Adds a headless test that plays a real round with bots and checks that
in-game state replicates to a connected client, going beyond the existing
lobby/join tests.

## What it does

- The server adds bots (`OLX_BOTS`) that move, shoot, damage each other,
  die and respawn with no human input, so a full round plays out headlessly.
  They can optionally be clustered at one spot (`OLX_SPAWN_CLOSE`) for prompt
  combat.
- The server and a connected client each report every worm's state
  (`OLX_EMIT_STATE`): health, kills and damage.
- The test asserts a real round happened (combat, plus a death and a
  respawn) and that the client's view matches the server's: it observed the
  same combat and a death, and its damage numbers track the server's within
  tolerance.

## The one code change

`getWormPos`, `getWormVelocity`, `getWormHealth` and `getWormScore` only read
a worm's already-replicated state, but they went through `CheckWorm`, which
refuses to run on a client, so a client could not be queried for the state it
already has. This adds a client-allowed lookup for those four readers
(mutators and connection-level getters stay server-only), which is what lets
the test compare the two sides. Same idea as the earlier #979 change that made
`getWormList` client-side.

## Notes

- The simulation is not deterministic (bot AI and frame timing vary), so the
  test checks properties and a tolerance, not exact values.
- Runs in ~35s; the existing headless suite still passes.
