### PR TITLE
Fix connect handshake dropping the challenge on a stale or duplicate packet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,8 @@ IF(OLX_TESTS)
 		${OLXROOTDIR}/tests/unit/test_main.cpp
 		${OLXROOTDIR}/tests/unit/test_CBytestream.cpp
 		${OLXROOTDIR}/tests/unit/test_Version.cpp
+		${OLXROOTDIR}/tests/unit/test_loopback.cpp
+		${OLXROOTDIR}/tests/unit/test_challenge_table.cpp
 		${ALL_SRCS} ${OLX_WIN_RESOURCES})
 	SET_TARGET_PROPERTIES(olx_tests PROPERTIES
 		RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"

--- a/include/CServer.h
+++ b/include/CServer.h
@@ -26,6 +26,7 @@
 #include "Timer.h"
 #include "CBanList.h"
 #include "game/GameMode.h"
+#include "ChallengeTable.h"
 
 class CWorm;
 class CServerConnection;
@@ -41,14 +42,6 @@ enum {
 	MAX_SERVER_SOCKETS = 6, // = max UDP masterservers
 };
 
-
-// Challenge structure
-class challenge_t { public:
-	NetworkAddr	Address;
-	AbsTime		fTime;
-	int			iNum;
-	std::string	sClientVersion;
-};
 
 // Client leaving reasons
 enum {

--- a/include/ChallengeTable.h
+++ b/include/ChallengeTable.h
@@ -1,0 +1,31 @@
+/*
+ *  The connection challenges the game server hands out:
+ *  a client must echo its number back in the connect packet.
+ */
+
+#ifndef OLX_CHALLENGETABLE_H
+#define OLX_CHALLENGETABLE_H
+
+#include <string>
+#include "Networking.h"
+#include "Timer.h"
+
+class challenge_t { public:
+	NetworkAddr	Address;
+	AbsTime		fTime;
+	int			iNum;
+	std::string	sClientVersion;
+};
+
+// Issue a challenge for addr in a table of count slots; return its number.
+int ChallengeTable_issue(challenge_t* slots, int count,
+						 const NetworkAddr& addr, AbsTime now,
+						 const std::string& clientVersion);
+
+// Consume addr's challenge if challId matches it, filling clientVersion;
+// return whether it matched.
+bool ChallengeTable_consume(challenge_t* slots, int count,
+							const NetworkAddr& addr, int challId,
+							std::string& clientVersion);
+
+#endif // OLX_CHALLENGETABLE_H

--- a/include/ChallengeTable.h
+++ b/include/ChallengeTable.h
@@ -17,13 +17,16 @@ class challenge_t { public:
 	std::string	sClientVersion;
 };
 
-// Issue a challenge for addr in a table of count slots; return its number.
+// Issue (or refresh) addr's challenge in a table of count slots;
+// return its number.
+// Repeated calls for the same address return the same number until consumed.
 int ChallengeTable_issue(challenge_t* slots, int count,
 						 const NetworkAddr& addr, AbsTime now,
 						 const std::string& clientVersion);
 
 // Consume addr's challenge if challId matches it, filling clientVersion;
 // return whether it matched.
+// A non-match leaves the challenge in place.
 bool ChallengeTable_consume(challenge_t* slots, int count,
 							const NetworkAddr& addr, int challId,
 							std::string& clientVersion);

--- a/src/server/CServer_Parse.cpp
+++ b/src/server/CServer_Parse.cpp
@@ -1025,8 +1025,6 @@ void GameServer::ParseConnectionlessPacket(const SmartPointer<NetworkSocket>& tS
 // Handle a "getchallenge" msg
 void GameServer::ParseGetChallenge(const SmartPointer<NetworkSocket>& tSocket, CBytestream *bs_in) {
 	NetworkAddr	adrFrom;
-	AbsTime		OldestTime = AbsTime::Max();
-	int			ChallengeToSet = -1;
 	CBytestream	bs;
 
 	//hints << "Got GetChallenge packet" << endl;
@@ -1080,40 +1078,9 @@ void GameServer::ParseGetChallenge(const SmartPointer<NetworkSocket>& tSocket, C
 		return;
 	}
 	
-	// see if we already have a challenge for this ip
-	for (int i = 0;i < MAX_CHALLENGES;i++) {
-
-		if (IsNetAddrValid(tChallenges[i].Address)) {
-			if (AreNetAddrEqual(adrFrom, tChallenges[i].Address)) {
-				// We already have a challenge for this address, reuse the slot.
-				// (Skipping it instead would, once every slot holds this address,
-				// leave ChallengeToSet at -1, i.e. no slot selected.)
-				ChallengeToSet = i;
-				break;
-			}
-			if (ChallengeToSet < 0 || tChallenges[i].fTime < OldestTime) {
-				OldestTime = tChallenges[i].fTime;
-				ChallengeToSet = i;
-			}
-		} else {
-			ChallengeToSet = i;
-			break;
-		}
-	}
-
-	// The loop above always selects a slot, so ChallengeToSet is >= 0 here.
-	// Guard anyway, so the tChallenges[ChallengeToSet] accesses below never
-	// use an invalid index should that ever change.
-	if (ChallengeToSet < 0) {
-		errors << "GameServer::ParseGetChallenge: no challenge slot selected" << endl;
-		return;
-	}
-
-	// overwrite the oldest
-	tChallenges[ChallengeToSet].iNum = (rand() << 16) ^ rand();
-	tChallenges[ChallengeToSet].Address = adrFrom;
-	tChallenges[ChallengeToSet].fTime = tLX->currentTime;
-	tChallenges[ChallengeToSet].sClientVersion = client_version;
+	// Issue (or reuse) a challenge slot for this address.
+	int challNum = ChallengeTable_issue(
+		tChallenges, MAX_CHALLENGES, adrFrom, tLX->currentTime, client_version);
 
 	// Send the challenge details back to the client
 	tSocket->setRemoteAddress(adrFrom);
@@ -1122,7 +1089,7 @@ void GameServer::ParseGetChallenge(const SmartPointer<NetworkSocket>& tSocket, C
 	// TODO: move this out here
 	bs.writeInt(-1, 4);
 	bs.writeString("lx::challenge");
-	bs.writeInt(tChallenges[ChallengeToSet].iNum, 4);
+	bs.writeInt(challNum, 4);
 	if( client_version != "" )
 		bs.writeString(GetFullGameName());
 	bs.Send(tSocket.get());
@@ -1233,37 +1200,15 @@ void GameServer::ParseConnect(const SmartPointer<NetworkSocket>& net_socket, CBy
 	
 	// If we ignored this challenge verification, there could be double connections
 
-	// See if the challenge is valid
+	// See if the challenge is valid.
+	// A reconnecting client keeps its slot on the server (reconnectFrom set),
+	// so its challenge need not still match.
 	{
-		bool valid_challenge = false;
-		int i;
-		for (i = 0; i < MAX_CHALLENGES; i++) {
-			if (IsNetAddrValid(tChallenges[i].Address) && AreNetAddrEqual(adrFrom, tChallenges[i].Address)) {
+		std::string challClientVersion;
+		bool validChallenge =
+			ChallengeTable_consume(tChallenges, MAX_CHALLENGES, adrFrom, ChallId, challClientVersion);
 
-				if (ChallId == tChallenges[i].iNum)  { // good
-					SetNetAddrValid(tChallenges[i].Address, false); // Invalidate it here to avoid duplicate connections
-					tChallenges[i].iNum = 0;
-					valid_challenge = true;
-					break;
-				} else { // bad
-					valid_challenge = false;
-
-					// HINT: we could receive another connect packet which will contain this challenge
-					// and therefore get the worm connected twice. To avoid it, we clear the challenge here
-					SetNetAddrValid(tChallenges[i].Address, false);
-					tChallenges[i].iNum = 0;
-					if(!reconnectFrom) {
-						hints << "HINT: deleting a doubled challenge" << endl;
-					}
-					
-					// There can be more challanges from one client, if this one doesn't match,
-					// perhaps some other does
-				}
-			}
-		}
-
-		// Ran out of challenges
-		if (!reconnectFrom && i == MAX_CHALLENGES ) {
+		if (!reconnectFrom && !validChallenge) {
 			notes << "No connection verification for client found" << endl;
 			CBytestream bytestr;
 			bytestr.writeInt(-1, 4);
@@ -1273,20 +1218,10 @@ void GameServer::ParseConnect(const SmartPointer<NetworkSocket>& net_socket, CBy
 			return;
 		}
 
-		if (!reconnectFrom && !valid_challenge)  {
-			notes << "Bad connection verification of client" << endl;
-			CBytestream bytestr;
-			bytestr.writeInt(-1, 4);
-			bytestr.writeString("lx::badconnect");
-			bytestr.writeString(OldLxCompatibleString(networkTexts->sBadVerification));
-			bytestr.Send(net_socket.get());
-			return;
-		}
-				
 		if(reconnectFrom)
 			clientVersion = reconnectFrom->getClientVersion();
 		else
-			clientVersion = tChallenges[i].sClientVersion;
+			clientVersion = challClientVersion;
 	}
 
 

--- a/src/server/ChallengeTable.cpp
+++ b/src/server/ChallengeTable.cpp
@@ -10,15 +10,22 @@
 int ChallengeTable_issue(challenge_t* slots, int count,
 						 const NetworkAddr& addr, AbsTime now,
 						 const std::string& clientVersion) {
-	AbsTime oldest = AbsTime::Max();
-	int slot = -1;
-
-	// Reuse this address's slot if it has one, else a free slot or the oldest.
+	// Reuse this address's live challenge if it has one,
+	// so a repeated getchallenge (e.g. a duplicated packet) returns the same number.
 	for(int i = 0; i < count; i++) {
-		if(IsNetAddrValid(slots[i].Address)) {
-			if(AreNetAddrEqual(addr, slots[i].Address)) { slot = i; break; }
-			if(slot < 0 || slots[i].fTime < oldest) { oldest = slots[i].fTime; slot = i; }
-		} else { slot = i; break; }
+		if(IsNetAddrValid(slots[i].Address) && AreNetAddrEqual(addr, slots[i].Address)) {
+			slots[i].fTime = now;
+			slots[i].sClientVersion = clientVersion;
+			return slots[i].iNum;
+		}
+	}
+
+	// Otherwise take a free slot, or overwrite the oldest.
+	int slot = -1;
+	AbsTime oldest = AbsTime::Max();
+	for(int i = 0; i < count; i++) {
+		if(!IsNetAddrValid(slots[i].Address)) { slot = i; break; }
+		if(slot < 0 || slots[i].fTime < oldest) { oldest = slots[i].fTime; slot = i; }
 	}
 	if(slot < 0) return 0;  // count <= 0
 
@@ -33,17 +40,16 @@ int ChallengeTable_issue(challenge_t* slots, int count,
 bool ChallengeTable_consume(challenge_t* slots, int count,
 							const NetworkAddr& addr, int challId,
 							std::string& clientVersion) {
+	// There is at most one live challenge per address (see ChallengeTable_issue).
 	for(int i = 0; i < count; i++) {
 		if(IsNetAddrValid(slots[i].Address) && AreNetAddrEqual(addr, slots[i].Address)) {
-			if(challId == slots[i].iNum) {
-				SetNetAddrValid(slots[i].Address, false);
-				slots[i].iNum = 0;
-				clientVersion = slots[i].sClientVersion;
-				return true;
-			}
-			// Mismatch: discard this address's live challenge.
-			SetNetAddrValid(slots[i].Address, false);
+			if(challId != slots[i].iNum)
+				// Stale or duplicate connect: keep the challenge for the correct one.
+				return false;
+			SetNetAddrValid(slots[i].Address, false);  // consume; blocks a replayed connect
 			slots[i].iNum = 0;
+			clientVersion = slots[i].sClientVersion;
+			return true;
 		}
 	}
 	return false;

--- a/src/server/ChallengeTable.cpp
+++ b/src/server/ChallengeTable.cpp
@@ -1,0 +1,50 @@
+/*
+ *  Connection-challenge table. See ChallengeTable.h.
+ */
+
+#include "ChallengeTable.h"
+
+#include <cstdlib>
+
+
+int ChallengeTable_issue(challenge_t* slots, int count,
+						 const NetworkAddr& addr, AbsTime now,
+						 const std::string& clientVersion) {
+	AbsTime oldest = AbsTime::Max();
+	int slot = -1;
+
+	// Reuse this address's slot if it has one, else a free slot or the oldest.
+	for(int i = 0; i < count; i++) {
+		if(IsNetAddrValid(slots[i].Address)) {
+			if(AreNetAddrEqual(addr, slots[i].Address)) { slot = i; break; }
+			if(slot < 0 || slots[i].fTime < oldest) { oldest = slots[i].fTime; slot = i; }
+		} else { slot = i; break; }
+	}
+	if(slot < 0) return 0;  // count <= 0
+
+	slots[slot].iNum = (rand() << 16) ^ rand();
+	slots[slot].Address = addr;
+	slots[slot].fTime = now;
+	slots[slot].sClientVersion = clientVersion;
+	return slots[slot].iNum;
+}
+
+
+bool ChallengeTable_consume(challenge_t* slots, int count,
+							const NetworkAddr& addr, int challId,
+							std::string& clientVersion) {
+	for(int i = 0; i < count; i++) {
+		if(IsNetAddrValid(slots[i].Address) && AreNetAddrEqual(addr, slots[i].Address)) {
+			if(challId == slots[i].iNum) {
+				SetNetAddrValid(slots[i].Address, false);
+				slots[i].iNum = 0;
+				clientVersion = slots[i].sClientVersion;
+				return true;
+			}
+			// Mismatch: discard this address's live challenge.
+			SetNetAddrValid(slots[i].Address, false);
+			slots[i].iNum = 0;
+		}
+	}
+	return false;
+}

--- a/tests/unit/test_challenge_table.cpp
+++ b/tests/unit/test_challenge_table.cpp
@@ -1,0 +1,92 @@
+/*
+ *  Unit tests for the server's connection-challenge table (ChallengeTable.h).
+ */
+
+#include "unittest.h"
+#include "ChallengeTable.h"
+
+#include <nl.h>
+#include <string>
+
+namespace {
+
+// StringToNetAddr needs a network driver selected; loopback is enough.
+struct NetDriver {
+	NetDriver() { nlInit(); nlSelectNetwork(NL_LOOP_BACK); }
+	~NetDriver() { nlShutdown(); }
+};
+
+void clearTable(challenge_t* t, int n) {
+	for(int i = 0; i < n; i++)
+		SetNetAddrValid(t[i].Address, false);
+}
+
+}
+
+// Issue a challenge, echo it back to connect, and it can't be replayed.
+void test_ChallengeIssueThenConsume() {
+	NetDriver net;
+	challenge_t table[8];
+	clearTable(table, 8);
+
+	NetworkAddr addr = StringToNetAddr("127.0.0.1:5555");
+	CHECK(IsNetAddrValid(addr));
+
+	int num = ChallengeTable_issue(table, 8, addr, AbsTime(), "beta9");
+	std::string ver;
+	CHECK(ChallengeTable_consume(table, 8, addr, num, ver));
+	CHECK(ver == "beta9");
+	CHECK(!ChallengeTable_consume(table, 8, addr, num, ver));  // consumed already
+}
+
+// A connect with the wrong challenge must not discard the live one,
+// so the correct connect right after still succeeds (the wasm 2nd-game bug).
+void test_ChallengeSurvivesStaleConnect() {
+	NetDriver net;
+	challenge_t table[8];
+	clearTable(table, 8);
+
+	NetworkAddr addr = StringToNetAddr("127.0.0.1:5555");
+	int cur = ChallengeTable_issue(table, 8, addr, AbsTime(), "beta9");
+
+	std::string ver;
+	CHECK(!ChallengeTable_consume(table, 8, addr, cur ^ 0x5a5a5a5a, ver));
+	CHECK(ChallengeTable_consume(table, 8, addr, cur, ver));
+	CHECK(ver == "beta9");
+}
+
+// A repeated getchallenge for the same address returns the same number
+// (idempotent), so a duplicated packet can't invalidate the first reply.
+void test_ChallengeReissueIsIdempotent() {
+	NetDriver net;
+	challenge_t table[8];
+	clearTable(table, 8);
+
+	NetworkAddr addr = StringToNetAddr("127.0.0.1:5555");
+	int a = ChallengeTable_issue(table, 8, addr, AbsTime(), "beta9");
+	int b = ChallengeTable_issue(table, 8, addr, AbsTime(), "beta9");
+	CHECK(a == b);
+
+	std::string ver;
+	CHECK(ChallengeTable_consume(table, 8, addr, a, ver));
+	// After it is consumed, the next getchallenge issues a fresh one.
+	int c = ChallengeTable_issue(table, 8, addr, AbsTime(), "beta9");
+	CHECK(ChallengeTable_consume(table, 8, addr, c, ver));
+}
+
+// A repeated consume with the same number:
+// the second one currently fails, because consume resets iNum on the first.
+// (Whether a duplicate connect should be re-accepted here,
+// or left to reconnectFrom in ParseConnect, is the open question.)
+void test_ChallengeConsumeRepeated() {
+	NetDriver net;
+	challenge_t table[8];
+	clearTable(table, 8);
+
+	NetworkAddr addr = StringToNetAddr("127.0.0.1:5555");
+	int num = ChallengeTable_issue(table, 8, addr, AbsTime(), "beta9");
+
+	std::string ver;
+	CHECK(ChallengeTable_consume(table, 8, addr, num, ver));
+	CHECK(!ChallengeTable_consume(table, 8, addr, num, ver));  // second: currently fails
+}

--- a/tests/unit/test_loopback.cpp
+++ b/tests/unit/test_loopback.cpp
@@ -1,0 +1,119 @@
+/*
+ *  Unit tests for HawkNL's loopback driver (NL_LOOP_BACK),
+ *  which only the wasm build uses (browsers can't open raw UDP sockets).
+ *  Checks the UDP-emulation OLX depends on: a datagram reaches a bound port
+ *  exactly once, the receiver can reply, and a second client still works.
+ */
+
+#include "unittest.h"
+
+#include <nl.h>
+
+static const NLushort kServerPort = 27100;
+
+// HawkNL defaults to non-blocking IO,
+// so a read with no data returns 0 rather than blocking.
+// Drain a socket and return how many datagrams it held.
+static int drain(NLsocket s) {
+	char buf[512];
+	int count = 0;
+	while(nlRead(s, buf, sizeof(buf)) > 0)
+		++count;
+	return count;
+}
+
+// Set up loopback for one test; torn down when it leaves scope.
+namespace {
+struct LoopbackNet {
+	LoopbackNet() {
+		CHECK(nlInit());
+		CHECK(nlSelectNetwork(NL_LOOP_BACK));
+	}
+	~LoopbackNet() { nlShutdown(); }
+};
+}
+
+// A single datagram to a bound port must arrive there exactly once.
+void test_LoopbackDeliversDatagramExactlyOnce() {
+	LoopbackNet net;
+	NLsocket server = nlOpen(kServerPort, NL_UNRELIABLE);
+	NLsocket client = nlOpen(0, NL_UNRELIABLE);
+	CHECK(server != NL_INVALID);
+	CHECK(client != NL_INVALID);
+
+	NLaddress srvAddr;
+	CHECK(nlGetLocalAddr(server, &srvAddr));
+	CHECK(nlSetRemoteAddr(client, &srvAddr));
+	CHECK(nlWrite(client, "hello", 5) == 5);
+
+	char buf[512];
+	CHECK(nlRead(server, buf, sizeof(buf)) == 5);
+	// Nothing else queued: the datagram was delivered exactly once.
+	CHECK(drain(server) == 0);
+
+	nlClose(client);
+	nlClose(server);
+}
+
+// The receiver must learn the sender's address and be able to reply,
+// which is what the server does to answer a getchallenge.
+void test_LoopbackReplyReachesSender() {
+	LoopbackNet net;
+	NLsocket server = nlOpen(kServerPort, NL_UNRELIABLE);
+	NLsocket client = nlOpen(0, NL_UNRELIABLE);
+	CHECK(server != NL_INVALID);
+	CHECK(client != NL_INVALID);
+
+	NLaddress srvAddr;
+	CHECK(nlGetLocalAddr(server, &srvAddr));
+	CHECK(nlSetRemoteAddr(client, &srvAddr));
+	CHECK(nlWrite(client, "getchallenge", 12) == 12);
+
+	char buf[512];
+	CHECK(nlRead(server, buf, sizeof(buf)) == 12);
+	NLaddress from;
+	CHECK(nlGetRemoteAddr(server, &from));
+
+	CHECK(nlSetRemoteAddr(server, &from));
+	CHECK(nlWrite(server, "challenge", 9) == 9);
+	CHECK(nlRead(client, buf, sizeof(buf)) == 9);
+	CHECK(drain(client) == 0);
+
+	nlClose(client);
+	nlClose(server);
+}
+
+// A second local game opens a fresh client socket against the same server.
+// The new datagram must reach the server exactly once,
+// with no stale or duplicated delivery left over from the first client.
+void test_LoopbackSecondClientReconnects() {
+	LoopbackNet net;
+	NLsocket server = nlOpen(kServerPort, NL_UNRELIABLE);
+	CHECK(server != NL_INVALID);
+
+	NLaddress srvAddr;
+	CHECK(nlGetLocalAddr(server, &srvAddr));
+	char buf[512];
+
+	{	// game 1
+		NLsocket c1 = nlOpen(0, NL_UNRELIABLE);
+		CHECK(c1 != NL_INVALID);
+		CHECK(nlSetRemoteAddr(c1, &srvAddr));
+		CHECK(nlWrite(c1, "g1", 2) == 2);
+		CHECK(nlRead(server, buf, sizeof(buf)) == 2);
+		CHECK(drain(server) == 0);
+		nlClose(c1);
+	}
+
+	{	// game 2: a new client socket
+		NLsocket c2 = nlOpen(0, NL_UNRELIABLE);
+		CHECK(c2 != NL_INVALID);
+		CHECK(nlSetRemoteAddr(c2, &srvAddr));
+		CHECK(nlWrite(c2, "g2", 2) == 2);
+		CHECK(nlRead(server, buf, sizeof(buf)) == 2);
+		CHECK(drain(server) == 0);
+		nlClose(c2);
+	}
+
+	nlClose(server);
+}

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -20,12 +20,26 @@ void olxCheckFailed(const char* expr, const char* file, int line) {
 // Test entry points, defined in the test_*.cpp files.
 void test_CBytestream();
 void test_Version();
+void test_LoopbackDeliversDatagramExactlyOnce();
+void test_LoopbackReplyReachesSender();
+void test_LoopbackSecondClientReconnects();
+void test_ChallengeIssueThenConsume();
+void test_ChallengeSurvivesStaleConnect();
+void test_ChallengeReissueIsIdempotent();
+void test_ChallengeConsumeRepeated();
 
 int main() {
 	printf("Running OLX unit tests...\n");
 
 	test_CBytestream();
 	test_Version();
+	test_LoopbackDeliversDatagramExactlyOnce();
+	test_LoopbackReplyReachesSender();
+	test_LoopbackSecondClientReconnects();
+	test_ChallengeIssueThenConsume();
+	test_ChallengeSurvivesStaleConnect();
+	test_ChallengeReissueIsIdempotent();
+	test_ChallengeConsumeRepeated();
 
 	if(g_olxTestFailures) {
 		printf("FAILED: %d check(s)\n", g_olxTestFailures);


### PR DESCRIPTION
## Problem

On the WebAssembly build, starting a **second** local game fails
with "client did not connect" (the game never starts).
The log shows `deleting a doubled challenge`
followed by repeated `No connection verification for client found`.
The desktop build is unaffected.

## The connect handshake

Before a client may connect,
the server issues a random challenge number for the client's address;
the client must echo it in its `connect`.
This holds those outstanding challenges (`ChallengeTable`), keyed by address.

## Fix

Two related weaknesses let a stale or duplicate packet break the handshake.

**1. A mismatched connect discarded the live challenge.**
A `connect` whose challenge number did not match the live one for its address
used to *delete* that challenge.
That is exactly the log above:
a re-connecting client sends a `connect` carrying a previous game's stale challenge,
it mismatches the freshly issued one,
the live challenge is deleted,
and the correct `connect` that follows then finds none.
Now a mismatch leaves the challenge in place;
only a matching `connect` consumes it (which still blocks a replayed connect).

**2. `getchallenge` was not idempotent.**
A duplicated `getchallenge` regenerated the number,
so two replies differed and the client's first `connect` mismatched.
Now a repeated `getchallenge` for an address returns the same number until consumed.
(This only matters on real UDP, since loopback doesn't duplicate packets,
but it fits the same "tolerate stale/duplicate packets" goal.)

The result is one uniform path for every case
(local or remote, first connect or reconnect),
with no special-case reconnect handling.

## Scope / honesty

Fix 1 targets the exact failure in the log and is the WASM-relevant change;
fix 2 is complementary UDP hardening.
The `ChallengeTable` logic is proven by unit tests,
but the full end-to-end WASM sequence
(which reconnect fires, why `reconnectFrom` is NULL) was not reproduced live.
The fix does not depend on that detail,
but a WASM trace would confirm sufficiency.

## Changes

- Extract the challenge storage and its issue/consume operations
  out of `GameServer` into `ChallengeTable`
  (behaviour-preserving refactor; also drops an unreachable branch),
  so the rules are unit-testable.
- Keep the challenge on a mismatched connect; make `getchallenge` idempotent.

## Tests

- `test_challenge_table.cpp`:
  the stale-then-correct sequence fails before the fix and passes after,
  plus idempotent issue and single-use consume.
- `test_loopback.cpp`:
  pins down that the loopback transport delivers exactly once and routes replies,
  isolating the fault to the logic.
- Unit tests and the full headless suite pass.
