### PR TITLE
Bundle libSDL3 into the macOS .app

### DIFF
--- a/.github/workflows/package-macos.sh
+++ b/.github/workflows/package-macos.sh
@@ -91,19 +91,21 @@ dylibbundler -od -b \
     -d "$APP/Contents/Frameworks" \
     -p "@executable_path/../Frameworks/"
 
-# Homebrew's "sdl2" is really sdl2-compat: an SDL2-ABI shim that dlopens
-# the real SDL3 at runtime. Because that load goes through dlopen and not
-# a link-time reference, dylibbundler never sees SDL3 and leaves it out,
-# so the app dies at startup with "Failed loading SDL3 library." Copy
-# SDL3 in by hand, next to the bundled libSDL2, under the name
-# sdl2-compat looks for first (@loader_path/libSDL3.dylib). SDL3 itself
-# depends only on system frameworks, so nothing else needs bundling.
+# Homebrew's "sdl2" is really sdl2-compat:
+# an SDL2-ABI shim that dlopens the real SDL3 at runtime.
+# Because that load goes through dlopen and not a link-time reference,
+# dylibbundler never sees SDL3 and leaves it out,
+# so the app dies at startup with "Failed loading SDL3 library."
+# Copy SDL3 in by hand, next to the bundled libSDL2,
+# under the name sdl2-compat looks for first (@loader_path/libSDL3.dylib).
+# SDL3 itself depends only on system frameworks,
+# so nothing else needs bundling.
 SDL3_SRC="$(brew --prefix sdl3 2>/dev/null || true)/lib/libSDL3.dylib"
 if [ ! -f "$SDL3_SRC" ]; then
     SDL3_SRC="$(brew --prefix)/lib/libSDL3.dylib"
 fi
 if [ ! -f "$SDL3_SRC" ]; then
-    echo "ERROR: libSDL3.dylib not found — sdl2-compat needs it at runtime" >&2
+    echo "ERROR: libSDL3.dylib not found -- sdl2-compat needs it at runtime" >&2
     exit 1
 fi
 cp -L "$SDL3_SRC" "$APP/Contents/Frameworks/libSDL3.dylib"
@@ -112,10 +114,12 @@ install_name_tool -id "@executable_path/../Frameworks/libSDL3.dylib" \
     "$APP/Contents/Frameworks/libSDL3.dylib"
 codesign --force --sign - "$APP/Contents/Frameworks/libSDL3.dylib"
 
-# The bundle must be self-contained: a load path still pointing into
-# /opt/homebrew or /usr/local means a dependency was missed and the app
-# would fail on a machine without that library (exactly the SDL3 bug
-# above, which shipped silently). Fail the build here instead.
+# The bundle must be self-contained:
+# a load path still pointing into /opt/homebrew or /usr/local
+# means a dependency was missed
+# and the app would fail on a machine without that library
+# (exactly the SDL3 bug above, which shipped silently).
+# Fail the build here instead.
 leaked=0
 for f in "$APP/Contents/MacOS/openlierox" "$APP/Contents/Frameworks/"*.dylib; do
     refs="$(otool -L "$f" | tail -n +2 | grep -E '/opt/homebrew|/usr/local/' || true)"

--- a/.github/workflows/package-macos.sh
+++ b/.github/workflows/package-macos.sh
@@ -91,6 +91,44 @@ dylibbundler -od -b \
     -d "$APP/Contents/Frameworks" \
     -p "@executable_path/../Frameworks/"
 
