### PR TITLE
Fix yoff computed from the X coordinate in CShootList

### DIFF
--- a/src/common/CShootList.cpp
+++ b/src/common/CShootList.cpp
@@ -323,7 +323,7 @@ void CShootList::writeSmallShot( shoot_t *psFirst, CBytestream *bs, const Versio
 
 
 	int xoff = (int)( psShot->cPos.x - psFirst->cPos.x );
-	int yoff = (int)( psShot->cPos.x - psFirst->cPos.x );
+	int yoff = (int)( psShot->cPos.y - psFirst->cPos.y );
 	xoff = abs(xoff);
 	yoff = abs(yoff);
 


### PR DESCRIPTION
## `CShootList`: `yoff` is computed from the X coordinate

In `CShootList::writeSmallShot` (`src/common/CShootList.cpp:326`):

```cpp
int xoff = (int)( psShot->cPos.x - psFirst->cPos.x );
int yoff = (int)( psShot->cPos.x - psFirst->cPos.x );   // copy-paste: should be cPos.y
```

`yoff` is derived from `cPos.x` instead of `cPos.y`, so it always equals `xoff`.

It is then used to decide `SHF_LARGEYOFF` (line 361) and to write the Y-offset value in both the large-offset path (`writeByte(yoff)`, line 402) and the small-offset path (`write2Int4(xoff, yoff)`, line 408). So in the multi-shot delta encoding (`writeMulti`), each secondary shot's transmitted **Y** offset is really its **X** offset.

### Impact
Projectiles from multi-shot weapons are placed at the wrong Y on the receiver (the Y delta of each shot relative to the first is replaced by its X delta). Sender-side only; not a memory-safety issue.

### Fix
One line: `cPos.x` -> `cPos.y` on line 326.

### Test
A clean round-trip unit test isn't easily feasible: the write side builds shots from live `CWorm`s via `addShoot`, the read dispatch lives in the client game code (there is no public "read packet" entry), and the shot array is private. So this is a straightforward typo fix verified by inspection and build.
