### PR TITLE
Don't set game.state from the quit-signal handler

### DIFF
--- a/src/common/EventQueue.cpp
+++ b/src/common/EventQueue.cpp
@@ -209,7 +209,13 @@ static BOOL QuitSignalHandler( DWORD fdwCtrlType )
 	ev.type = SDL_QUIT;
 	mainQueue->push(ev);
 	tLX->bQuitCtrlC = true; // Set the special CTRL-C flag, so Dedicated Server won't try to close the non-existant pipe
-	game.state = Game::S_Quit;
+	// Don't set game.state here.
+	// This handler runs on a separate console-control-handler thread,
+	// so assigning the game.state Attr
+	// would run the attribute-update machinery off the gameloop thread,
+	// which is not allowed.
+	// The pushed SDL_QUIT event sets game.state = S_Quit via EvHndl_Quit,
+	// on the gameloop thread where ProcessEvents() dispatches it.
 	return TRUE;
 }
 
@@ -233,7 +239,18 @@ static void QuitSignalHandler(int sig)
 	} else {
 		warnings << "got quit-signal and mainQueue is not set" << endl;
 	}
-	game.state = Game::S_Quit;
+	// Don't set game.state here.
+	// This runs asynchronously in signal context,
+	// on whatever thread caught the signal,
+	// which is usually not the gameloop thread.
+	// game.state is an Attr,
+	// and assigning it runs the attribute-update machinery
+	// (locks, allocation, and a gameloop-thread assertion),
+	// which is neither reentrant nor async-signal-safe.
+	// Doing it here asserted or raced against the gameloop,
+	// and crashed on quit.
+	// The pushed SDL_QUIT event sets game.state = S_Quit via EvHndl_Quit,
+	// on the gameloop thread where ProcessEvents() dispatches it.
 }
 
 static void InitQuitSignalHandler()

--- a/tests/headless/test_smoke.py
+++ b/tests/headless/test_smoke.py
@@ -5,6 +5,9 @@ just that the binary starts, initialises,
 and reaches the lobby as a dedicated server.
 """
 
+import signal
+import subprocess
+
 
 def test_dedicated_server_reaches_lobby(network_game):
     """A dedicated server starts up and reaches the hosting lobby."""
@@ -30,3 +33,35 @@ def test_loads_configured_mod_and_map(network_game):
     log = server.read_log()
     assert "invalid mod name" not in log, log
     assert "could not load level" not in log.lower(), log
+
+
+def test_graceful_shutdown_on_quit_signal(network_game):
+    """A quit signal to a running server shuts it down cleanly, without crashing.
+
+    Regression test for the quit-signal crash:
+    once the gameloop thread is running,
+    the SIGINT/SIGTERM handler used to assign the game.state Attr directly
+    from signal context, off the gameloop thread,
+    which tripped the attribute-update machinery's thread assertion and aborted.
+    The handler must instead only push an SDL_QUIT event,
+    which the gameloop dispatches to set the state on the right thread.
+    """
+    server = network_game.start_server()
+    # Once the lobby is up, the gameloop thread is running,
+    # which is the precondition for the crash.
+    assert server.wait_for("SERVER_LOBBY", timeout=30), server.read_log()
+
+    server.proc.send_signal(signal.SIGINT)
+
+    try:
+        rc = server.proc.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        raise AssertionError(
+            "server did not exit after SIGINT:\n" + server.read_log())
+
+    # A crash (abort/segfault) shows up as termination by signal,
+    # i.e. a negative return code (e.g. -6 for SIGABRT).
+    # A clean shutdown returns 0.
+    assert rc == 0, (
+        "server did not shut down cleanly (returncode=%d):\n" % rc
+    ) + server.read_log()


### PR DESCRIPTION
## The crash

Pressing Ctrl-C (or sending SIGINT/SIGTERM) while a game was running aborted with:

```
Assertion failed: (!isGameloopThreadRunning() || isGameloopThread()),
function pushObjAttrUpdate, file Attr.cpp, line 357.
```

The frame chain was
`QuitSignalHandler -> AttrWithIntOpts::operator= -> Attr::write -> pushObjAttrUpdate -> abort`.

## Root cause

`QuitSignalHandler` ended with `game.state = Game::S_Quit`.
That reads like a cheap flag store,
but `game.state` is an `Attr<>` with an `onUpdate` handler,
so assigning it calls into `pushObjAttrUpdate`,
which takes mutexes, allocates,
and asserts it runs on the gameloop thread (or with no gameloop running).

A signal handler runs asynchronously in signal context,
on whatever thread caught the signal,
which is usually the main thread, not the gameloop thread.
With the gameloop running, the assertion failed and aborted,
and the write also raced the gameloop thread,
which was concurrently updating the same attribute
after processing the SDL_QUIT event.

This regressed in 61e56a9a2 (2012),
which mechanically rewrote `tLX->bQuitGame = true` (a plain bool)
into the `game.state` Attr assignment,
silently turning a safe flag store into an unsafe cross-thread call.

## The fix

The handler already pushes an `SDL_QUIT` event,
which `ProcessEvents()` dispatches to `EvHndl_Quit` on the gameloop thread,
setting `game.state = S_Quit` there.
That path is sufficient and correct,
so the direct assignment is just dropped
from both the Unix and Windows handlers.

## Test

A headless regression test reaches the lobby
(so the gameloop thread is running, the precondition for the crash),
sends SIGINT, and asserts the process exits cleanly.

Verified against a DEBUG build (asserts enabled, matching the crash report):

- Without the fix, the test reproduces the original abort at `Attr.cpp:357`.
- With the fix, the full smoke suite passes, including a clean SIGINT shutdown.

The existing harness already worked around this bug:
`stop()` uses SIGKILL rather than SIGTERM
because "OLX's shutdown path ... can trip its own crash handler".
That was this crash.
