### PR TITLE
Deterministic physics test harness + gravity regression test

### DIFF
--- a/src/common/CWorm.cpp
+++ b/src/common/CWorm.cpp
@@ -193,6 +193,7 @@ CWorm::CWorm() :
 
 	// set all pointers to NULL
 	m_inputHandler = NULL;
+	m_forceInput = false;
 	cOwner = NULL;
 	m_type = NULL;
 	m_node = NULL;
@@ -463,12 +464,30 @@ void CWorm::getInput() {
 		return;
 	}
 	
+	if(m_forceInput) {
+		// Test hook: apply the fixed input instead of running the handler.
+		worm_state_t& ws = tState.write();
+		ws.bMove = m_forcedMove;
+		ws.bShoot = m_forcedShoot;
+		ws.bJump = m_forcedJump;
+		ws.bCarve = m_forcedCarve;
+		return;
+	}
+
 	if(!m_inputHandler) {
 		warnings << "CWorm::getInput: input handler not set for worm " << getName() << ", cannot get input" << endl;
 		return;
 	}
-	
+
 	m_inputHandler->getInput();
+}
+
+void CWorm::setForcedInput(bool move, bool shoot, bool jump, bool carve) {
+	m_forceInput = true;
+	m_forcedMove = move;
+	m_forcedShoot = shoot;
+	m_forcedJump = jump;
+	m_forcedCarve = carve;
 }
 
 void CWorm::clearInput() {

--- a/src/common/Command.cpp
+++ b/src/common/Command.cpp
@@ -2259,6 +2259,55 @@ void Cmd_getGameState::exec(CmdLineIntf* caller, const std::vector<std::string>&
 }
 
 
+// Test hooks for deterministic physics tests (see tests/headless/test_physics.py).
+
+COMMAND(getFrame, "get the current simulation frame (test hook)", "", 0, 0);
+void Cmd_getFrame::exec(CmdLineIntf* caller, const std::vector<std::string>& params) {
+	caller->pushReturnArg(to_string(game.serverFrame));
+}
+
+COMMAND(simSetSeed, "seed the random number generator (test hook)", "seed", 1, 1);
+void Cmd_simSetSeed::exec(CmdLineIntf* caller, const std::vector<std::string>& params) {
+	bool fail = false;
+	int seed = from_string<int>(params[0], fail);
+	if(fail) { printUsage(caller); return; }
+	srand((unsigned int)seed);
+}
+
+COMMAND(simStep, "advance the simulation by N fixed frames (test hook)", "[n]", 0, 1);
+void Cmd_simStep::exec(CmdLineIntf* caller, const std::vector<std::string>& params) {
+	int n = 1;
+	if(params.size() > 0) {
+		bool fail = false;
+		n = from_string<int>(params[0], fail);
+		if(fail || n < 0) { printUsage(caller); return; }
+	}
+	if(!game.manualStep) {
+		// From now on the simulation only advances when told to.
+		game.manualStep = true;
+		// Align the LX physics clock (~84 FPS) to the sim clock, so the first
+		// step does not run an extra sub-step depending on prior wall-clock timing.
+		if(cClient) cClient->fLastSimulationTime = game.simulationAbsTime();
+	}
+	game.manualStepBudget += n;
+}
+
+COMMAND(setWormInput, "force a worm's per-frame input (test hook)", "id move shoot jump carve", 5, 5);
+void Cmd_setWormInput::exec(CmdLineIntf* caller, const std::vector<std::string>& params) {
+	bool fail = false;
+	int id = from_string<int>(params[0], fail);
+	if(fail) { printUsage(caller); return; }
+	CWorm* w = CheckWorm(caller, id, name);
+	if(!w) return;
+	bool move  = from_string<bool>(params[1], fail);
+	bool shoot = from_string<bool>(params[2], fail);
+	bool jump  = from_string<bool>(params[3], fail);
+	bool carve = from_string<bool>(params[4], fail);
+	if(fail) { printUsage(caller); return; }
+	w->setForcedInput(move, shoot, jump, carve);
+}
+
+
 COMMAND(dumpGameState, "dump game state", "", 0, 0);
 void Cmd_dumpGameState::exec(CmdLineIntf* caller, const std::vector<std::string>& params) {
 	caller->writeMsg("GameState: " + Game::StateAsStr(game.state), CNC_DEV);

--- a/src/common/Command.cpp
+++ b/src/common/Command.cpp
@@ -2285,8 +2285,8 @@ void Cmd_simStep::exec(CmdLineIntf* caller, const std::vector<std::string>& para
 	if(!game.manualStep) {
 		// From now on the simulation only advances when told to.
 		game.manualStep = true;
-		// Align the LX physics clock (~84 FPS) to the sim clock, so the first
-		// step does not run an extra sub-step depending on prior wall-clock timing.
+		// Align the LX physics clock (~84 FPS) to the sim clock,
+		// so the first step does not run an extra sub-step depending on prior wall-clock timing.
 		if(cClient) cClient->fLastSimulationTime = game.simulationAbsTime();
 	}
 	game.manualStepBudget += n;

--- a/src/game/CWorm.h
+++ b/src/game/CWorm.h
@@ -191,8 +191,9 @@ protected:
 	CWormInputHandler* m_inputHandler;
 	bool            bPrepared;
 
-	// Test hook: when set, getInput() ignores the input handler (AI/keyboard)
-	// and applies this fixed input each frame, for deterministic physics tests.
+	// Test hook: when set,
+	// getInput() ignores the input handler (AI/keyboard) and applies this fixed input each frame,
+	// for deterministic physics tests.
 	bool            m_forceInput;
 	bool            m_forcedMove, m_forcedShoot, m_forcedJump, m_forcedCarve;
 

--- a/src/game/CWorm.h
+++ b/src/game/CWorm.h
@@ -191,6 +191,11 @@ protected:
 	CWormInputHandler* m_inputHandler;
 	bool            bPrepared;
 
+	// Test hook: when set, getInput() ignores the input handler (AI/keyboard)
+	// and applies this fixed input each frame, for deterministic physics tests.
+	bool            m_forceInput;
+	bool            m_forcedMove, m_forcedShoot, m_forcedJump, m_forcedCarve;
+
 public:
 	ATTR(CWorm, int32_t,	iTeam, 1, {serverside = true;})
 	ATTR(CWorm, std::string,	sName, 2, {serverside = false;})
@@ -405,6 +410,7 @@ public:
 
 
 	void		getInput();
+	void		setForcedInput(bool move, bool shoot, bool jump, bool carve);
 	void		clearInput();
 	void		initWeaponSelection();
 	void		doWeaponSelectionFrame(SDL_Surface * bmpDest, CViewport *v);

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -896,9 +896,9 @@ void Game::frameInner()
 				frameDt = TimeDiff(1);
 		}
 		
-		// In manual-step mode (test hook) the loop runs exactly manualStepBudget
-		// fixed frames instead of chasing the wall clock, so a test can advance
-		// the simulation by an exact number of frames.
+		// In manual-step mode (test hook) the loop runs exactly manualStepBudget fixed frames
+		// instead of chasing the wall clock,
+		// so a test can advance the simulation by an exact number of frames.
 		while(manualStep ? (manualStepBudget > 0) : (simulationTime < tLX->currentTime)) {
 
 			if(!manualStep && hasSeriousHighSimulationDelay()) {

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -80,6 +80,8 @@ Game::Game() {
 	thisRef.objId = 1;
 	m_isServer = false;
 	m_isLocalGame = false;
+	manualStep = false;
+	manualStepBudget = 0;
 	m_wpnRest = new CWpnRest();
 	gameStateUpdates = new GameStateUpdates;
 }
@@ -894,9 +896,12 @@ void Game::frameInner()
 				frameDt = TimeDiff(1);
 		}
 		
-		while(simulationTime < tLX->currentTime) {
+		// In manual-step mode (test hook) the loop runs exactly manualStepBudget
+		// fixed frames instead of chasing the wall clock, so a test can advance
+		// the simulation by an exact number of frames.
+		while(manualStep ? (manualStepBudget > 0) : (simulationTime < tLX->currentTime)) {
 
-			if(hasSeriousHighSimulationDelay()) {
+			if(!manualStep && hasSeriousHighSimulationDelay()) {
 				TimeDiff simDelay = simulationDelay();
 				if(simDelay > 0.5f)
 					warnings << "deltatime " << simDelay.seconds() << " is too high" << endl;
@@ -932,6 +937,7 @@ void Game::frameInner()
 			if(isServer())
 				cServer->Frame();
 
+			if(manualStep) manualStepBudget--;
 			simulationTime += frameDt;
 		}
 		tLX->fDeltaTime = tLX->fRealDeltaTime = curDeltaTime;

--- a/src/game/Game.h
+++ b/src/game/Game.h
@@ -115,6 +115,12 @@ public:
 	}
 	AbsTime simulationAbsTime() const { return simulationTime; }
 
+	// Test hook: when manualStep is on, the simulation advances only by
+	// manualStepBudget frames (added via the simStep command), decoupled from
+	// the wall clock, so physics tests are frame-exact and reproducible.
+	bool manualStep;
+	int manualStepBudget;
+
 	bool hasHighSimulationDelay();
 	bool hasSeriousHighSimulationDelay();
 

--- a/src/game/Game.h
+++ b/src/game/Game.h
@@ -115,9 +115,10 @@ public:
 	}
 	AbsTime simulationAbsTime() const { return simulationTime; }
 
-	// Test hook: when manualStep is on, the simulation advances only by
-	// manualStepBudget frames (added via the simStep command), decoupled from
-	// the wall clock, so physics tests are frame-exact and reproducible.
+	// Test hook: when manualStep is on,
+	// the simulation advances only by manualStepBudget frames (added via simStep),
+	// decoupled from the wall clock,
+	// so physics tests are frame-exact and reproducible.
 	bool manualStep;
 	int manualStepBudget;
 

--- a/tests/headless/README.md
+++ b/tests/headless/README.md
@@ -8,6 +8,8 @@ and run on a bare CI runner.
 - `test_network.py` — networked play between instances.
 - `test_gameplay.py` — bots play a real round (combat, death, respawn),
   and the in-game state (health, kills, damage) syncs to a connected client.
+- `test_physics.py` — deterministic, frame-exact physics regression
+  (drives the fixed-timestep sim frame by frame and checks a golden value).
 - `harness.py`, `conftest.py`, `control/` —
   helpers plus the Python 3 control scripts that drive each instance.
 

--- a/tests/headless/control/physics_control.py
+++ b/tests/headless/control/physics_control.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Control script for the deterministic physics tests.
+
+It sets up a single controlled worm and advances the simulation by an exact
+number of fixed frames, then reports the worm's state. The simulation uses a
+fixed timestep, and here it is driven frame by frame (``simStep``) with a fixed
+seed (``simSetSeed``) and forced input (``setWormInput``, so no non-deterministic
+bot AI runs), so the outcome is reproducible and a test can compare it against a
+golden value.
+
+Environment variables:
+
+====================  =========================================================
+``OLX_PHYS_SEED``     RNG seed (default 12345)
+``OLX_PHYS_SPAWN``    "x,y" to drop the worm at, in the air (default "456,212")
+``OLX_PHYS_INPUT``    forced input "move shoot jump carve" (default all false)
+``OLX_PHYS_STEPS``    number of fixed frames to advance (default 50)
+====================  =========================================================
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _olx_pipe import command, emit, game_state, worm_ids  # noqa: E402
+
+
+def main():
+    seed = os.environ.get("OLX_PHYS_SEED", "12345")
+    spawn = os.environ.get("OLX_PHYS_SPAWN", "456,212")
+    forced = os.environ.get("OLX_PHYS_INPUT", "false false false false")
+    steps = int(os.environ.get("OLX_PHYS_STEPS", "50"))
+
+    settings = {
+        "GameOptions.Network.RegisterServer": 0,
+        "GameOptions.Network.UseIpToCountry": 0,
+        "GameOptions.GameInfo.GameType": "Death Match",
+        "GameOptions.GameInfo.LevelName": "Dirt Level.lxl",
+        "GameOptions.GameInfo.ModName": "Classic",
+        "GameOptions.GameInfo.ForceRandomWeapons": 1,
+        "GameOptions.GameInfo.ImmediateStart": 1,
+        "GameOptions.GameInfo.AllowEmptyGames": 1,
+    }
+    for key, value in settings.items():
+        command('setvar %s "%s"' % (key, value))
+    command("startlobby 23400")
+
+    # One bot, purely so there is a worm object to control; its AI never runs
+    # because we force its input below.
+    added = set()
+    deadline = time.time() + 15
+    while len(added) < 1 and time.time() < deadline:
+        if game_state() == "Lobby":
+            added.update(command("addBots 1"))
+        if len(added) < 1:
+            time.sleep(0.3)
+    command("startgame")
+    for _ in range(60):
+        if game_state() == "Playing":
+            break
+        time.sleep(0.2)
+    if not worm_ids():
+        emit("PHYS_ERROR no worm")
+        return
+    wid = worm_ids()[0]
+
+    # Deterministic setup: fixed seed, freeze the sim (manual stepping only),
+    # force the worm's input, and drop it at a known point in the air.
+    command("simSetSeed " + seed)
+    command("simStep 0")
+    command("setWormInput %s %s" % (wid, forced))
+    command('spawnWorm %s "%s"' % (wid, spawn))
+
+    def frame():
+        return int(command("getFrame")[0])
+
+    def report(label):
+        pos = command("getWormPos %s" % wid)
+        vel = command("getWormVelocity %s" % wid)
+        emit("%s x=%s y=%s vx=%s vy=%s frame=%d"
+             % (label, pos[0], pos[1], vel[0], vel[1], frame()))
+
+    report("PHYS_INIT")
+    target = frame() + steps
+    command("simStep %d" % steps)
+    while frame() < target:  # wait until all steps are done
+        time.sleep(0.02)
+    report("PHYS_RESULT")
+
+
+main()

--- a/tests/headless/control/physics_control.py
+++ b/tests/headless/control/physics_control.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """Control script for the deterministic physics tests.
 
-It sets up a single controlled worm and advances the simulation by an exact
-number of fixed frames, then reports the worm's state. The simulation uses a
-fixed timestep, and here it is driven frame by frame (``simStep``) with a fixed
-seed (``simSetSeed``) and forced input (``setWormInput``, so no non-deterministic
-bot AI runs), so the outcome is reproducible and a test can compare it against a
-golden value.
+It sets up a single controlled worm,
+advances the simulation by an exact number of fixed frames,
+then reports the worm's state.
+The simulation uses a fixed timestep,
+and here it is driven frame by frame (``simStep``)
+with a fixed seed (``simSetSeed``)
+and forced input (``setWormInput``, so no non-deterministic bot AI runs),
+so the outcome is reproducible and a test can compare it against a golden value.
 
 Environment variables:
 
@@ -46,8 +48,10 @@ def main():
         command('setvar %s "%s"' % (key, value))
     command("startlobby 23400")
 
-    # One bot, purely so there is a worm object to control; its AI never runs
-    # because we force its input below.
+    # A bot, purely as a worm object to control:
+    # a dedicated server cannot add a human worm (addHuman is refused in
+    # dedicated mode), and setWormInput below bypasses the bot AI entirely,
+    # so the worm never acts on its own.
     added = set()
     deadline = time.time() + 15
     while len(added) < 1 and time.time() < deadline:

--- a/tests/headless/test_physics.py
+++ b/tests/headless/test_physics.py
@@ -1,0 +1,52 @@
+"""Deterministic physics regression tests.
+
+These pin down exact physics behaviour so a refactor of the physics code can be
+checked to still behave as before. The simulation runs at a fixed timestep, and
+the control script drives it frame by frame (``simStep``) with a fixed seed and
+forced worm input, so the outcome is reproducible. We then assert it against a
+golden value.
+
+If a change to the physics alters the outcome, this fails. If the change is
+intended, update the golden below; the failure message prints the actual values.
+
+The tolerance is small but non-zero, to absorb floating-point differences across
+compilers/CPUs while still catching any real behaviour change (a real change
+moves the worm by far more than a fraction of a pixel over many frames).
+"""
+
+import os
+import re
+
+from harness import OlxInstance, CONTROL_DIR
+
+PHYSICS_CONTROL = os.path.join(CONTROL_DIR, "physics_control.py")
+
+# Worm dropped at (456,212) on "Dirt Level.lxl", all-zero input, 50 fixed frames.
+GRAVITY_GOLDEN = {"x": 456.0, "y": 223.979, "vx": 0.0, "vy": 48.4}
+EPS_POS = 1.0
+EPS_VEL = 2.0
+
+
+def _parse_state(line):
+    return {k: float(v) for k, v in re.findall(r"(\w+)=(-?[\d.eE+]+)", line)}
+
+
+def _run_scenario(binary, home, env=None):
+    inst = OlxInstance(binary, "phys", home, PHYSICS_CONTROL, env=env).start()
+    try:
+        assert inst.wait_for("PHYS_RESULT", timeout=60), (
+            "physics scenario never finished:\n" + inst.read_log())
+        line = next(l for l in inst.read_log().splitlines()
+                    if l.startswith("PHYS_RESULT"))
+    finally:
+        inst.stop()
+    return _parse_state(line)
+
+
+def test_worm_falls_under_gravity(olx_binary, tmp_path):
+    got = _run_scenario(olx_binary, str(tmp_path / "phys"))
+    for key, eps in (("x", EPS_POS), ("y", EPS_POS), ("vx", EPS_VEL), ("vy", EPS_VEL)):
+        assert abs(got[key] - GRAVITY_GOLDEN[key]) <= eps, (
+            "physics changed: %s=%g, golden=%g (eps %g); full state %s.\n"
+            "If this change is intended, update GRAVITY_GOLDEN."
+            % (key, got[key], GRAVITY_GOLDEN[key], eps, got))

--- a/tests/headless/test_physics.py
+++ b/tests/headless/test_physics.py
@@ -1,17 +1,21 @@
 """Deterministic physics regression tests.
 
-These pin down exact physics behaviour so a refactor of the physics code can be
-checked to still behave as before. The simulation runs at a fixed timestep, and
-the control script drives it frame by frame (``simStep``) with a fixed seed and
-forced worm input, so the outcome is reproducible. We then assert it against a
-golden value.
+These pin down exact physics behaviour,
+so a refactor of the physics code can be checked to still behave as before.
+The simulation runs at a fixed timestep,
+and the control script drives it frame by frame (``simStep``)
+with a fixed seed and forced worm input,
+so the outcome is reproducible.
+We then assert it against a golden value.
 
-If a change to the physics alters the outcome, this fails. If the change is
-intended, update the golden below; the failure message prints the actual values.
+If a change to the physics alters the outcome, this fails.
+If the change is intended, update the golden below;
+the failure message prints the actual values.
 
-The tolerance is small but non-zero, to absorb floating-point differences across
-compilers/CPUs while still catching any real behaviour change (a real change
-moves the worm by far more than a fraction of a pixel over many frames).
+The tolerance is small but non-zero,
+to absorb floating-point differences across compilers/CPUs
+while still catching any real behaviour change
+(a real change moves the worm by far more than a fraction of a pixel over many frames).
 """
 
 import os


### PR DESCRIPTION
Adds a minimal harness for **deterministic, frame-exact physics regression
tests**, plus a first gravity test. The goal: refactor the physics code and be
sure it still behaves as before.

## Why it works

The simulation already runs at a fixed timestep (100 FPS game loop, ~84 FPS LX56
physics), so state at a given frame is a pure function of inputs and RNG. What
was missing to exploit that was frame-exact control, a fixed RNG seed, and
deterministic worm input. This adds those as hidden test-hook console commands
(same dedicated-control pipe the other headless tests use):

- `simStep <n>` — advance the sim by exactly n fixed frames, decoupled from the
  wall clock (a step budget on the existing catch-up loop). On entering
  manual-step mode it also aligns the LX56 physics clock to the sim clock, so
  stepping is reproducible (without that, the first step could do an extra
  sub-step depending on prior real-time timing).
- `simSetSeed <n>` — `srand(n)`, so RNG-driven behaviour repeats. (The global
  RNG is otherwise seeded from `time(NULL)`.)
- `setWormInput <id> move shoot jump carve` — force a worm's per-frame input,
  bypassing the bot AI, whose pathfinding runs on a worker thread and is not
  deterministic.
- `getFrame` — read the current simulation frame.

None of this changes normal play: `manualStep` and a worm's forced input both
default off, so the loop and input handling behave exactly as before unless a
test opts in.

## The test

`test_physics.py` drops a worm in the air at a fixed point with all-zero input,
steps 50 fixed frames, and asserts its position and velocity against a golden
within a small epsilon. Verified reproducible (identical across repeated runs
once the physics clock is aligned).

## Notes and next steps

- Epsilon, not exact equality, absorbs floating-point differences across
  compilers/CPUs; it's still far tighter than any real physics change over 50
  frames. The golden was recorded on the dev machine; if a build platform's FP
  differs, update it (the failure message prints the actual values).
- This is deliberately a first slice. The same harness extends to projectile
  trajectories, explosion craters (would want a `getPixelMaterial` reader),
  scripted-input movement, etc.
