### PR TITLE
WASM: explain isolation/file:// failures and ship a local server

### DIFF
--- a/build/wasm/WASM-PORT.md
+++ b/build/wasm/WASM-PORT.md
@@ -336,13 +336,15 @@ distrib/openlierox-wasm/
 ```
 
 To test a bundle locally, serve it over HTTP with the isolation headers
-(`python3 serve.py` inside the bundle, or double-click `run.command` on
-macOS), then open `http://localhost:8000/`. Opening `index.html` as a
-`file://` URL cannot work: the threaded build needs `SharedArrayBuffer`,
-which browsers only grant to cross-origin-isolated pages served over
-http(s) — and `file://` can carry no headers and can't register the COI
-service-worker shim either. The shell shows an explanatory message in
-that case (and when a page is served without the isolation headers)
+(`python3 serve.py` inside the bundle, or double-click `run.command` on macOS),
+then open `http://localhost:8000/`.
+Opening `index.html` as a `file://` URL cannot work:
+the threaded build needs `SharedArrayBuffer`,
+which browsers only grant to cross-origin-isolated pages served over http(s),
+and `file://` can carry no headers
+and can't register the COI service-worker shim either.
+The shell shows an explanatory message in that case
+(and when a page is served without the isolation headers),
 rather than the browser's opaque "Script error.".
 
 The bundle works on:

--- a/build/wasm/WASM-PORT.md
+++ b/build/wasm/WASM-PORT.md
@@ -330,8 +330,20 @@ distrib/openlierox-wasm/
 ├── icon-512.png
 ├── build-info.json         # version / commit / file list (provenance)
 ├── _headers                # Netlify / CF Pages headers
-└── .htaccess               # Apache headers + MIME types
+├── .htaccess               # Apache headers + MIME types
+├── serve.py                # local test server (sets COOP/COEP headers)
+└── run.command             # macOS double-click launcher for serve.py
 ```
+
+To test a bundle locally, serve it over HTTP with the isolation headers
+(`python3 serve.py` inside the bundle, or double-click `run.command` on
+macOS), then open `http://localhost:8000/`. Opening `index.html` as a
+`file://` URL cannot work: the threaded build needs `SharedArrayBuffer`,
+which browsers only grant to cross-origin-isolated pages served over
+http(s) — and `file://` can carry no headers and can't register the COI
+service-worker shim either. The shell shows an explanatory message in
+that case (and when a page is served without the isolation headers)
+rather than the browser's opaque "Script error.".
 
 The bundle works on:
 

--- a/build/wasm/build.sh
+++ b/build/wasm/build.sh
@@ -77,6 +77,21 @@ cp -f "$SHIM_SRC" "$DIST_DIR/coi-serviceworker.js"
     cp -f "$WASM_DIR/shell/coi-serviceworker.LICENSE" \
           "$DIST_DIR/coi-serviceworker.LICENSE"
 
+# Local-testing launcher. serve.py sets the COOP/COEP headers the threaded
+# build needs; a plain `python3 -m http.server` doesn't, and the engine then
+# hangs at startup with SharedArrayBuffer unavailable. run.command is a
+# double-clickable macOS wrapper that serves the bundle and opens a browser.
+cp -f "$WASM_DIR/serve.py" "$DIST_DIR/serve.py"
+cat > "$DIST_DIR/run.command" <<'EOF'
+#!/bin/sh
+# Double-click (macOS) to serve this OpenLieroX bundle locally with the
+# COOP/COEP headers the WebAssembly build requires, then open it in a browser.
+cd "$(dirname "$0")" || exit 1
+( sleep 1 && open "http://localhost:8000/" ) &
+exec python3 serve.py
+EOF
+chmod +x "$DIST_DIR/run.command"
+
 # PWA assets: web app manifest + icons referenced by the shell's <head>.
 # These make the bundle installable as a standalone web app out of the box
 # (the shell's "Install web app" button needs a manifest to get a real
@@ -156,7 +171,7 @@ json.dump({
         "index.html", "openlierox.js", "openlierox.wasm", "openlierox.data",
         "coi-serviceworker.js", "coi-serviceworker.LICENSE",
         "manifest.webmanifest", "icon-256.png", "icon-512.png",
-        "_headers", ".htaccess",
+        "_headers", ".htaccess", "serve.py", "run.command",
     ],
 }, open(sys.argv[1], "w"), indent=2)
 open(sys.argv[1], "a").write("\n")
