### PR TITLE
Parse and display version build metadata (git hash)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ IF(OLX_TESTS)
 	ADD_EXECUTABLE(olx_tests
 		${OLXROOTDIR}/tests/unit/test_main.cpp
 		${OLXROOTDIR}/tests/unit/test_CBytestream.cpp
+		${OLXROOTDIR}/tests/unit/test_Version.cpp
 		${ALL_SRCS} ${OLX_WIN_RESOURCES})
 	SET_TARGET_PROPERTIES(olx_tests PROPERTIES
 		RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"

--- a/CMakeOlxVersion.cmake
+++ b/CMakeOlxVersion.cmake
@@ -3,10 +3,11 @@
 # Generates a Version_generated.h that defines LX_VERSION from the output of
 # get_version_full.sh (see functions.sh:get_olx_version_with_hash — the
 # YYYYMMDD.N+git.HASH scheme). The binary embeds the full version (with hash)
-# for provenance/crash reports; the menu and window title display the short
-# version via GetGameVersionShortString(). src/common/Version.cpp is the only
-# translation unit that includes Version_generated.h, so bumping the version
-# recompiles just that one file.
+# for provenance/crash reports,
+# and the menu and window title show it too via GetGameVersionStringFull().
+# src/common/Version.cpp is the only translation unit
+# that includes Version_generated.h,
+# so bumping the version recompiles just that one file.
 #
 # Without this Version.cpp has no LX_VERSION and the build fails (#error)
 # rather than baking in a bogus version.

--- a/functions.sh
+++ b/functions.sh
@@ -103,17 +103,25 @@ get_olx_version() {
 
 # get the full OLX version-string, i.e. get_olx_version() plus the git hash:
 #
-#   YYYYMMDD.N+git.HASH      e.g. 20260615.1+git.a6632ac
+#   YYYYMMDD.N+git.HASH        e.g. 20260615.1+git.a6632ac
+#   YYYYMMDD.N+git.HASH-dirty  when the working tree has uncommitted changes
 #
-# where HASH is the 7-char hash of the HEAD commit. Use this where the exact
-# build provenance matters (crash reports, the in-binary version). When git
-# is unavailable it degrades to plain get_olx_version(); if that can't
-# determine a version either, the failure propagates (non-zero return).
+# where HASH is the 7-char hash of the HEAD commit. The "-dirty" marker flags a
+# build made from a modified tree, so its hash alone does not identify the code.
+# Use this where the exact build provenance matters
+# (crash reports, the in-binary version). When git is unavailable it degrades to
+# plain get_olx_version(); if that can't determine a version either, the failure
+# propagates (non-zero return).
 get_olx_version_with_hash() {
 	_olx_ver="$(get_olx_version)" || return 1
 	if command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1; then
 		_olx_hash="$(git rev-parse --short=7 HEAD)"
-		echo "${_olx_ver}+git.${_olx_hash}"
+		# Only tracked changes count as dirty (like `git describe --dirty`);
+		# refresh the stat cache first to avoid false positives from mtimes.
+		git update-index -q --refresh >/dev/null 2>&1
+		_olx_dirty=""
+		git diff-index --quiet HEAD -- >/dev/null 2>&1 || _olx_dirty="-dirty"
+		echo "${_olx_ver}+git.${_olx_hash}${_olx_dirty}"
 		return 0
 	fi
 	echo "${_olx_ver}"

--- a/functions.sh
+++ b/functions.sh
@@ -104,10 +104,11 @@ get_olx_version() {
 # get the full OLX version-string, i.e. get_olx_version() plus the git hash:
 #
 #   YYYYMMDD.N+git.HASH        e.g. 20260615.1+git.a6632ac
-#   YYYYMMDD.N+git.HASH-dirty  when the working tree has uncommitted changes
+#   YYYYMMDD.N+git.HASH.dirty  when the working tree has uncommitted changes
 #
 # where HASH is the 7-char hash of the HEAD commit.
-# The "-dirty" marker flags a build made from a modified tree,
+# The ".dirty" marker (a separate SemVer build-metadata identifier)
+# flags a build made from a modified tree,
 # so its hash alone does not identify the code.
 # Use this where the exact build provenance matters
 # (crash reports, the in-binary version).
@@ -123,7 +124,7 @@ get_olx_version_with_hash() {
 		# so unchanged files with new mtimes don't read as dirty.
 		git update-index -q --refresh >/dev/null 2>&1
 		_olx_dirty=""
-		git diff-index --quiet HEAD -- >/dev/null 2>&1 || _olx_dirty="-dirty"
+		git diff-index --quiet HEAD -- >/dev/null 2>&1 || _olx_dirty=".dirty"
 		echo "${_olx_ver}+git.${_olx_hash}${_olx_dirty}"
 		return 0
 	fi

--- a/functions.sh
+++ b/functions.sh
@@ -106,18 +106,21 @@ get_olx_version() {
 #   YYYYMMDD.N+git.HASH        e.g. 20260615.1+git.a6632ac
 #   YYYYMMDD.N+git.HASH-dirty  when the working tree has uncommitted changes
 #
-# where HASH is the 7-char hash of the HEAD commit. The "-dirty" marker flags a
-# build made from a modified tree, so its hash alone does not identify the code.
+# where HASH is the 7-char hash of the HEAD commit.
+# The "-dirty" marker flags a build made from a modified tree,
+# so its hash alone does not identify the code.
 # Use this where the exact build provenance matters
-# (crash reports, the in-binary version). When git is unavailable it degrades to
-# plain get_olx_version(); if that can't determine a version either, the failure
-# propagates (non-zero return).
+# (crash reports, the in-binary version).
+# When git is unavailable it degrades to plain get_olx_version();
+# if that can't determine a version either,
+# the failure propagates (non-zero return).
 get_olx_version_with_hash() {
 	_olx_ver="$(get_olx_version)" || return 1
 	if command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1; then
 		_olx_hash="$(git rev-parse --short=7 HEAD)"
-		# Only tracked changes count as dirty (like `git describe --dirty`);
-		# refresh the stat cache first to avoid false positives from mtimes.
+		# Only tracked changes count as dirty, like `git describe --dirty`;
+		# refresh the stat cache first,
+		# so unchanged files with new mtimes don't read as dirty.
 		git update-index -q --refresh >/dev/null 2>&1
 		_olx_dirty=""
 		git diff-index --quiet HEAD -- >/dev/null 2>&1 || _olx_dirty="-dirty"

--- a/include/Version.h
+++ b/include/Version.h
@@ -24,7 +24,8 @@ const Version& GetGameVersion();
 // including the "+git.HASH" suffix (and a "-dirty" marker for a modified tree),
 // e.g. "20260616.4+git.b547037".
 // Shown verbatim wherever the version is displayed (window title, menu, crash reports):
-// it is the exact build string, not reconstructed through Version, so nothing is lost.
+// it is the exact build string, not reconstructed through Version,
+// so nothing is lost.
 const std::string& GetGameVersionStringFull();
 
 
@@ -49,7 +50,9 @@ struct Version {
 		RT_UNKNOWN, RT_ALPHA, RT_BETA, RT_RC, RT_NORMAL
 	} releasetype;
 	std::string gamename; // OpenLieroX
-	std::string buildmetadata; // SemVer build metadata after '+', e.g. "git.db202c4"; provenance only, ignored when comparing
+	// SemVer build metadata after '+', e.g. "git.db202c4";
+	// provenance only, ignored when comparing.
+	std::string buildmetadata;
 
 };
 

--- a/include/Version.h
+++ b/include/Version.h
@@ -20,17 +20,11 @@ INLINE const char* GetFullGameName() { return fullGameName; }
 const char* GetGameName();
 const Version& GetGameVersion();
 
-// The OLX version string without the git hash, e.g. "20260616.4". This is
-// what should be shown in most user-facing places (menu, window title) — the
-// git hash is noise there. Unlike Version::asHumanString() this is NOT
-// re-parsed through the integer num.subnum.subsubnum scheme (which can't
-// represent the date-based version system — see functions.sh), so it is
-// shown verbatim.
-const std::string& GetGameVersionString();
-
-// The full version string including the "+git.HASH" suffix, e.g.
-// "20260616.4+git.b547037" (matches get_version_full.sh). Use this only
-// where the exact build provenance matters (crash reports, etc.).
+// The full version string as produced by get_version_full.sh,
+// including the "+git.HASH" suffix (and a "-dirty" marker for a modified tree),
+// e.g. "20260616.4+git.b547037".
+// Shown verbatim wherever the version is displayed (window title, menu, crash reports):
+// it is the exact build string, not reconstructed through Version, so nothing is lost.
 const std::string& GetGameVersionStringFull();
 
 

--- a/include/Version.h
+++ b/include/Version.h
@@ -38,7 +38,7 @@ struct Version {
 	Version() { reset(); }
 	Version(const std::string& versionStr) { setByString(versionStr); }
 	
-	void reset() { gamename = "LieroX"; num = 0; subnum = 56; subsubnum = 0; revnum = 0; releasetype = RT_NORMAL; }
+	void reset() { gamename = "LieroX"; num = 0; subnum = 56; subsubnum = 0; revnum = 0; releasetype = RT_NORMAL; buildmetadata = ""; }
 	void setByString(const std::string& versionStr);
 	std::string asString() const;
 	std::string asHumanString() const;
@@ -55,13 +55,14 @@ struct Version {
 		RT_UNKNOWN, RT_ALPHA, RT_BETA, RT_RC, RT_NORMAL
 	} releasetype;
 	std::string gamename; // OpenLieroX
+	std::string buildmetadata; // SemVer build metadata after '+', e.g. "git.db202c4"; provenance only, ignored when comparing
 
 };
 
 
 // The following functions are declared INLINE because they are used very often.
 
-// For comparision, we ignore the following: revnum, gamename
+// For comparision, we ignore the following: revnum, gamename, buildmetadata
 // That means, a special revision of a baseversion should not change the behaviour (and it's only for debugging).
 // And another game like Hirudo should keep the same version-counting. We can start Hirudo at version 1.0 or 0.99.
 

--- a/include/Version.h
+++ b/include/Version.h
@@ -21,7 +21,7 @@ const char* GetGameName();
 const Version& GetGameVersion();
 
 // The full version string as produced by get_version_full.sh,
-// including the "+git.HASH" suffix (and a "-dirty" marker for a modified tree),
+// including the "+git.HASH" suffix (and a ".dirty" marker for a modified tree),
 // e.g. "20260616.4+git.b547037".
 // Shown verbatim wherever the version is displayed (window title, menu, crash reports):
 // it is the exact build string, not reconstructed through Version,

--- a/src/client/AuxLib.cpp
+++ b/src/client/AuxLib.cpp
@@ -466,9 +466,11 @@ bool VideoPostProcessor::initWindow() {
 	}
 
 setvideomode:
-	// Window title: short version string (see GetGameVersionString), not the
-	// integer-parsed asHumanString() which mangles the new format.
-	m_window = SDL_CreateWindow((std::string(GetGameName()) + " " + GetGameVersionString()).c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, screenWidth(), screenHeight(), vidflags);
+	// Window title: full version string incl. the "+git.HASH" suffix, so a dev
+	// build is identifiable at a glance. This is the raw string (see
+	// GetGameVersionStringFull), not the integer-parsed asHumanString() which
+	// mangles the new format.
+	m_window = SDL_CreateWindow((std::string(GetGameName()) + " " + GetGameVersionStringFull()).c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, screenWidth(), screenHeight(), vidflags);
 	
 	if(m_window.get() == NULL) {
 		if (resetting)  {

--- a/src/client/AuxLib.cpp
+++ b/src/client/AuxLib.cpp
@@ -466,10 +466,10 @@ bool VideoPostProcessor::initWindow() {
 	}
 
 setvideomode:
-	// Window title: full version string incl. the "+git.HASH" suffix, so a dev
-	// build is identifiable at a glance. This is the raw string (see
-	// GetGameVersionStringFull), not the integer-parsed asHumanString() which
-	// mangles the new format.
+	// Window title: the full version string incl. the "+git.HASH" suffix,
+	// so a dev build is identifiable at a glance.
+	// This is the exact build string (see GetGameVersionStringFull),
+	// shown verbatim rather than reconstructed via Version.
 	m_window = SDL_CreateWindow((std::string(GetGameName()) + " " + GetGameVersionStringFull()).c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, screenWidth(), screenHeight(), vidflags);
 	
 	if(m_window.get() == NULL) {

--- a/src/client/DeprecatedGUI/Menu_Main.cpp
+++ b/src/client/DeprecatedGUI/Menu_Main.cpp
@@ -270,10 +270,11 @@ void Menu_MainFrame()
 
 	// Credits
 
-	// Show the short get_version.sh string (e.g. "20260616.4", no git hash)
-	// rather than GetGameVersion().asHumanString(), which forces it through
-	// the old integer num.subnum scheme and would mangle the new format.
-	static const std::string credits1 = "  " + std::string(GetGameName()) + " " + GetGameVersionString();
+	// Show the full get_version_full.sh string (e.g. "20260616.4+git.b547037"),
+	// so the git hash of a dev build is visible. This is the raw string rather
+	// than GetGameVersion().asHumanString(), which forces it through the old
+	// integer num.subnum scheme and would mangle the new format.
+	static const std::string credits1 = "  " + std::string(GetGameName()) + " " + GetGameVersionStringFull();
 
 	static const std::string credits2 = std::string(
 		"- Original code by Jason Boettcher\n"

--- a/src/client/DeprecatedGUI/Menu_Main.cpp
+++ b/src/client/DeprecatedGUI/Menu_Main.cpp
@@ -271,9 +271,8 @@ void Menu_MainFrame()
 	// Credits
 
 	// Show the full get_version_full.sh string (e.g. "20260616.4+git.b547037"),
-	// so the git hash of a dev build is visible. This is the raw string rather
-	// than GetGameVersion().asHumanString(), which forces it through the old
-	// integer num.subnum scheme and would mangle the new format.
+	// so the git hash of a dev build is visible.
+	// This is the exact build string, shown verbatim rather than reconstructed via Version.
 	static const std::string credits1 = "  " + std::string(GetGameName()) + " " + GetGameVersionStringFull();
 
 	static const std::string credits2 = std::string(

--- a/src/common/Version.cpp
+++ b/src/common/Version.cpp
@@ -42,17 +42,6 @@ const std::string& GetGameVersionStringFull() {
 	return ver;
 }
 
-const std::string& GetGameVersionString() {
-	static std::string ver;
-	if(ver.empty()) {
-		ver = LX_VERSION;
-		// Strip the "+git.HASH" provenance suffix; keep just "YYYYMMDD.N".
-		size_t p = ver.find('+');
-		if(p != std::string::npos) ver.erase(p);
-	}
-	return ver;
-}
-
 INLINE void setByString__optionalPostCheck(const Version* version, const std::string& versionStr) {
 #ifdef DEBUG
 	if(version->asString() != versionStr) {

--- a/src/common/Version.cpp
+++ b/src/common/Version.cpp
@@ -62,9 +62,18 @@ INLINE void setByString__optionalPostCheck(const Version* version, const std::st
 }
 
 void Version::setByString(const std::string& versionStr) {
-	if(versionStr == "") { reset(); setByString__optionalPostCheck(this,versionStr); return; }
+	// SemVer build metadata (everything from the first '+', e.g. "+git.db202c4")
+	// is build provenance, not part of the comparable version,
+	// so drop it before parsing.
+	// Otherwise the git hash leaks into subsubnum
+	// and two builds of the same release compare as different versions.
+	std::string cmpStr = versionStr;
+	size_t plus = cmpStr.find('+');
+	if(plus != std::string::npos) cmpStr.erase(plus);
 
-	std::string tmp = versionStr;
+	if(cmpStr == "") { reset(); setByString__optionalPostCheck(this,cmpStr); return; }
+
+	std::string tmp = cmpStr;
 
 	size_t p = tmp.find_first_of(" /\\");
 	if(p == std::string::npos)
@@ -83,19 +92,19 @@ void Version::setByString(const std::string& versionStr) {
 	p = tmp.find(".");
 	bool fail = false;
 	num = from_string<int>(tmp.substr(0, p), fail);
-	if(fail) { num = 0; setByString__optionalPostCheck(this,versionStr); return; }
-	if(p == std::string::npos) { setByString__optionalPostCheck(this,versionStr); return; }
+	if(fail) { num = 0; setByString__optionalPostCheck(this,cmpStr); return; }
+	if(p == std::string::npos) { setByString__optionalPostCheck(this,cmpStr); return; }
 	tmp.erase(0, p + 1);
 
 	// subnum
 	p = tmp.find_first_of("._-");
 	subnum = from_string<int>(tmp.substr(0, p), fail);
-	if(fail) { subnum = 0; setByString__optionalPostCheck(this,versionStr); return; }
-	if(p == std::string::npos) { setByString__optionalPostCheck(this,versionStr); return; }
+	if(fail) { subnum = 0; setByString__optionalPostCheck(this,cmpStr); return; }
+	if(p == std::string::npos) { setByString__optionalPostCheck(this,cmpStr); return; }
 	tmp.erase(0, p + 1);
 
 	// releasetype
-	if(tmp == "") { setByString__optionalPostCheck(this,versionStr); return; }
+	if(tmp == "") { setByString__optionalPostCheck(this,cmpStr); return; }
 	size_t nextNumP = tmp.find_first_of("0123456789");
 	if(nextNumP == 0)
 		releasetype = RT_NORMAL;
@@ -110,22 +119,22 @@ void Version::setByString(const std::string& versionStr) {
 	tmp.erase(0, nextNumP);
 
 	// subsubnum
-	if(tmp == "") { setByString__optionalPostCheck(this,versionStr); return; }
+	if(tmp == "") { setByString__optionalPostCheck(this,cmpStr); return; }
 	if(tmp.find_first_of(".") == 0) tmp.erase(0, 1);
 	p = tmp.find_first_of("._-");
 	subsubnum = from_string<int>(tmp.substr(0, p), fail);
-	if(fail) { subsubnum = 0; setByString__optionalPostCheck(this,versionStr); return; }
-	if(p == std::string::npos) { setByString__optionalPostCheck(this,versionStr); return; }
+	if(fail) { subsubnum = 0; setByString__optionalPostCheck(this,cmpStr); return; }
+	if(p == std::string::npos) { setByString__optionalPostCheck(this,cmpStr); return; }
 	tmp.erase(0, p + 1);
 
 	// revnum
 	nextNumP = tmp.find_first_of("0123456789");
-	if(nextNumP == std::string::npos) { setByString__optionalPostCheck(this,versionStr); return; }
+	if(nextNumP == std::string::npos) { setByString__optionalPostCheck(this,cmpStr); return; }
 	tmp.erase(0, nextNumP);
 	revnum = from_string<int>(tmp, fail);
 	if(fail) revnum = 0;
 
-	setByString__optionalPostCheck(this,versionStr); return;
+	setByString__optionalPostCheck(this,cmpStr); return;
 }
 
 

--- a/src/common/Version.cpp
+++ b/src/common/Version.cpp
@@ -62,16 +62,22 @@ INLINE void setByString__optionalPostCheck(const Version* version, const std::st
 }
 
 void Version::setByString(const std::string& versionStr) {
-	// SemVer build metadata (everything from the first '+', e.g. "+git.db202c4")
-	// is build provenance, not part of the comparable version,
-	// so drop it before parsing.
-	// Otherwise the git hash leaks into subsubnum
-	// and two builds of the same release compare as different versions.
+	// Split off the SemVer build metadata (everything after the first '+', e.g. "git.db202c4").
+	// It is build provenance:
+	// kept for display and round-tripped by asString(),
+	// but not parsed into the num.subnum.subsubnum version,
+	// and ignored when comparing.
+	// Otherwise the git hash would leak into subsubnum
+	// and two builds of the same release would compare as different.
+	buildmetadata = "";
 	std::string cmpStr = versionStr;
 	size_t plus = cmpStr.find('+');
-	if(plus != std::string::npos) cmpStr.erase(plus);
+	if(plus != std::string::npos) {
+		buildmetadata = cmpStr.substr(plus + 1);
+		cmpStr.erase(plus);
+	}
 
-	if(cmpStr == "") { reset(); setByString__optionalPostCheck(this,cmpStr); return; }
+	if(versionStr == "") { reset(); setByString__optionalPostCheck(this,versionStr); return; }
 
 	std::string tmp = cmpStr;
 
@@ -92,19 +98,19 @@ void Version::setByString(const std::string& versionStr) {
 	p = tmp.find(".");
 	bool fail = false;
 	num = from_string<int>(tmp.substr(0, p), fail);
-	if(fail) { num = 0; setByString__optionalPostCheck(this,cmpStr); return; }
-	if(p == std::string::npos) { setByString__optionalPostCheck(this,cmpStr); return; }
+	if(fail) { num = 0; setByString__optionalPostCheck(this,versionStr); return; }
+	if(p == std::string::npos) { setByString__optionalPostCheck(this,versionStr); return; }
 	tmp.erase(0, p + 1);
 
 	// subnum
 	p = tmp.find_first_of("._-");
 	subnum = from_string<int>(tmp.substr(0, p), fail);
-	if(fail) { subnum = 0; setByString__optionalPostCheck(this,cmpStr); return; }
-	if(p == std::string::npos) { setByString__optionalPostCheck(this,cmpStr); return; }
+	if(fail) { subnum = 0; setByString__optionalPostCheck(this,versionStr); return; }
+	if(p == std::string::npos) { setByString__optionalPostCheck(this,versionStr); return; }
 	tmp.erase(0, p + 1);
 
 	// releasetype
-	if(tmp == "") { setByString__optionalPostCheck(this,cmpStr); return; }
+	if(tmp == "") { setByString__optionalPostCheck(this,versionStr); return; }
 	size_t nextNumP = tmp.find_first_of("0123456789");
 	if(nextNumP == 0)
 		releasetype = RT_NORMAL;
@@ -119,22 +125,22 @@ void Version::setByString(const std::string& versionStr) {
 	tmp.erase(0, nextNumP);
 
 	// subsubnum
-	if(tmp == "") { setByString__optionalPostCheck(this,cmpStr); return; }
+	if(tmp == "") { setByString__optionalPostCheck(this,versionStr); return; }
 	if(tmp.find_first_of(".") == 0) tmp.erase(0, 1);
 	p = tmp.find_first_of("._-");
 	subsubnum = from_string<int>(tmp.substr(0, p), fail);
-	if(fail) { subsubnum = 0; setByString__optionalPostCheck(this,cmpStr); return; }
-	if(p == std::string::npos) { setByString__optionalPostCheck(this,cmpStr); return; }
+	if(fail) { subsubnum = 0; setByString__optionalPostCheck(this,versionStr); return; }
+	if(p == std::string::npos) { setByString__optionalPostCheck(this,versionStr); return; }
 	tmp.erase(0, p + 1);
 
 	// revnum
 	nextNumP = tmp.find_first_of("0123456789");
-	if(nextNumP == std::string::npos) { setByString__optionalPostCheck(this,cmpStr); return; }
+	if(nextNumP == std::string::npos) { setByString__optionalPostCheck(this,versionStr); return; }
 	tmp.erase(0, nextNumP);
 	revnum = from_string<int>(tmp, fail);
 	if(fail) revnum = 0;
 
-	setByString__optionalPostCheck(this,cmpStr); return;
+	setByString__optionalPostCheck(this,versionStr); return;
 }
 
 
@@ -161,6 +167,12 @@ std::string Version::asString() const {
 		ret += itoa(revnum);
 	}
 
+	// SemVer build metadata, so the string round-trips through setByString.
+	if(!buildmetadata.empty()) {
+		ret += "+";
+		ret += buildmetadata;
+	}
+
 	return ret;
 }
 
@@ -181,6 +193,13 @@ std::string Version::asHumanString() const
 		case RT_UNKNOWN: ret += " "; break;
 		}
 		ret += itoa(subsubnum);
+	}
+
+	// Show the build provenance (git hash) in parentheses; helpful for dev builds.
+	if(!buildmetadata.empty()) {
+		ret += " (";
+		ret += buildmetadata;
+		ret += ")";
 	}
 
 	return ret;

--- a/tests/unit/test_Version.cpp
+++ b/tests/unit/test_Version.cpp
@@ -1,0 +1,38 @@
+/*
+ *  Unit tests for Version::setByString, the version-string parser.
+ */
+
+#include "unittest.h"
+#include "Version.h"
+
+void test_Version() {
+	// Regression: the SemVer "+git.HASH" build-metadata suffix must not leak
+	// into the parsed version. Before the fix "20260708.1+git.db202c4" parsed
+	// as num.subnum.subsubnum = 20260708.1.202 (the "202" from the hash),
+	// so a hashed build compared as a different version than a clean build.
+	{
+		Version v("OpenLieroX/20260708.1+git.db202c4");
+		CHECK(v.gamename == "OpenLieroX");
+		CHECK(v.num == 20260708);
+		CHECK(v.subnum == 1);
+		CHECK(v.subsubnum == 0);
+		CHECK(v.releasetype == Version::RT_NORMAL);
+		// Same release with and without the hash must compare equal.
+		CHECK(v == Version("OpenLieroX/20260708.1"));
+	}
+
+	// The plain date-based version round-trips through asString().
+	{
+		Version v("OpenLieroX/20260708.1");
+		CHECK(v.asString() == "OpenLieroX/20260708.1");
+	}
+
+	// A classic beta version still parses as before.
+	{
+		Version v("OpenLieroX/0.58_beta9");
+		CHECK(v.num == 0);
+		CHECK(v.subnum == 58);
+		CHECK(v.subsubnum == 9);
+		CHECK(v.releasetype == Version::RT_BETA);
+	}
+}

--- a/tests/unit/test_Version.cpp
+++ b/tests/unit/test_Version.cpp
@@ -35,14 +35,14 @@ void test_Version() {
 		CHECK(v.asString() == "OpenLieroX/20260708.1");
 	}
 
-	// A "-dirty" build marker (uncommitted tree, see functions.sh)
-	// is kept and round-trips:
-	// the hyphen lives in the metadata and is not parsed further.
+	// A ".dirty" build marker (uncommitted tree, see functions.sh)
+	// is kept and round-trips as an extra build-metadata identifier;
+	// the dots after '+' are not parsed as version components.
 	{
-		Version v("OpenLieroX/20260708.1+git.db202c4-dirty");
-		CHECK(v.buildmetadata == "git.db202c4-dirty");
+		Version v("OpenLieroX/20260708.1+git.db202c4.dirty");
+		CHECK(v.buildmetadata == "git.db202c4.dirty");
 		CHECK(v.subsubnum == 0);
-		CHECK(v.asString() == "OpenLieroX/20260708.1+git.db202c4-dirty");
+		CHECK(v.asString() == "OpenLieroX/20260708.1+git.db202c4.dirty");
 		CHECK(v == Version("OpenLieroX/20260708.1"));
 	}
 

--- a/tests/unit/test_Version.cpp
+++ b/tests/unit/test_Version.cpp
@@ -6,11 +6,12 @@
 #include "Version.h"
 
 void test_Version() {
-	// The SemVer "+git.HASH" build-metadata suffix is kept as provenance but
-	// must not leak into the parsed version. Before the fix
-	// "20260708.1+git.db202c4" parsed as num.subnum.subsubnum = 20260708.1.202
-	// (the "202" from the hash), so a hashed build compared as a different
-	// version than a clean build.
+	// The SemVer "+git.HASH" build-metadata suffix is kept as provenance,
+	// but must not leak into the parsed version.
+	// Before the fix, "20260708.1+git.db202c4" parsed
+	// as num.subnum.subsubnum = 20260708.1.202 (the "202" from the hash),
+	// so a hashed build compared as a different version
+	// than a clean build.
 	{
 		Version v("OpenLieroX/20260708.1+git.db202c4");
 		CHECK(v.gamename == "OpenLieroX");
@@ -34,8 +35,9 @@ void test_Version() {
 		CHECK(v.asString() == "OpenLieroX/20260708.1");
 	}
 
-	// A "-dirty" build marker (uncommitted tree, see functions.sh) is kept and
-	// round-trips: the hyphen lives in the metadata and is not parsed further.
+	// A "-dirty" build marker (uncommitted tree, see functions.sh)
+	// is kept and round-trips:
+	// the hyphen lives in the metadata and is not parsed further.
 	{
 		Version v("OpenLieroX/20260708.1+git.db202c4-dirty");
 		CHECK(v.buildmetadata == "git.db202c4-dirty");

--- a/tests/unit/test_Version.cpp
+++ b/tests/unit/test_Version.cpp
@@ -34,6 +34,16 @@ void test_Version() {
 		CHECK(v.asString() == "OpenLieroX/20260708.1");
 	}
 
+	// A "-dirty" build marker (uncommitted tree, see functions.sh) is kept and
+	// round-trips: the hyphen lives in the metadata and is not parsed further.
+	{
+		Version v("OpenLieroX/20260708.1+git.db202c4-dirty");
+		CHECK(v.buildmetadata == "git.db202c4-dirty");
+		CHECK(v.subsubnum == 0);
+		CHECK(v.asString() == "OpenLieroX/20260708.1+git.db202c4-dirty");
+		CHECK(v == Version("OpenLieroX/20260708.1"));
+	}
+
 	// A classic beta version still parses as before.
 	{
 		Version v("OpenLieroX/0.58_beta9");

--- a/tests/unit/test_Version.cpp
+++ b/tests/unit/test_Version.cpp
@@ -6,10 +6,11 @@
 #include "Version.h"
 
 void test_Version() {
-	// Regression: the SemVer "+git.HASH" build-metadata suffix must not leak
-	// into the parsed version. Before the fix "20260708.1+git.db202c4" parsed
-	// as num.subnum.subsubnum = 20260708.1.202 (the "202" from the hash),
-	// so a hashed build compared as a different version than a clean build.
+	// The SemVer "+git.HASH" build-metadata suffix is kept as provenance but
+	// must not leak into the parsed version. Before the fix
+	// "20260708.1+git.db202c4" parsed as num.subnum.subsubnum = 20260708.1.202
+	// (the "202" from the hash), so a hashed build compared as a different
+	// version than a clean build.
 	{
 		Version v("OpenLieroX/20260708.1+git.db202c4");
 		CHECK(v.gamename == "OpenLieroX");
@@ -17,13 +18,19 @@ void test_Version() {
 		CHECK(v.subnum == 1);
 		CHECK(v.subsubnum == 0);
 		CHECK(v.releasetype == Version::RT_NORMAL);
+		CHECK(v.buildmetadata == "git.db202c4");
 		// Same release with and without the hash must compare equal.
 		CHECK(v == Version("OpenLieroX/20260708.1"));
+		// asString() round-trips the full string, hash included.
+		CHECK(v.asString() == "OpenLieroX/20260708.1+git.db202c4");
+		// asHumanString() shows the hash for dev builds.
+		CHECK(v.asHumanString() == "OpenLieroX 20260708.1 (git.db202c4)");
 	}
 
-	// The plain date-based version round-trips through asString().
+	// The plain date-based version round-trips through asString(), no metadata.
 	{
 		Version v("OpenLieroX/20260708.1");
+		CHECK(v.buildmetadata == "");
 		CHECK(v.asString() == "OpenLieroX/20260708.1");
 	}
 

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -19,11 +19,13 @@ void olxCheckFailed(const char* expr, const char* file, int line) {
 
 // Test entry points, defined in the test_*.cpp files.
 void test_CBytestream();
+void test_Version();
 
 int main() {
 	printf("Running OLX unit tests...\n");
 
 	test_CBytestream();
+	test_Version();
 
 	if(g_olxTestFailures) {
 		printf("FAILED: %d check(s)\n", g_olxTestFailures);


### PR DESCRIPTION
## Problem

`Version::setByString` did not account for the SemVer `+git.HASH` build-metadata suffix
that the build system appends to the version string
(see `functions.sh`, format `YYYYMMDD.N+git.HASH`).

Parsing `OpenLieroX/20260708.1+git.db202c4`:

- `subnum` was read from `"1+git"`, giving `1` (the stream stops at `+`)
- the `db202c4` hash then fell through into the `subsubnum` slot
  as `202`, with an unknown release type

so it parsed as `20260708.1_202`, which is what the DEBUG warning reported:

```
WARNING: Version::setByString: 'OpenLieroX/20260708.1+git.db202c4' get parsed as 'OpenLieroX/20260708.1_202'
```

This is not only cosmetic:
a hashed build compared as a *different* version (`subsubnum` 202 vs 0)
than a clean build of the same release,
which affects version ordering and `isBanned()`.

## Change

Rather than discarding the suffix, keep it as build provenance and surface it:

- Parse the metadata into a new `Version::buildmetadata` field
  (everything after the first `+`, e.g. `git.db202c4`).
- It is **ignored when comparing** versions (like `revnum` and `gamename`),
  so two builds of the same release stay equal
  and `isBanned()` / ordering are unaffected.
- `asString()` round-trips it (so the DEBUG warning is gone),
  and `asHumanString()` shows it as `... (git.db202c4)`.

Because `asString()` is the on-the-wire version string,
a connected peer's hash now shows in its version line, e.g.
`Server is using OpenLieroX/20260708.35+git.db202c4`.
The local build's hash is shown in the window title and the main-menu credits
(now via `GetGameVersionStringFull()`, the exact build string);
the crash-report subject uses `asHumanString()` and so gains the hash for free.

Since `asHumanString()` no longer mangles the date format (that was the same hash-leak bug),
comments that warned it was broken are corrected,
and the now-unused short helper `GetGameVersionString()` is removed.

Additionally, `functions.sh` now appends a `.dirty` build-metadata identifier when the build tree has
uncommitted (tracked) changes, e.g. `20260708.37+git.e59a09b.dirty`,
so a build from a modified tree is not mistaken for the clean commit it is based on.
It rides along in the build metadata, so `Version` keeps and displays it with no C++ change.

Compatibility note:
the date-based `num` (e.g. `20260708`) dwarfs the old `0.5x` scheme,
so old peers already treat this build as "newest"
and enable every `>= 0.58.1` feature gate;
`isBanned()` is unaffected.
Network protocol compatibility is gated separately by `PROTOCOL_VERSION`,
not by this string.
Old OLX mis-parsing the hash is harmless
(and master already sent a mangled string before this PR).

## Test

Adds `tests/unit/test_Version.cpp`
(wired into `test_main.cpp` and the `olx_tests` target)
covering the hash-suffix parse (field value, comparison-equality, `asString`/`asHumanString` round-trip),
the plain no-metadata case, and an existing beta format as a guard.

## Verification

- `olx_tests` passes.
- Headless suite (`tests/headless/test_network.py`) passes; the client log confirms
  the wire round-trip: `Server is using OpenLieroX/20260708.35+git.db202c4`.
