### PR TITLE
Bounds-check CBytestream::Skip and readData

### DIFF
--- a/src/common/CBytestream.cpp
+++ b/src/common/CBytestream.cpp
@@ -583,6 +583,10 @@ bool CBytestream::readBit()
 // Get data from the bytestream
 std::string CBytestream::readData( size_t size )
 {
+	// Nothing left, and guards against pos being at/past the end:
+	// otherwise GetLength() - pos underflows and substr throws.
+	if( pos >= GetLength() )
+		return "";
 	size = MIN( size, GetLength() - pos );
 	size_t oldpos = pos;
 	pos += size;
@@ -671,7 +675,9 @@ bool CBytestream::SkipString() {
 }
 
 bool CBytestream::Skip(size_t num) {
-	pos += num;
+	// Clamp to the end so pos never runs past the buffer
+	// (readData and others rely on pos <= GetLength()).
+	pos = MIN( pos + num, GetLength() );
 	return isPosAtEnd();
 }
 


### PR DESCRIPTION
Fixes #1000.

`CBytestream::Skip` advanced `pos` with no bounds check (`pos += num`), so a skip past the end -- reachable with attacker-controlled sizes, e.g. the reliable-channel `bs->Skip(seqSizeList[f])` in `CChannel` -- could leave `pos > Data.size()`. `readData` then computed `MIN(size, GetLength() - pos)`, where `GetLength() - pos` **underflows** (both `size_t`), and `Data.substr(oldpos, ...)` with `oldpos > size()` threw `std::out_of_range`. Packet parsing doesn't catch that, so a crafted packet could crash the process.

The byte-level reads (`readByte` and everything built on it) already guard with `isPosAtEnd()`; `Skip`/`readData` were the gap.

**Fix:**
- `Skip` clamps to the end (`pos = MIN(pos + num, GetLength())`), keeping the `pos <= size` invariant everything else assumes.
- `readData` returns empty when already at/past the end (which also makes it robust on its own, independent of `Skip`).

### Verification
- GCC and clang builds are clean; the full headless suite passes (all network traffic flows through `CBytestream`, so it's a broad regression check on `Skip`/`readData`).
- No behavioural reproducing test: triggering it needs a crafted malformed reliable packet, which the process-level headless harness can't inject, and the project has no C++ unit-test target for `CBytestream`. Verified by code reasoning + build + regression.
