### PR TITLE
Recommend plain git over git -C in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,12 @@ To keep commands auto-approved, write them plain and literal:
   run separate commands, or issue parallel tool calls.
 - Don't combine `cd` with a write in one compound command
   (`cd dir && git commit ...`);
-  the working directory already persists between calls,
-  so use an absolute path or `git -C <dir> ...`.
+  the working directory already persists between calls
+  and is the repo, so just run plain `git ...` there.
+  Avoid `git -C <dir>`:
+  read-only auto-approval and `git <subcommand>` allowlist entries
+  match only a plain leading `git <subcommand>`,
+  so `git -C <dir> <subcommand>` falls back to a prompt every time.
 - Don't use `find -exec`;
   list with `find`, then act in a separate step.
 - Don't pass a shell script as a quoted string (`sh -c "..."`).


### PR DESCRIPTION
The "Running shell commands" section (added in #988) advised agents to use `git -C <dir>` to avoid a `cd`-with-write permission prompt. In practice that advice is counter-productive: it defeats the permission tooling.

- The built-in read-only auto-approval (which lets `git log`/`git show`/`git diff`/`git status` run without a prompt) keys off the command starting with a plain `git <subcommand>`; it does not skip a `-C <path>` prefix.
- Allowlist entries are command-prefix matches, so `Bash(git commit *)` matches `git commit ...` but not `git -C /path commit ...`.

So every `git -C <dir> <subcommand>` falls back to a manual confirmation prompt, even for read-only commands. Since the working directory is already the repo and persists between calls, plain `git ...` is simpler and prompt-free.

This updates the note to recommend plain `git` and explain why `git -C` should be avoided. `CLAUDE.md` imports `AGENTS.md`, so the corrected guidance loads automatically in Claude Code sessions.
