### PR TITLE
Bound gusanos olxParse packet loop by the stream end

### DIFF
--- a/src/gusanos/netstream.cpp
+++ b/src/gusanos/netstream.cpp
@@ -456,7 +456,9 @@ void Net_Control::olxParse(Net_ConnID src, CBytestream& bs) {
 	//size_t bsStart = bs.GetPos();
 	size_t len = readEliasGammaNr(bs) + 1;
 
-	for(size_t i = 0; i < len; ++i) {
+	// Stop once the packet is exhausted: a real package consumes bytes,
+	// so the attacker-controlled len can never exceed the bytes present.
+	for(size_t i = 0; i < len && !bs.isPosAtEnd(); ++i) {
 		intern->packetsReceived.push_back(NetControlIntern::DataPackage());
 		NetControlIntern::DataPackage& p = intern->packetsReceived.back();
 		p.read(this->intern, bs);
@@ -469,7 +471,8 @@ void Net_Control::olxParse(Net_ConnID src, CBytestream& bs) {
 static void olxParseWithFixedType(Net_Control* con, Net_ConnID src, CBytestream& bs, NetControlIntern::DataPackage::Type type) {
 	size_t len = readEliasGammaNr(bs) + 1;
 	
-	for(size_t i = 0; i < len; ++i) {
+	// Same bound as olxParse: stop once the packet is exhausted.
+	for(size_t i = 0; i < len && !bs.isPosAtEnd(); ++i) {
 		con->intern->packetsReceived.push_back(NetControlIntern::DataPackage());
 		NetControlIntern::DataPackage& p = con->intern->packetsReceived.back();
 		p.type = type;


### PR DESCRIPTION
## Remote memory-exhaustion DoS: unbounded packet count in gusanos `olxParse`

`Net_Control::olxParse` (`src/gusanos/netstream.cpp:455`) and `olxParseWithFixedType` (line 469) read a package count straight from the network and loop that many times with no bound relating it to the bytes actually present:

```cpp
size_t len = readEliasGammaNr(bs) + 1;       // attacker-controlled
for(size_t i = 0; i < len; ++i) {
    intern->packetsReceived.push_back(NetControlIntern::DataPackage());
    intern->packetsReceived.back().read(this->intern, bs);
    ...
}
```

`readEliasGammaNr` decodes an Elias-gamma value, so a handful of bytes can encode `len` up to ~2^31. When the stream is then exhausted, each `DataPackage::read` consumes 0 bytes and returns an empty package, but the loop still runs `len` times, `push_back`-ing a `DataPackage` each iteration -> unbounded allocation and a very long stall from a tiny packet.

### Reachability
Reached on the raw network bytestream in both directions:
- server parsing a client packet: `network.olxParse(NetConnID_conn(cl), *bs)` (`src/server/CServer_Parse.cpp:168`, and `olxParseUpdate` at 172);
- client parsing a server packet: `network.olxParse(NetConnID_server(), *bs)` (`src/client/CClient_Parse.cpp:643`, and `olxParseUpdate` at 651).

So a single malicious gusanos packet from a connected peer can exhaust memory / hang the dedicated server or a client.

### Severity
Medium: remote DoS (memory exhaustion / long stall), no memory corruption, requires being a connected peer.

### Fix
Stop the loop once the stream is exhausted, since a real package always consumes bytes and the count can never exceed the packet size:

```cpp
for(size_t i = 0; i < len && !bs.isPosAtEnd(); ++i) { ... }
```

in both `olxParse` and `olxParseWithFixedType`.
