### PR TITLE
Fix out-of-bounds read in ParseGetChallenge

### DIFF
--- a/src/server/CServer_Parse.cpp
+++ b/src/server/CServer_Parse.cpp
@@ -1106,8 +1106,10 @@ void GameServer::ParseGetChallenge(const SmartPointer<NetworkSocket>& tSocket, C
 	// The loop above always selects a slot, so ChallengeToSet is >= 0 here.
 	// Guard anyway, so tChallenges[i] below can never be indexed out of
 	// bounds (with i == MAX_CHALLENGES) should that ever change.
-	if (ChallengeToSet < 0)
+	if (ChallengeToSet < 0) {
+		errors << "GameServer::ParseGetChallenge: no challenge slot selected" << endl;
 		return;
+	}
 
 	// overwrite the oldest
 	tChallenges[ChallengeToSet].iNum = (rand() << 16) ^ rand();

--- a/src/server/CServer_Parse.cpp
+++ b/src/server/CServer_Parse.cpp
@@ -1085,8 +1085,14 @@ void GameServer::ParseGetChallenge(const SmartPointer<NetworkSocket>& tSocket, C
 	for (i = 0;i < MAX_CHALLENGES;i++) {
 
 		if (IsNetAddrValid(tChallenges[i].Address)) {
-			if (AreNetAddrEqual(adrFrom, tChallenges[i].Address))
-				continue;
+			if (AreNetAddrEqual(adrFrom, tChallenges[i].Address)) {
+				// We already have a challenge for this address, reuse the slot.
+				// (Skipping it instead would, once every slot holds this address,
+				// leave ChallengeToSet at -1 and i at MAX_CHALLENGES,
+				// so the tChallenges[i] read below would be out of bounds.)
+				ChallengeToSet = i;
+				break;
+			}
 			if (ChallengeToSet < 0 || tChallenges[i].fTime < OldestTime) {
 				OldestTime = tChallenges[i].fTime;
 				ChallengeToSet = i;

--- a/src/server/CServer_Parse.cpp
+++ b/src/server/CServer_Parse.cpp
@@ -1024,7 +1024,6 @@ void GameServer::ParseConnectionlessPacket(const SmartPointer<NetworkSocket>& tS
 ///////////////////
 // Handle a "getchallenge" msg
 void GameServer::ParseGetChallenge(const SmartPointer<NetworkSocket>& tSocket, CBytestream *bs_in) {
-	int			i;
 	NetworkAddr	adrFrom;
 	AbsTime		OldestTime = AbsTime::Max();
 	int			ChallengeToSet = -1;
@@ -1082,14 +1081,13 @@ void GameServer::ParseGetChallenge(const SmartPointer<NetworkSocket>& tSocket, C
 	}
 	
 	// see if we already have a challenge for this ip
-	for (i = 0;i < MAX_CHALLENGES;i++) {
+	for (int i = 0;i < MAX_CHALLENGES;i++) {
 
 		if (IsNetAddrValid(tChallenges[i].Address)) {
 			if (AreNetAddrEqual(adrFrom, tChallenges[i].Address)) {
 				// We already have a challenge for this address, reuse the slot.
 				// (Skipping it instead would, once every slot holds this address,
-				// leave ChallengeToSet at -1 and i at MAX_CHALLENGES,
-				// so the tChallenges[i] read below would be out of bounds.)
+				// leave ChallengeToSet at -1, i.e. no slot selected.)
 				ChallengeToSet = i;
 				break;
 			}
@@ -1104,8 +1102,8 @@ void GameServer::ParseGetChallenge(const SmartPointer<NetworkSocket>& tSocket, C
 	}
 
 	// The loop above always selects a slot, so ChallengeToSet is >= 0 here.
-	// Guard anyway, so tChallenges[i] below can never be indexed out of
-	// bounds (with i == MAX_CHALLENGES) should that ever change.
+	// Guard anyway, so the tChallenges[ChallengeToSet] accesses below never
+	// use an invalid index should that ever change.
 	if (ChallengeToSet < 0) {
 		errors << "GameServer::ParseGetChallenge: no challenge slot selected" << endl;
 		return;
@@ -1117,8 +1115,6 @@ void GameServer::ParseGetChallenge(const SmartPointer<NetworkSocket>& tSocket, C
 	tChallenges[ChallengeToSet].fTime = tLX->currentTime;
 	tChallenges[ChallengeToSet].sClientVersion = client_version;
 
-	i = ChallengeToSet;
-
 	// Send the challenge details back to the client
 	tSocket->setRemoteAddress(adrFrom);
 
@@ -1126,7 +1122,7 @@ void GameServer::ParseGetChallenge(const SmartPointer<NetworkSocket>& tSocket, C
 	// TODO: move this out here
 	bs.writeInt(-1, 4);
 	bs.writeString("lx::challenge");
-	bs.writeInt(tChallenges[i].iNum, 4);
+	bs.writeInt(tChallenges[ChallengeToSet].iNum, 4);
 	if( client_version != "" )
 		bs.writeString(GetFullGameName());
 	bs.Send(tSocket.get());

--- a/src/server/CServer_Parse.cpp
+++ b/src/server/CServer_Parse.cpp
@@ -1103,16 +1103,19 @@ void GameServer::ParseGetChallenge(const SmartPointer<NetworkSocket>& tSocket, C
 		}
 	}
 
-	if (ChallengeToSet >= 0) {
+	// The loop above always selects a slot, so ChallengeToSet is >= 0 here.
+	// Guard anyway, so tChallenges[i] below can never be indexed out of
+	// bounds (with i == MAX_CHALLENGES) should that ever change.
+	if (ChallengeToSet < 0)
+		return;
 
-		// overwrite the oldest
-		tChallenges[ChallengeToSet].iNum = (rand() << 16) ^ rand();
-		tChallenges[ChallengeToSet].Address = adrFrom;
-		tChallenges[ChallengeToSet].fTime = tLX->currentTime;
-		tChallenges[ChallengeToSet].sClientVersion = client_version;
+	// overwrite the oldest
+	tChallenges[ChallengeToSet].iNum = (rand() << 16) ^ rand();
+	tChallenges[ChallengeToSet].Address = adrFrom;
+	tChallenges[ChallengeToSet].fTime = tLX->currentTime;
+	tChallenges[ChallengeToSet].sClientVersion = client_version;
 
-		i = ChallengeToSet;
-	}
+	i = ChallengeToSet;
 
 	// Send the challenge details back to the client
 	tSocket->setRemoteAddress(adrFrom);


### PR DESCRIPTION
Fixes #999.

`GameServer::ParseGetChallenge` reads `tChallenges[i]` after a loop that, when every one of the `MAX_CHALLENGES` (1024) slots already holds the requester's address, `continue`s over all of them -- leaving `ChallengeToSet == -1` and `i == MAX_CHALLENGES`. The `if (ChallengeToSet >= 0)` block is then skipped (so `i` is not reset), and `bs.writeInt(tChallenges[i].iNum, 4)` reads `tChallenges[1024]`, one element past the array end, leaking 4 bytes of adjacent memory back to the remote peer.

Reachable by sending 1024 `lx::getchallenge` packets from one UDP source (filling every slot with that address), then a 1025th to trigger the read. Unauthenticated and connectionless.

**Fix:** when a slot already matches the requester's address, reuse it (`ChallengeToSet = i; break;`) instead of skipping it. This is what the loop's own comment describes ("see if we already have a challenge for this ip"), guarantees `ChallengeToSet >= 0` (so the index is always valid), and additionally stops one address from occupying all 1024 slots.

### Verification
- GCC and clang builds are clean; the full headless suite passes (its network tests connect through the getchallenge path).
- No behavioural reproducing test: the project's harness is process-level and the bug is a silent OOB *read* (no crash without a sanitizer, and the harness can't inject 1025 raw connectionless packets). Verified by code reasoning + build + regression. Happy to add an ASan build + raw-packet test harness as a separate change if wanted.