@@ -181,3 +196,7 @@ echo "      Cross-Origin-Resource-Policy: same-origin"
 echo "  - Hosts without header config (GitHub Pages): coi-serviceworker.js"
 echo "    is wired into index.html and provides the headers client-side."
 echo "    First load triggers a one-time reload to activate the worker."
+echo
+echo "To test the bundle locally: run 'python3 serve.py' inside it (or"
+echo "double-click run.command on macOS), then open http://localhost:8000/."
+echo "Opening index.html as a file:// URL will not work."

--- a/build/wasm/build.sh
+++ b/build/wasm/build.sh
@@ -77,15 +77,18 @@ cp -f "$SHIM_SRC" "$DIST_DIR/coi-serviceworker.js"
     cp -f "$WASM_DIR/shell/coi-serviceworker.LICENSE" \
           "$DIST_DIR/coi-serviceworker.LICENSE"
 
-# Local-testing launcher. serve.py sets the COOP/COEP headers the threaded
-# build needs; a plain `python3 -m http.server` doesn't, and the engine then
-# hangs at startup with SharedArrayBuffer unavailable. run.command is a
-# double-clickable macOS wrapper that serves the bundle and opens a browser.
+# Local-testing launcher.
+# serve.py sets the COOP/COEP headers the threaded build needs;
+# a plain `python3 -m http.server` doesn't,
+# and the engine then hangs at startup with SharedArrayBuffer unavailable.
+# run.command is a double-clickable macOS wrapper
+# that serves the bundle and opens a browser.
 cp -f "$WASM_DIR/serve.py" "$DIST_DIR/serve.py"
 cat > "$DIST_DIR/run.command" <<'EOF'
 #!/bin/sh
-# Double-click (macOS) to serve this OpenLieroX bundle locally with the
-# COOP/COEP headers the WebAssembly build requires, then open it in a browser.
+# Double-click (macOS) to serve this OpenLieroX bundle locally
+# with the COOP/COEP headers the WebAssembly build requires,
+# then open it in a browser.
 cd "$(dirname "$0")" || exit 1
 ( sleep 1 && open "http://localhost:8000/" ) &
 exec python3 serve.py
@@ -197,6 +200,7 @@ echo "  - Hosts without header config (GitHub Pages): coi-serviceworker.js"
 echo "    is wired into index.html and provides the headers client-side."
 echo "    First load triggers a one-time reload to activate the worker."
 echo
-echo "To test the bundle locally: run 'python3 serve.py' inside it (or"
-echo "double-click run.command on macOS), then open http://localhost:8000/."
+echo "To test the bundle locally, run 'python3 serve.py' inside it"
+echo "(or double-click run.command on macOS),"
+echo "then open http://localhost:8000/."
 echo "Opening index.html as a file:// URL will not work."

