### PR TITLE
Add C++ unit-test target olx_tests and CI job

### DIFF
--- a/.github/workflows/headless-tests.yml
+++ b/.github/workflows/headless-tests.yml
@@ -34,3 +34,30 @@ jobs:
 
       - name: Run headless tests
         run: python3 -m pytest tests/headless -v
+
+  unit:
+    name: Unit tests (Linux)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: |
+          # Drop broken pre-installed third-party apt repos (microsoft/azure); we don't use them.
+          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure*
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake build-essential \
+            libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev \
+            libxml2-dev libgd-dev zlib1g-dev libzip-dev libx11-dev \
+            libcurl4-openssl-dev libboost-dev libopenal-dev libalut-dev \
+            libvorbis-dev libyaml-cpp-dev binutils-dev libiberty-dev
+
+      - name: Build unit tests
+        run: |
+          cmake -S . -B build-tests -DCMAKE_BUILD_TYPE=Release -DHAWKNL_BUILTIN=Yes -DOLX_TESTS=Yes
+          cmake --build build-tests --target olx_tests -j$(nproc)
+
+      - name: Run unit tests
+        run: ./build-tests/bin/olx_tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,3 +42,20 @@ IF(PCH)
 	ADD_PRECOMPILED_HEADER(openlierox ${OLXROOTDIR}/include/PrecompiledHeader.hpp 1)
 ENDIF(PCH)
 
+# Dedicated unit-test executable, built only with -DOLX_TESTS=Yes.
+# It links the whole engine (its main() disabled via the OLX_UNITTEST
+# define) plus the tests/unit sources, which provide their own main(),
+# so a test can exercise any engine class directly.
+IF(OLX_TESTS)
+	INCLUDE_DIRECTORIES(${OLXROOTDIR}/tests/unit)
+	ADD_EXECUTABLE(olx_tests
+		${OLXROOTDIR}/tests/unit/test_main.cpp
+		${OLXROOTDIR}/tests/unit/test_CBytestream.cpp
+		${ALL_SRCS} ${OLX_WIN_RESOURCES})
+	SET_TARGET_PROPERTIES(olx_tests PROPERTIES
+		RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+		OUTPUT_NAME olx_tests
+		COMPILE_DEFINITIONS "OLX_UNITTEST")
+	TARGET_LINK_LIBRARIES(olx_tests ${LIBS})
+ENDIF(OLX_TESTS)
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -195,7 +195,9 @@ static bool afterCrashInformedUser = false;
 
 extern "C" int real_main(int argc, char *argv[]);
 
-#if !defined(__APPLE__) || defined(OLX_USE_STD_MAIN)
+// OLX_UNITTEST is defined for the olx_tests target, whose main() lives in
+// tests/unit/test_main.cpp; disable this one there to avoid two main()s.
+#if (!defined(__APPLE__) || defined(OLX_USE_STD_MAIN)) && !defined(OLX_UNITTEST)
 int main(int argc, char *argv[]) {
 	return real_main(argc, argv);
 }

--- a/tests/unit/test_CBytestream.cpp
+++ b/tests/unit/test_CBytestream.cpp
@@ -1,0 +1,42 @@
+/*
+ *  Unit tests for CBytestream, the network byte-buffer reader/writer.
+ */
+
+#include "unittest.h"
+#include "CBytestream.h"
+
+void test_CBytestream() {
+	// Regression for the Skip/readData underflow (#1000):
+	// skipping past the end must keep the read position in bounds,
+	// so readData clamps instead of underflowing and throwing.
+	{
+		CBytestream bs;
+		bs.writeByte(1);
+		bs.writeByte(2);
+		bs.Skip(1000);                  // far past the two written bytes
+		CHECK(bs.readData(10) == "");   // must return empty, not throw
+		CHECK(bs.readByte() == 0);      // reading past the end yields 0
+	}
+
+	// Truncated reads: past the end, primitive reads return zero.
+	{
+		CBytestream bs;
+		bs.writeByte(42);
+		bs.ResetPosToBegin();
+		CHECK(bs.readByte() == 42);
+		CHECK(bs.readByte() == 0);      // nothing left
+		CHECK(bs.readInt(4) == 0);
+	}
+
+	// Basic write/read round-trip.
+	{
+		CBytestream bs;
+		bs.writeInt(0x12345678, 4);
+		bs.writeInt16(-1234);
+		bs.writeString("hello");
+		bs.ResetPosToBegin();
+		CHECK(bs.readInt(4) == 0x12345678);
+		CHECK(bs.readInt16() == -1234);
+		CHECK(bs.readString() == "hello");
+	}
+}

