### PR TITLE
Fix displayScreenWidth race in render()

### DIFF
--- a/include/AuxLib.h
+++ b/include/AuxLib.h
@@ -87,6 +87,15 @@ protected:
 	// Set per-frame by the menu / gameplay draw. See render() and the mouse
 	// handling, and displayScreenWidth()/displayScreenOffsetX() below.
 	int m_displayScreenWidth = 640;
+	// Snapshot of m_displayScreenWidth taken when a drawn frame is committed
+	// (flipBuffers, under the video mutex) and handed to render() via process(),
+	// so each frame is presented with the layout width it was actually drawn for.
+	// render() runs on the main thread,
+	// while the game thread keeps updating m_displayScreenWidth for the next frame,
+	// so reading it live in render() races
+	// and can center a frame with the wrong offset at menu/game transitions.
+	int m_committedDisplayScreenWidth = 640; // flipBuffers writes, process reads (both under mutex)
+	int m_renderDisplayScreenWidth = 640;    // main-thread only: process writes, render reads
 	static VideoPostProcessor instance;
 	
 public:

--- a/src/client/AuxLib.cpp
+++ b/src/client/AuxLib.cpp
@@ -646,6 +646,10 @@ bool VideoPostProcessor::resetVideo() {
 
 void VideoPostProcessor::flipBuffers() {
 	std::swap(get()->m_videoBufferSurface, get()->m_videoSurface);
+	// Capture the layout width the just-committed frame was drawn for,
+	// so render() presents it with the matching centering
+	// even after the game thread changes m_displayScreenWidth for the next frame.
+	get()->m_committedDisplayScreenWidth = get()->m_displayScreenWidth;
 }
 
 
@@ -656,6 +660,9 @@ void VideoPostProcessor::process() {
 	
 	void* pixels = get()->m_videoBufferSurface->pixels;
 	SDL_UpdateTexture(get()->m_videoTexture.get(), NULL, pixels, get()->screenWidth() * sizeof (uint32_t));
+	// Hand the committed frame's layout width to the main-thread-only render().
+	// This runs under the video mutex; render() does not.
+	get()->m_renderDisplayScreenWidth = get()->m_committedDisplayScreenWidth;
 }
 
 void VideoPostProcessor::render() {
@@ -667,8 +674,11 @@ void VideoPostProcessor::render() {
 	if(!get()->m_renderer.get()) return;
 
 	SDL_RenderClear(get()->m_renderer.get());
-	const int dw = get()->displayScreenWidth();
-	const int centerOffset = get()->displayScreenOffsetX();
+	// Use the layout width captured for this frame (see process()), not the live
+	// displayScreenWidth(), which the game thread may already have moved on.
+	const int dw = get()->m_renderDisplayScreenWidth;
+	int centerOffset = (get()->m_screenWidth - dw) / 2;
+	if(centerOffset < 0) centerOffset = 0;
 	if(centerOffset > 0) {
 		// The frame's content (a menu, or a network game) is only dw wide and is
 		// drawn into the left dw columns of the (wider) video surface. Present


### PR DESCRIPTION
## Problem

`VideoPostProcessor::render()` runs on the main thread and read the layout width live:

```cpp
const int dw = get()->displayScreenWidth();
const int centerOffset = get()->displayScreenOffsetX();
```

But `m_displayScreenWidth` is written by the **game thread** --
`Menu_Frame` sets it to `menuWidth` (640),
and `CClient::Draw` sets it to the widescreen game width
([CClient_Draw.cpp:422](src/client/CClient_Draw.cpp), [CClient.cpp:1602](src/client/CClient.cpp)/[1722](src/client/CClient.cpp)).

So the main thread could present an already-committed frame using the *next* frame's width,
centering it with the wrong horizontal offset for one frame at menu↔game transitions.
It is also an unsynchronized read of a value another thread writes.

## Fix

Capture the layout width when a frame is committed (`flipBuffers`, under the video mutex),
hand it to the main thread in `process()`,
and use that captured width in `render()` instead of the live value.
The captured value is written under the mutex and consumed only on the main thread,
so `render()` no longer reads game-thread state unsynchronized,
and each frame is presented with the width it was drawn for.

## Testing

Builds clean; the app starts, sets the video mode, and reaches the main menu with no crash or regression.
The steady main menu is unaffected (the width is constant there);
the fix matters at transitions, which are timing-dependent and hard to capture in a screenshot.

Found while investigating a menu flicker; it is an independent correctness bug and is submitted on its own.
