### PR TITLE
Ignore local cmake/ninja build and packaging output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,16 @@ libopenlierox_pch_dephelp.a
 *-build
 /build-*
 
+# Ninja + generated files from a local cmake build into ./build
+.ninja_deps
+.ninja_log
+*.ninja
+olx-version-include
+
+# macOS .app packaging output (.github/workflows/package-macos.sh)
+/mac-stage
+/openlierox_*_macos.zip
+
 # Temp file used while downloading the SDL gamepad mapping DB at build time
 # (CMakeOlxCommon.cmake). The committed copy share/gamedir/gamecontrollerdb.txt
 # is tracked.


### PR DESCRIPTION
Building into ./build (the CI's default BUILD_DIR) and running package-macos.sh left several untracked artifacts showing up in git status: ninja's .ninja_deps/.ninja_log/build.ninja, the generated olx-version-include/ header dir, the mac-stage/ .app bundle (dozens of bundled dylibs), and the openlierox_*_macos.zip output.

bin, CMakeFiles, and CMakeCache.txt were already ignored; these were the remaining gaps. Ignore them so a local build/package leaves the working tree clean.

No tracked files are affected (the tracked entries under build/ are only the IDE project dirs).