### PR TITLE
Fix OpenLieroX casing in man page and config comments

### DIFF
--- a/doc/openlierox.6
+++ b/doc/openlierox.6
@@ -1,4 +1,4 @@
-.TH OPENLIEROX 6 "Version 1.0" Openlierox GAMES
+.TH OPENLIEROX 6 "Version 1.0" OpenLieroX GAMES
 
 .nf
 

--- a/share/gamedir/cfg/dedicated_config.py
+++ b/share/gamedir/cfg/dedicated_config.py
@@ -8,7 +8,7 @@ ADMIN_PREFIX = "!" # What kind of prefix you want for admin commands. Example: !
 SERVER_PORT = 23400 # What port to start server on, 23400 is the default
 
 # Where to log what is happening
-#NOTE: Do not specify path here, only file name. Path will be searched automatically based on Openlierox settings
+#NOTE: Do not specify path here, only file name. Path will be searched automatically based on OpenLieroX settings
 LOG_FILE = "dedicated_control.log"
 
 MIN_PLAYERS = 1

--- a/share/gamedir/cfg/dedicated_config_lx56.py
+++ b/share/gamedir/cfg/dedicated_config_lx56.py
@@ -8,7 +8,7 @@ ADMIN_PREFIX = "!" # What kind of prefix you want for admin commands. Example: !
 SERVER_PORT = 23402 # What port to start server on, 23400 is the default
 
 # Where to log what is happening
-#NOTE: Do not specify path here, only file name. Path will be searched automatically based on Openlierox settings
+#NOTE: Do not specify path here, only file name. Path will be searched automatically based on OpenLieroX settings
 LOG_FILE = "dedicated_control.log"
 
 MIN_PLAYERS = 1


### PR DESCRIPTION
Fix three stray `Openlierox` spellings to the correct `OpenLieroX`:

- the man page `.TH` source field (`doc/openlierox.6`),
- the log-file note in both dedicated-server config samples
  (`share/gamedir/cfg/dedicated_config.py`, `dedicated_config_lx56.py`).

Comment/doc-only, no code or behaviour change.
