### PR TITLE
Fix exit crash in ExactFilenameCache destructor

### DIFF
--- a/src/common/FindFile.cpp
+++ b/src/common/FindFile.cpp
@@ -311,8 +311,18 @@ struct ExactFilenameCache {
 		Mutex::ScopedLock lock(mutex);
 		cache.insert(exactname);
 	}
+};
+
+// Leaky singleton: intentionally allocated once and never freed.
+// As a global with a non-trivial destructor it would otherwise be torn down
+// during static finalization at exit (__cxa_finalize),
+// where file-search worker threads may still be inserting into it;
+// destroying the hash_set under them crashes in free().
+// Never destructing it makes any such late access harmless.
+static ExactFilenameCache& exactFilenameCache() {
+	static ExactFilenameCache* instance = new ExactFilenameCache();
+	return *instance;
 }
-exactfilenamecache;
 
 
 // used by unix-GetExactFileName
@@ -345,7 +355,7 @@ bool CaseInsFindFile(const std::string& dir, const std::string& searchname, std:
 		// Cache fillup logic.
 		if(count >= CacheIgnoreNum) {
 			std::string dirSearchName = dir.empty() ? direntry->d_name : (dir + "/" + direntry->d_name);
-			exactfilenamecache.add_searchname(dirSearchName);
+			exactFilenameCache().add_searchname(dirSearchName);
 		}
 		count++;
 
@@ -398,7 +408,7 @@ bool GetExactFileName(const std::string& abs_searchname, std::string& filename) 
 	std::string rest;
 	while(true) {
 		rest = sname.substr(0,pos);
-		if(exactfilenamecache.has_searchname(rest, filename)) {
+		if(exactFilenameCache().has_searchname(rest, filename)) {
 			if(IsPathStatable(filename)) {
 				if(pos == sname.size()) // do we got the whole filename?
 					return true;


### PR DESCRIPTION
## Problem

Crash on exit:

```
2   openlierox   ExactFilenameCache::~ExactFilenameCache() + 84
3   libsystem_c  __cxa_finalize_ranges + 416
4   libsystem_c  exit + 44
```

`exactfilenamecache` ([FindFile.cpp](src/common/FindFile.cpp)) is a global with a non-trivial destructor
(a `hash_set` of cached filenames plus a `Mutex`).
File-search worker threads insert into it through `add_searchname` during `CaseInsFindFile`.
At process exit, `__cxa_finalize` runs the global's destructor on the main thread;
if a worker thread is still touching the cache,
the `hash_set` is torn down under it and it crashes in `free()`.

## Fix

Make it a leaky singleton: allocate once and never free it,
so the destructor is never registered with `__cxa_finalize` and cannot run during static finalization.
A late access from a still-running thread then hits a live object and is harmless.
This is the standard treatment for a global with a non-trivial destructor that other threads may outlive.

## Testing

Builds clean; the app starts and loads the game data normally
(all file lookups go through the accessor now).

I could not reproduce the exit crash locally in this headless setup
(it needs a clean `exit()` with the cache populated and a worker still live,
which I can't drive without the GUI),
so please confirm on your end that quitting no longer crashes.
The change removes the crash site by construction -- the destructor no longer runs at exit.

Alternative if you'd prefer a root-cause fix instead:
guarantee all file-search worker threads are joined before `exit()`.
That's more invasive; the leaky singleton is the low-risk option.
