### PR TITLE
Fix heap OOB read in LieroX image-map loader

### DIFF
--- a/src/common/MapLoader_LieroX.cpp
+++ b/src/common/MapLoader_LieroX.cpp
@@ -94,7 +94,11 @@ class ML_LieroX : public MapLoad {
 			return false;
 		}
 		destsize = (uint32_t) lng_dsize; // can only get smaller
-		if( destsize < Uint32(head.width * head.height * 3 * 2) )
+		// We read 7 bytes per pixel below:
+		// 3 (back image) + 3 (front image) + 1 (pixel flags).
+		// Require all of them, computed in 64-bit
+		// so a huge width*height cannot wrap the check.
+		if( destsize < Uint64(head.width) * Uint64(head.height) * 7 )
 		{
 			errors("CMap::LoadImageFormat(): image too small for Width*Height");
 			delete[] pSource;


### PR DESCRIPTION
Fixes #1015.

`MapLoader_LieroX.cpp` `LoadImageFormat` (the `MPT_IMAGE` `.lxl` path, reachable from a downloaded map) decompresses the blob into `pDest` and validated only `destsize >= width*height*3*2` (= 6·W·H). But it then reads three planes:

- back image: `p` 0 → 3·W·H
- front image: `p` 3·W·H → 6·W·H
- **pixel flags: `pDest[p++]` per pixel → 6·W·H → 7·W·H** ← not covered

So a crafted image map whose blob decompresses to exactly `6·W·H` bytes passed the check, and the flag loop read up to `W·H` bytes past the `new uint8_t[destsize]` buffer, feeding OOB bytes into `Material::indexFromLxFlag` → heap OOB read (crash / UB), remotely reachable.

**Fix:** require `destsize >= Uint64(width) * Uint64(height) * 7`, computed in 64-bit (which also removes the old `Uint32(...)` cast that could truncate the check for large dimensions).

### Verification
Builds clean (clang). No fails-before-fix unit test: exercising this path needs a crafted `MPT_IMAGE` `.lxl` fixture plus a `MapLoad`/`CMap` harness, which the current unit-test target can't set up cheaply; verified by code reasoning + build. Found by re-auditing the loader.