+# Homebrew's "sdl2" is really sdl2-compat: an SDL2-ABI shim that dlopens
+# the real SDL3 at runtime. Because that load goes through dlopen and not
+# a link-time reference, dylibbundler never sees SDL3 and leaves it out,
+# so the app dies at startup with "Failed loading SDL3 library." Copy
+# SDL3 in by hand, next to the bundled libSDL2, under the name
+# sdl2-compat looks for first (@loader_path/libSDL3.dylib). SDL3 itself
+# depends only on system frameworks, so nothing else needs bundling.
+SDL3_SRC="$(brew --prefix sdl3 2>/dev/null || true)/lib/libSDL3.dylib"
+if [ ! -f "$SDL3_SRC" ]; then
+    SDL3_SRC="$(brew --prefix)/lib/libSDL3.dylib"
+fi
+if [ ! -f "$SDL3_SRC" ]; then
+    echo "ERROR: libSDL3.dylib not found — sdl2-compat needs it at runtime" >&2
+    exit 1
+fi
+cp -L "$SDL3_SRC" "$APP/Contents/Frameworks/libSDL3.dylib"
+chmod u+w "$APP/Contents/Frameworks/libSDL3.dylib"
+install_name_tool -id "@executable_path/../Frameworks/libSDL3.dylib" \
+    "$APP/Contents/Frameworks/libSDL3.dylib"
+codesign --force --sign - "$APP/Contents/Frameworks/libSDL3.dylib"
+
+# The bundle must be self-contained: a load path still pointing into
+# /opt/homebrew or /usr/local means a dependency was missed and the app
+# would fail on a machine without that library (exactly the SDL3 bug
+# above, which shipped silently). Fail the build here instead.
+leaked=0
+for f in "$APP/Contents/MacOS/openlierox" "$APP/Contents/Frameworks/"*.dylib; do
+    refs="$(otool -L "$f" | tail -n +2 | grep -E '/opt/homebrew|/usr/local/' || true)"
+    if [ -n "$refs" ]; then
+        echo "ERROR: $f still references non-bundled libraries:" >&2
+        echo "$refs" >&2
+        leaked=1
+    fi
+done
+if [ "$leaked" -ne 0 ]; then
+    exit 1
+fi
+
 # Zip uses tilde instead of underscore so e.g. "beta9" sorts correctly.
 VERSION="$(./get_version.sh | tr '_' '~')"
 ZIP="openlierox_${VERSION}_macos.zip"


### PR DESCRIPTION
Fixes #1010.

## Problem

The current macOS build aborts at startup with a native dialog:
"Fatal error! Cannot continue! / Failed loading SDL3 library."

Neither string comes from OpenLieroX.
Both are emitted by **sdl2-compat**:
Homebrew's `sdl2` formula is no longer real SDL2,
it is an SDL2-ABI shim that `dlopen`s the real **SDL3** at runtime rather than linking it.

Our packaging bundles dependencies with `dylibbundler`,
which only follows link-time dependencies (`otool -L`).
Because sdl2-compat pulls in SDL3 through `dlopen` and not through a load command,
dylibbundler never sees SDL3 and left `libSDL3.dylib` out of the `.app`.
On the CI build machine the app silently fell back to the Homebrew-installed SDL3, so the bundle looked fine;
on any other Mac it aborted at startup.

## Change

In `package-macos.sh`, after `dylibbundler`:

- Copy `libSDL3.dylib` into `Contents/Frameworks/` next to the bundled `libSDL2`,
  the `@loader_path/libSDL3.dylib` location sdl2-compat searches first,
  rewrite its install id and ad-hoc codesign it.
  SDL3 depends only on system frameworks, so nothing else needs bundling.
- Add a self-containment check
  that scans every bundled binary and dylib for leftover `/opt/homebrew` or `/usr/local` references
  and fails the build if any remain.
  That is exactly the class of bug that shipped here,
  and it would now break CI loudly instead of shipping a broken bundle silently.

## Why no better runtime message

The failure happens entirely inside sdl2-compat,
before OLX's own startup and logging run,
so OLX cannot extend or replace that dialog.
The actionable improvement is therefore the build-time self-containment check above.

## Testing

I could not run the full packaging script locally
(dylibbundler is not installed on this machine and there is no built binary in the worktree),
so the SDL3-bundling logic and the self-containment scan were validated in isolation
against a hand-built bundle that mimics the post-dylibbundler state:

- A minimal SDL2 program bundled the same way, with the Homebrew tree blocked
  (`DYLD_FALLBACK_LIBRARY_PATH=/nonexistent`), reproduces the exact failure (SIGABRT + same dialog).
- After copying `libSDL3.dylib` in and fixing its id, `SDL_Init` succeeds with the Homebrew tree still blocked.
- The self-containment scan reports no leaks.

A green Build Mac run on this PR is the real end-to-end confirmation.