--- a/build/wasm/serve.py
+++ b/build/wasm/serve.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 """Tiny static server for the OpenLieroX Wasm build.
 
-Serves build/wasm/output/ on http://localhost:8000 with:
+Serves the bundle on http://localhost:8000 with:
 - Correct MIME types for .wasm / .data / .js
 - Cross-Origin-Opener-Policy / Cross-Origin-Embedder-Policy headers,
   required by the -pthread build (SharedArrayBuffer).
+
+Serves build/wasm/output/ when run from the repo, or the directory it
+sits in when shipped inside a distributed bundle (next to index.html).
+Set OLX_WASM_ROOT to serve a different directory.
 
 Optional TLS, for testing on a phone over the LAN: SharedArrayBuffer
 needs a *secure context*, which over a LAN IP means HTTPS (localhost is
@@ -19,7 +23,16 @@ import os
 import ssl
 import sys
 
-ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "output")
+_HERE = os.path.dirname(os.path.abspath(__file__))
+# Serve the bundle directory. Inside a distributed bundle this script sits next
+# to index.html; in the repo it sits in build/wasm/ with the artefacts under
+# output/. An explicit OLX_WASM_ROOT wins over both.
+if os.environ.get("OLX_WASM_ROOT"):
+    ROOT = os.environ["OLX_WASM_ROOT"]
+elif os.path.isfile(os.path.join(_HERE, "index.html")):
+    ROOT = _HERE
+else:
+    ROOT = os.path.join(_HERE, "output")
 PORT = int(os.environ.get("PORT", "8000"))
 CERTFILE = os.environ.get("CERTFILE")
 KEYFILE = os.environ.get("KEYFILE")  # may be None if cert.pem also holds the key

--- a/build/wasm/serve.py
+++ b/build/wasm/serve.py
@@ -6,8 +6,9 @@ Serves the bundle on http://localhost:8000 with:
 - Cross-Origin-Opener-Policy / Cross-Origin-Embedder-Policy headers,
   required by the -pthread build (SharedArrayBuffer).
 
-Serves build/wasm/output/ when run from the repo, or the directory it
-sits in when shipped inside a distributed bundle (next to index.html).
+Serves build/wasm/output/ when run from the repo,
+or the directory it sits in when shipped inside a distributed bundle
+(next to index.html).
 Set OLX_WASM_ROOT to serve a different directory.
 
 Optional TLS, for testing on a phone over the LAN: SharedArrayBuffer
@@ -24,9 +25,10 @@ import ssl
 import sys
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
-# Serve the bundle directory. Inside a distributed bundle this script sits next
-# to index.html; in the repo it sits in build/wasm/ with the artefacts under
-# output/. An explicit OLX_WASM_ROOT wins over both.
+# Serve the bundle directory.
+# Inside a distributed bundle this script sits next to index.html;
+# in the repo it sits in build/wasm/ with the artefacts under output/.
+# An explicit OLX_WASM_ROOT wins over both.
 if os.environ.get("OLX_WASM_ROOT"):
     ROOT = os.environ["OLX_WASM_ROOT"]
 elif os.path.isfile(os.path.join(_HERE, "index.html")):

--- a/build/wasm/shell/shell.html
+++ b/build/wasm/shell/shell.html
@@ -110,8 +110,8 @@
     let loadingDone = false;
 
     // Set once an environment preflight has shown a fatal, actionable message
-    // (wrong URL scheme / no cross-origin isolation). When set, the engine's
-    // own status and error churn must not overwrite it.
+    // (wrong URL scheme, or no cross-origin isolation).
+    // When set, the engine's own status and error churn must not overwrite it.
     let preflightFailed = false;
     function showStarting() {
       if (loadingDone) return;
@@ -121,23 +121,25 @@
       statusEl.textContent = "Starting OpenLieroX…";
     }
 
-    // Startup watchdog. Once every asset has loaded (monitorRunDependencies
-    // reaches 0) the engine normally boots to the main menu within a few
-    // seconds and calls olxOnEngineReady(). If it never does, startup has most
-    // likely failed — a wasm abort or a failed thread spawn that surfaced no
-    // error — and the page would otherwise sit on "Starting OpenLieroX…"
-    // forever. Replace that dead-end with a message pointing at the console.
+    // Startup watchdog.
+    // Once every asset has loaded (monitorRunDependencies reaches 0),
+    // the engine normally boots to the main menu within a few seconds
+    // and calls olxOnEngineReady().
+    // If it never does, startup has most likely failed
+    // (a wasm abort, or a failed thread spawn that surfaced no error),
+    // and the page would otherwise sit on "Starting OpenLieroX…" forever.
+    // Replace that dead-end with a message pointing at the console.
     let startWatchdog = null;
     function armStartWatchdog() {
       if (startWatchdog !== null) return;
       startWatchdog = setTimeout(() => {
-        // Don't stomp a clearer message that already owns the status line (a
-        // preflight failure, an abort, or an engine error).
+        // Don't stomp a clearer message that already owns the status line
+        // (a preflight failure, an abort, or an engine error).
         if (preflightFailed || statusEl.classList.contains("err")) return;
         statusEl.style.display = "";
         statusEl.classList.add("err");
         statusEl.innerHTML =
-          "OpenLieroX hasn’t reached the menu — startup may have failed.<br>" +
+          "OpenLieroX hasn’t reached the menu; startup may have failed.<br>" +
           "Check the browser console (F12 / Developer Tools) for errors.";
       }, 30000);
     }
@@ -209,10 +211,12 @@
         statusEl.classList.remove("err");
       },
       monitorRunDependencies: (left) => {
-        // Backstop for the cached case where the byte counter may not emit a
-        // final x == y: once everything's resolved, show "Starting…". This is
-        // also the point where the wasm is instantiated and the thread pool is
-        // up, so it's when the boot-to-menu watchdog should start ticking.
+        // Backstop for the cached case
+        // where the byte counter may not emit a final x == y:
+        // once everything's resolved, show "Starting…".
+        // This is also the point where the wasm is instantiated
+        // and the thread pool is up,
+        // so it's when the boot-to-menu watchdog should start ticking.
         if (left === 0) { showStarting(); armStartWatchdog(); }
       },
       // Don't stream every "dependency: fp /xxx" or "(end of list)" line
@@ -228,29 +232,31 @@
     };
 
     // --- Environment preflight -------------------------------------------
-    // This is a threaded (-pthread) build: main() runs on a Web Worker and the
-    // engine can't start without SharedArrayBuffer, which browsers only expose
-    // to cross-origin-isolated pages served over http(s) with COOP/COEP
-    // headers. Opening this page as a file:// URL, or serving it without those
-    // headers, otherwise fails with an opaque "Script error." or just hangs at
-    // "Starting…". Detect both cases up front and explain what to do.
+    // This is a threaded (-pthread) build:
+    // main() runs on a Web Worker,
+    // and the engine can't start without SharedArrayBuffer,
+    // which browsers only expose to cross-origin-isolated pages
+    // served over http(s) with COOP/COEP headers.
+    // Opening this page as a file:// URL, or serving it without those headers,
+    // otherwise fails with an opaque "Script error." or just hangs at "Starting…".
+    // Detect both cases up front and explain what to do.
     const FATAL = {
       file:
-        "This WebAssembly build can’t run from a <code>file://</code> URL " +
-        "— it must be served over HTTP.<br>Use the bundled server: run " +
-        "<b>python3&nbsp;serve.py</b> in this folder,<br>then open the " +
-        "<b>http://localhost:8000/</b> URL it prints.",
+        "This WebAssembly build can’t run from a <code>file://</code> URL; " +
+        "it must be served over HTTP.<br>" +
+        "Use the bundled server: run <b>python3&nbsp;serve.py</b> in this folder,<br>" +
+        "then open the <b>http://localhost:8000/</b> URL it prints.",
       coi:
         "OpenLieroX can’t start: this page is not cross-origin isolated, " +
-        "so <b>SharedArrayBuffer</b> (required by the threaded build) is " +
-        "unavailable.<br>Serve it with the COOP/COEP headers — the bundled " +
-        "<b>python3&nbsp;serve.py</b> sets them for you.<br>(A plain " +
-        "<code>http.server</code> only works if <code>coi-serviceworker.js</code> " +
-        "is present and can register.)",
+        "so <b>SharedArrayBuffer</b> (required by the threaded build) is unavailable.<br>" +
+        "Serve it with the COOP/COEP headers; " +
+        "the bundled <b>python3&nbsp;serve.py</b> sets them for you.<br>" +
+        "(A plain <code>http.server</code> only works " +
+        "if <code>coi-serviceworker.js</code> is present and can register.)",
       script:
-        "OpenLieroX failed to load its engine files.<br>If you opened this as a " +
-        "<code>file://</code> URL, serve it over HTTP instead: run " +
-        "<b>python3&nbsp;serve.py</b> in this folder.",
+        "OpenLieroX failed to load its engine files.<br>" +
+        "If you opened this as a <code>file://</code> URL, " +
+        "serve it over HTTP instead: run <b>python3&nbsp;serve.py</b> in this folder.",
     };
     function showFatal(kind) {
       preflightFailed = true;
@@ -262,11 +268,12 @@
     if (location.protocol === "file:") {
       showFatal("file");
     } else if (!self.crossOriginIsolated) {
-      // Not isolated yet. The bundled coi-serviceworker.js shim can fix this on
-      // a header-less host, but only via a one-time reload — and that
-      // navigation tears down this timer. If we're still here and un-isolated
-      // after it's had time to act, isolation isn't coming: say so instead of
-      // hanging at "Starting…".
+      // Not isolated yet.
+      // The bundled coi-serviceworker.js shim can fix this on a header-less host,
+      // but only via a one-time reload,
+      // and that navigation tears down this timer.
+      // If we're still here and un-isolated after it's had time to act,
+      // isolation isn't coming: say so instead of hanging at "Starting…".
       setTimeout(() => {
         if (!self.crossOriginIsolated && !preflightFailed) showFatal("coi");
       }, 5000);
@@ -275,8 +282,9 @@
     Module.setStatus("Downloading…");
     window.onerror = (msg) => {
       if (preflightFailed) return;   // keep the clearer preflight message
-      // The browser scrubs cross-origin script errors down to a bare "Script
-      // error." with no detail — almost always a file:// / not-served page.
+      // The browser scrubs cross-origin script errors
+      // down to a bare "Script error." with no detail,
+      // almost always a file:// or otherwise not-served page.
       // Replace that with something actionable.
       if (typeof msg === "string" && /^script error\.?$/i.test(msg.trim())) {
         showFatal("script");

--- a/build/wasm/shell/shell.html
+++ b/build/wasm/shell/shell.html
@@ -108,12 +108,41 @@
     // Latch: once the data download is complete we show "Starting OpenLieroX…"
     // and ignore further loading-status churn until the engine is ready.
     let loadingDone = false;
+
+    // Set once an environment preflight has shown a fatal, actionable message
+    // (wrong URL scheme / no cross-origin isolation). When set, the engine's
+    // own status and error churn must not overwrite it.
+    let preflightFailed = false;
     function showStarting() {
       if (loadingDone) return;
       loadingDone = true;
       statusEl.style.display = "";
       statusEl.classList.remove("err");
       statusEl.textContent = "Starting OpenLieroX…";
+    }
+
+    // Startup watchdog. Once every asset has loaded (monitorRunDependencies
+    // reaches 0) the engine normally boots to the main menu within a few
+    // seconds and calls olxOnEngineReady(). If it never does, startup has most
+    // likely failed — a wasm abort or a failed thread spawn that surfaced no
+    // error — and the page would otherwise sit on "Starting OpenLieroX…"
+    // forever. Replace that dead-end with a message pointing at the console.
+    let startWatchdog = null;
+    function armStartWatchdog() {
+      if (startWatchdog !== null) return;
+      startWatchdog = setTimeout(() => {
+        // Don't stomp a clearer message that already owns the status line (a
+        // preflight failure, an abort, or an engine error).
+        if (preflightFailed || statusEl.classList.contains("err")) return;
+        statusEl.style.display = "";
+        statusEl.classList.add("err");
+        statusEl.innerHTML =
+          "OpenLieroX hasn’t reached the menu — startup may have failed.<br>" +
+          "Check the browser console (F12 / Developer Tools) for errors.";
+      }, 30000);
+    }
+    function clearStartWatchdog() {
+      if (startWatchdog !== null) { clearTimeout(startWatchdog); startWatchdog = null; }
     }
 
     function exitFullscreenIfActive() {
@@ -134,7 +163,7 @@
     // the few-second boot that follows the data download. Hide the loading /
     // "Starting OpenLieroX…" overlay at that point. (Hide directly — setStatus
     // ignores updates once the "Starting…" latch is set.)
-    window.olxOnEngineReady = () => { statusEl.style.display = "none"; };
+    window.olxOnEngineReady = () => { clearStartWatchdog(); statusEl.style.display = "none"; };
 
     var Module = {
       canvas: (() => {
@@ -155,6 +184,8 @@
         appendLog(text, true);
       },
       setStatus: (text) => {
+        // A preflight failure has shown a clearer, actionable message; keep it.
+        if (preflightFailed) return;
         text = text || "";
         // Errors/aborts always win and are shown verbatim.
         if (/error|abort|exception/i.test(text)) {
@@ -179,8 +210,10 @@
       },
       monitorRunDependencies: (left) => {
         // Backstop for the cached case where the byte counter may not emit a
-        // final x == y: once everything's resolved, show "Starting…".
-        if (left === 0) showStarting();
+        // final x == y: once everything's resolved, show "Starting…". This is
+        // also the point where the wasm is instantiated and the thread pool is
+        // up, so it's when the boot-to-menu watchdog should start ticking.
+        if (left === 0) { showStarting(); armStartWatchdog(); }
       },
       // Don't stream every "dependency: fp /xxx" or "(end of list)" line
       // into the on-page log; with thousands of preload files the spam
@@ -194,8 +227,63 @@
       onExit: () => exitFullscreenIfActive(),
     };
 
+    // --- Environment preflight -------------------------------------------
+    // This is a threaded (-pthread) build: main() runs on a Web Worker and the
+    // engine can't start without SharedArrayBuffer, which browsers only expose
+    // to cross-origin-isolated pages served over http(s) with COOP/COEP
+    // headers. Opening this page as a file:// URL, or serving it without those
+    // headers, otherwise fails with an opaque "Script error." or just hangs at
+    // "Starting…". Detect both cases up front and explain what to do.
+    const FATAL = {
+      file:
+        "This WebAssembly build can’t run from a <code>file://</code> URL " +
+        "— it must be served over HTTP.<br>Use the bundled server: run " +
+        "<b>python3&nbsp;serve.py</b> in this folder,<br>then open the " +
+        "<b>http://localhost:8000/</b> URL it prints.",
+      coi:
+        "OpenLieroX can’t start: this page is not cross-origin isolated, " +
+        "so <b>SharedArrayBuffer</b> (required by the threaded build) is " +
+        "unavailable.<br>Serve it with the COOP/COEP headers — the bundled " +
+        "<b>python3&nbsp;serve.py</b> sets them for you.<br>(A plain " +
+        "<code>http.server</code> only works if <code>coi-serviceworker.js</code> " +
+        "is present and can register.)",
+      script:
+        "OpenLieroX failed to load its engine files.<br>If you opened this as a " +
+        "<code>file://</code> URL, serve it over HTTP instead: run " +
+        "<b>python3&nbsp;serve.py</b> in this folder.",
+    };
+    function showFatal(kind) {
+      preflightFailed = true;
+      statusEl.style.display = "";
+      statusEl.classList.add("err");
+      statusEl.innerHTML = FATAL[kind];
+    }
+
+    if (location.protocol === "file:") {
+      showFatal("file");
+    } else if (!self.crossOriginIsolated) {
+      // Not isolated yet. The bundled coi-serviceworker.js shim can fix this on
+      // a header-less host, but only via a one-time reload — and that
+      // navigation tears down this timer. If we're still here and un-isolated
+      // after it's had time to act, isolation isn't coming: say so instead of
+      // hanging at "Starting…".
+      setTimeout(() => {
+        if (!self.crossOriginIsolated && !preflightFailed) showFatal("coi");
+      }, 5000);
+    }
+
     Module.setStatus("Downloading…");
-    window.onerror = (msg) => Module.setStatus("Exception: " + msg);
+    window.onerror = (msg) => {
+      if (preflightFailed) return;   // keep the clearer preflight message
+      // The browser scrubs cross-origin script errors down to a bare "Script
+      // error." with no detail — almost always a file:// / not-served page.
+      // Replace that with something actionable.
+      if (typeof msg === "string" && /^script error\.?$/i.test(msg.trim())) {
+        showFatal("script");
+        return;
+      }
+      Module.setStatus("Exception: " + msg);
+    };
 
     // --- Pointer-coordinate safety net for a letterboxed canvas.
     // Emscripten maps mouse/touch coordinates from the canvas element's


### PR DESCRIPTION
Make the WebAssembly bundle easy to test locally,
and fail with an actionable message
instead of an opaque browser error or a silent hang.

Two independent, complementary changes:

**Shell error messages** — opening the bundle as a `file://` URL,
or serving it without the COOP/COEP isolation headers,
previously died with the browser's opaque "Script error."
or hung forever on "Starting OpenLieroX...".
The shell now runs an up-front preflight:
it detects a `file://` URL and a non-cross-origin-isolated page
and shows a message pointing at `serve.py`,
maps the bare "Script error." to the same guidance,
and arms a startup watchdog
that turns a stuck "Starting..." into a hint to check the console.

**Bundled local server** — the threaded build needs `SharedArrayBuffer`,
which requires the isolation headers;
a plain `python3 -m http.server` doesn't set them.
`build.sh` now stages `serve.py` (which does)
plus a double-click `run.command` launcher into the distrib bundle,
and `serve.py` auto-detects whether it's sitting in a bundle (serve `.`)
or the repo (serve `output/`).

Testing: served the bundle via `serve.py`
(verified COOP/COEP/CORP headers and `application/wasm` MIME);
booted to menu and played a match.
