### PR TITLE
Fix nlThreadSleep sleeping 1000x too short

### DIFF
--- a/libs/hawknl/src/thread.c
+++ b/libs/hawknl/src/thread.c
@@ -182,7 +182,7 @@ void nlThreadSleep(NLint mseconds)
     struct timespec     tv;
 
     tv.tv_sec = mseconds / 1000;
-    tv.tv_nsec = (mseconds % 1000) * 1000;
+    tv.tv_nsec = (mseconds % 1000) * 1000000;
 
     (void)nanosleep(&tv, NULL);
 #endif /* !WINDOWS_APP */

--- a/tests/headless/harness.py
+++ b/tests/headless/harness.py
@@ -15,6 +15,7 @@ in each instance's combined output log.
 """
 
 import os
+import signal
 import subprocess
 import time
 
@@ -75,6 +76,11 @@ class OlxInstance:
         self.proc = subprocess.Popen(
             args, cwd=GAMEDIR, env=env,
             stdout=self._log_file, stderr=subprocess.STDOUT,
+            # Own session/process group, so stop() can reap the whole tree:
+            # OLX forks a child copy of itself, and killing only the tracked
+            # pid would strand that child as a launchd-orphaned dedicated
+            # server -- which, under OLX_FORCE_LOOPBACK, busy-spins forever.
+            start_new_session=True,
         )
         return self
 
@@ -108,7 +114,12 @@ class OlxInstance:
             # SIGKILL, not SIGTERM:
             # OLX's shutdown path is slow and can trip its own crash handler,
             # which only adds noise to the log.
-            self.proc.kill()
+            # Signal the whole process group (see start_new_session in start),
+            # so OLX's forked child is reaped too instead of being orphaned.
+            try:
+                os.killpg(self.proc.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
             try:
                 self.proc.wait(timeout=10)
             except subprocess.TimeoutExpired:


### PR DESCRIPTION
## What

Two fixes for a runaway-CPU incident:
a native headless dedicated server pinned several cores (~245-285%) while otherwise idle.

1. **`nlThreadSleep` slept 1000x too short** (`libs/hawknl/src/thread.c`).
   `tv_nsec` holds nanoseconds,
   but the ms-to-ns conversion multiplied by `1000` (microseconds) instead of `1000000`,
   so every POSIX sleep through this function was ~1000x shorter than requested.
   One-line fix.

2. **The headless test harness leaked dedicated servers** (`tests/headless/harness.py`).
   `Instance.stop()` killed only the tracked pid,
   but OLX forks a child copy of itself,
   so that child survived teardown and was reparented to launchd.
   Each instance now runs in its own session,
   and `stop()` SIGKILLs the whole group.

## Why it stayed hidden for so long

The `* 1000` typo dates to the original HawkNL import (2007) and had been latent ever since:

- Only the **loopback** driver's busy-poll (`loopback_PollGroup`) paces itself with `nlThreadSleep(1)`.
  The real IP driver blocks in `select()` with a kernel timeout and never calls it,
  so it is immune.
- Native builds have always selected `NL_IP`, so the buggy path was never taken.
  The Windows path was always correct (`Sleep(ms)`).
- The loopback driver was only wired in for the wasm port,
  and the `OLX_FORCE_LOOPBACK` test switch lets native headless tests exercise it.
  That is what finally lit up the bug:
  each per-socket event thread spun at full speed instead of polling at 1 ms.

The leaked orphans then ran that busy-spin forever,
turning a stray-process nuisance into a machine-wide CPU fire.

## Verification

- Fresh native dedicated server, idle in lobby, 42 worker threads:
  **0.0% CPU** across repeated samples, versus 245-285% for the pre-fix build.
- `tests/headless/test_network.py`: all 4 pass in ~12 s,
  and **no openlierox processes survive** the run (clean teardown confirmed).

## Notes for the reviewer

- The two commits are independent concerns
  (vendored HawkNL C fix vs. Python test harness);
  happy to split into separate PRs if preferred.
- The harness fix only helps when teardown actually runs.
  A hard-aborted pytest run or killed session can still leak,
  because a dedicated OLX server never self-exits when orphaned.
  Closing that fully would need an OLX-side parent-death watchdog,
  which is out of scope here.