--- a/tests/unit/test_CBytestream.cpp
+++ b/tests/unit/test_CBytestream.cpp
@@ -6,16 +6,18 @@
 #include "CBytestream.h"
 
 void test_CBytestream() {
-	// Regression for the Skip/readData underflow (#1000):
-	// skipping past the end must keep the read position in bounds,
-	// so readData clamps instead of underflowing and throwing.
+	// Regression for the Skip/readData underflow (#1000, fixed in #1002):
+	// skipping past the end must keep the read position in bounds, so
+	// readData clamps instead of underflowing GetLength()-pos and throwing.
 	{
 		CBytestream bs;
 		bs.writeByte(1);
 		bs.writeByte(2);
-		bs.Skip(1000);                  // far past the two written bytes
-		CHECK(bs.readData(10) == "");   // must return empty, not throw
-		CHECK(bs.readByte() == 0);      // reading past the end yields 0
+		bs.Skip(1000);                          // far past the two written bytes
+		std::string data = "unset";
+		CHECK_NOTHROW(data = bs.readData(10));  // must not throw
+		CHECK(data == "");                      // and returns empty
+		CHECK(bs.readByte() == 0);              // reading past the end yields 0
 	}
 
 	// Truncated reads: past the end, primitive reads return zero.

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -1,0 +1,34 @@
+/*
+ *  Entry point for the olx_tests unit-test executable.
+ *
+ *  This target links the whole engine (with its own main() disabled via
+ *  OLX_UNITTEST) plus the tests/unit sources, so tests can exercise any
+ *  engine class directly. Add a new test by writing a `void test_Foo();`
+ *  function in a test_*.cpp file and calling it from main() below.
+ */
+
+#include "unittest.h"
+#include <cstdio>
+
+int g_olxTestFailures = 0;
+
+void olxCheckFailed(const char* expr, const char* file, int line) {
+	++g_olxTestFailures;
+	printf("  CHECK failed: %s  (%s:%d)\n", expr, file, line);
+}
+
+// Test entry points, defined in the test_*.cpp files.
+void test_CBytestream();
+
+int main() {
+	printf("Running OLX unit tests...\n");
+
+	test_CBytestream();
+
+	if(g_olxTestFailures) {
+		printf("FAILED: %d check(s)\n", g_olxTestFailures);
+		return 1;
+	}
+	printf("OK: all unit tests passed\n");
+	return 0;
+}

--- a/tests/unit/unittest.h
+++ b/tests/unit/unittest.h
@@ -15,4 +15,10 @@ void olxCheckFailed(const char* expr, const char* file, int line);
 
 #define CHECK(cond) do { if(!(cond)) olxCheckFailed(#cond, __FILE__, __LINE__); } while(0)
 
+// Passes iff evaluating expr does not throw; records a failure if it does.
+#define CHECK_NOTHROW(expr) do { \
+	try { (void)(expr); } \
+	catch(...) { olxCheckFailed("must not throw: " #expr, __FILE__, __LINE__); } \
+} while(0)
+
 #endif // OLX_UNITTEST_H

--- a/tests/unit/unittest.h
+++ b/tests/unit/unittest.h
@@ -1,0 +1,18 @@
+/*
+ *  Minimal unit-test helpers for the olx_tests target.
+ *
+ *  A test is a plain `void test_Foo();` function;
+ *  call it from tests/unit/test_main.cpp and use CHECK(cond) for assertions.
+ *  A failing CHECK is recorded and printed but does not abort the run,
+ *  so one test failing still lets the others run.
+ */
+
+#ifndef OLX_UNITTEST_H
+#define OLX_UNITTEST_H
+
+extern int g_olxTestFailures;
+void olxCheckFailed(const char* expr, const char* file, int line);
+
+#define CHECK(cond) do { if(!(cond)) olxCheckFailed(#cond, __FILE__, __LINE__); } while(0)
+
+#endif // OLX_UNITTEST_H


### PR DESCRIPTION
Adds a dedicated C++ unit-test target, `olx_tests`, and a CI job to run it.

Until now the only automated tests were the process-level headless suite (`tests/headless/`), which can't reach a low-level class like `CBytestream`. That's why #1002 (the `Skip`/`readData` past-the-end underflow) couldn't ship with a reproducing test.

### How it works
- `olx_tests` is built only with `-DOLX_TESTS=Yes`, so the normal `openlierox` build is untouched.
- It links the whole engine, with `main()` in `src/main.cpp` disabled via a new `OLX_UNITTEST` define, plus the `tests/unit/` sources, which provide their own `main()` and a tiny `CHECK()` helper (`unittest.h`). Linking the full engine avoids the dependency rabbit hole of isolating a single class.
- Adding a test = write a `void test_Foo();` in a `test_*.cpp` and call it from `tests/unit/test_main.cpp`.

### First tests
`tests/unit/test_CBytestream.cpp` covers `CBytestream`, including a regression for #1002: after `Skip()` past the end, `readData()` must return empty rather than underflow and throw, and reads past the end return 0.

### CI
A new **Unit tests (Linux)** job in `headless-tests.yml` builds and runs `olx_tests`. Since that workflow is `workflow_call`-ed by the release pipeline, the release gate now covers unit tests too.

### Verification
Built and run locally (clang): `olx_tests` links, static init/teardown of the full engine is clean, and all tests pass (exit 0). The normal `openlierox` target still builds unchanged with the `main()` guard.
