### PR TITLE
Fix crash writing an Attr during static init

### DIFF
--- a/src/game/Attr.cpp
+++ b/src/game/Attr.cpp
@@ -75,12 +75,18 @@ void AttrDesc::set(BaseObject* base, const ScriptVar_t& v) const {
 
 bool AttrDesc::authorizedToWrite(const BaseObject* base) const {
 	assert(base != NULL);
+	// An unregistered object is not part of the networked game-state tree:
+	// there is nothing to authorize and nothing to propagate
+	// (pushObjAttrUpdate ignores it too). The write still sets the value.
+	// Check this first, before touching the global `game`,
+	// because such writes can happen during static initialization
+	// (e.g. a standalone LevelInfo default) before `game` is constructed.
+	if(!base->isRegistered()) return true;
 	if(this == Game::state_Type::attrDesc()) { // small exception for game.state
 		if(game.state == Game::S_Quit && !bRestartGameAfterQuit) return false; // don't allow any changes anymore on game.state. just quit
 		return true; // just allow any changes. client might want to disconnect, so client must be allowed to write this :)
 	}
 	if(game.state <= Game::S_Connecting) return true;
-	if(!base->isRegistered()) return true;
 	if(attrUpdateByServerScope || attrUpdateByClientScope) {
 		if(game.isServer()) {
 			assert(attrUpdateByClientScope);


### PR DESCRIPTION
## Problem

Startup crash inside a global constructor:

```
AttrDesc::authorizedToWrite(BaseObject const*) const
Attr<std::string, LevelInfo::_path_AttrDesc2>::write()
__cxx_global_var_init
dyld ... findAndRunAllInitializers
```

`AttrDesc::authorizedToWrite` reads the global `game` (`game.state`, `Game::state_Type::attrDesc()`). Writing an `Attr` on an object outside the game-state tree can happen during **static initialization**, before `game` is constructed -- e.g. a global `Settings` object ([Settings.cpp:19](src/game/Settings.cpp)) setting its `FT_Map` default writes `LevelInfo::path`. The read of `game` then crashes. A static-initialization-order fiasco.

## Fix

`authorizedToWrite` **already** returns `true` for unregistered objects, and `pushObjAttrUpdate` **already** ignores them ([Attr.cpp:341](src/game/Attr.cpp), whose comment literally names the `LevelInfo` case). An object outside the networked game state has nothing to authorize and no audience to propagate to. The only bug: that unregistered short-circuit ran *after* the `game`-dependent checks. Move it to the top, before anything touches `game`.

- The value is still written; only the (irrelevant) propagation is skipped. `isRegistered()` reads only the object's own `thisRef`/parent, never `game`.
- No behavior change for registered objects: `game` itself is registered, so `game.state` and all real game-state attributes take the existing path.

## Testing

Builds clean; app starts and runs normally. My local build's init order doesn't hit the crash, so I couldn't reproduce it directly -- please confirm on the build that did. The change removes the `game` dependency for exactly the objects that can be written before `game` exists.