### PR TITLE
Fill menu side bars with theme background

### DIFF
--- a/src/client/AuxLib.cpp
+++ b/src/client/AuxLib.cpp
@@ -680,13 +680,24 @@ void VideoPostProcessor::render() {
 	int centerOffset = (get()->m_screenWidth - dw) / 2;
 	if(centerOffset < 0) centerOffset = 0;
 	if(centerOffset > 0) {
-		// The frame's content (a menu, or a network game) is only dw wide and is
-		// drawn into the left dw columns of the (wider) video surface. Present
-		// just that region, centered, so it appears in the middle of the screen
-		// with black bars on the sides. The mouse is shifted by the same offset
-		// (see HandleMouseState) so clicks still line up.
-		SDL_Rect src = { 0, 0, dw, get()->screenHeight() };
-		SDL_Rect dst = { centerOffset, 0, dw, get()->screenHeight() };
+		// The frame's content (a menu, or a network game) is only dw wide
+		// and is drawn into the left dw columns of the (wider) video surface.
+		// Present just that region, centered,
+		// so it appears in the middle of the screen.
+		// The mouse is shifted by the same offset (see HandleMouseState)
+		// so clicks still line up.
+		const int h = get()->screenHeight();
+		// Fill the side gaps by stretching the frame's own edge columns outward,
+		// so the theme's background continues there instead of black bars.
+		SDL_Rect leftSrc = { 0, 0, 1, h };
+		SDL_Rect leftDst = { 0, 0, centerOffset, h };
+		SDL_RenderCopy(get()->m_renderer.get(), get()->m_videoTexture.get(), &leftSrc, &leftDst);
+		SDL_Rect rightSrc = { dw - 1, 0, 1, h };
+		SDL_Rect rightDst = { centerOffset + dw, 0, get()->screenWidth() - (centerOffset + dw), h };
+		SDL_RenderCopy(get()->m_renderer.get(), get()->m_videoTexture.get(), &rightSrc, &rightDst);
+
+		SDL_Rect src = { 0, 0, dw, h };
+		SDL_Rect dst = { centerOffset, 0, dw, h };
 		SDL_RenderCopy(get()->m_renderer.get(), get()->m_videoTexture.get(), &src, &dst);
 	} else {
 		SDL_RenderCopy(get()->m_renderer.get(), get()->m_videoTexture.get(), NULL, NULL);


### PR DESCRIPTION
## Problem

Since the widescreen support (#927),
the window is sized to the desktop aspect ratio at height 480
(e.g. 740x480 on a 16:10-ish display),
while menus stay `menuWidth` (640) wide and are presented centered.
That leaves black bars on the left and right in every menu.

## Fix

Instead of leaving the gaps black,
stretch the frame's own leftmost and rightmost columns outward into them,
so the theme's background continues into the bars.

- Uses the theme's actual edge pixels, so it adapts to any theme with no colour picking.
- Pure GPU `RenderCopy` (two extra 1px-wide copies per frame); no surface reads or locking in `render()`.
- Only affects the centered case (menus / network games); a full-width local game is unchanged.

## Testing

Builds clean; the app starts and renders the menu with no error or crash.
I can't screenshot from this environment (no Screen Recording permission),
so please eyeball a menu to confirm the bars now show the background rather than black.

If the stretched edge column doesn't look good on some theme,
the easy fallback is to sample one representative background colour and clear the gaps to that instead;
say the word and I'll switch it.

Note: this touches the same `render()` block as #1023 (displayScreenWidth race),
so whichever merges second will need a trivial rebase.
