### PR TITLE
Log SIGPIPE from the main loop, not the handler

### DIFF
--- a/include/Networking.h
+++ b/include/Networking.h
@@ -78,6 +78,7 @@ bool	GetFromDnsCache(const std::string& name, NetworkAddr& addr4, NetworkAddr& a
 // general networking
 bool	InitNetworkSystem();
 bool	QuitNetworkSystem();
+void	ReportPendingSigpipe();
 
 
 class NetworkSocket {

--- a/src/common/Networking.cpp
+++ b/src/common/Networking.cpp
@@ -198,12 +198,34 @@ static const NLaddress* getNLaddr(const NetworkAddr& addr) {
 // ------------------------------------------------------------------------
 
 
+
+
 #ifndef WIN32
-static void sigpipe_handler(int i) {
-	warnings << "got SIGPIPE, ignoring..." << endl;
-	signal(SIGPIPE, sigpipe_handler);
+// SIGPIPE fires when a write to a closed socket or pipe would otherwise kill us.
+// The handler runs in signal context, so it must be async-signal-safe:
+// it only bumps a counter.
+// It must not log here -- the logging path takes a mutex and writes to stdout,
+// and when the SIGPIPE came from a stdout write that recursed into a stack overflow.
+// ReportPendingSigpipe() emits the warning later, from the main loop.
+static volatile sig_atomic_t sigpipeCount = 0;
+static void sigpipe_handler(int) {
+	++sigpipeCount;
+	signal(SIGPIPE, sigpipe_handler); // re-arm where signal() resets the disposition
 }
 #endif
+
+// Runs on the main/game loop, where logging is safe.
+// Reports any SIGPIPEs that the handler recorded since the last call.
+void ReportPendingSigpipe() {
+#ifndef WIN32
+	static sig_atomic_t reported = 0;
+	const sig_atomic_t cur = sigpipeCount;
+	if(cur != reported) {
+		warnings << "got SIGPIPE (" << (int)(cur - reported) << "), ignoring" << endl;
+		reported = cur;
+	}
+#endif
+}
 
 
 /*
@@ -320,7 +342,8 @@ bool InitNetworkSystem() {
 	dnsCache6 = new ThreadVar<dnsCacheT>();
 
 #if !defined(WIN32) && !defined(__ANDROID__)
-	//sigignore(SIGPIPE);
+	// Catch SIGPIPE so a broken socket/pipe write does not kill us.
+	// The handler only records it; ReportPendingSigpipe() logs it safely later.
 	signal(SIGPIPE, sigpipe_handler);
 #endif
 	

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -45,6 +45,7 @@
 #include "Attr.h"
 #include "gusanos/luaapi/classes.h"
 #include "gusanos/network.h"
+#include "Networking.h"
 #include "FlagInfo.h"
 #include "CWpnRest.h"
 #include "CChannel.h"
@@ -679,6 +680,8 @@ struct GusSpeedScope {
 
 void Game::frame() {
 	SetCrashHandlerReturnPoint("main game loop");
+
+	ReportPendingSigpipe(); // log any SIGPIPE recorded by the signal handler
 
 	// Timing
 	tLX->currentTime = GetTime();


### PR DESCRIPTION
## Problem

Stack overflow (~90k frames) crashing the process:

```
sigpipe_handler(int)                       Networking.cpp
Logger::flush() / logger_output / endl     Debug.cpp
... repeated until the stack overflows ...
```

The SIGPIPE handler logged `got SIGPIPE` through the normal logging path, which takes a mutex and writes to stdout. When the SIGPIPE was itself raised by a *failed stdout write* (broken pipe), the handler's own log write raised SIGPIPE again, re-entered the handler, and recursed until the stack overflowed. (Logging from a signal handler is also not async-signal-safe -- mutex/printf/std::string are all disallowed there.)

## Fix

Keep the warning, but move it out of signal context:

- The handler only bumps a `volatile sig_atomic_t` counter (async-signal-safe), and re-arms itself.
- `ReportPendingSigpipe()`, called from `Game::frame`, logs any new SIGPIPEs from the main loop, where logging is valid.

So you still see `got SIGPIPE (N), ignoring`, without the recursion.

(Earlier revision of this PR used `SIG_IGN`, which dropped the warning entirely; this keeps it, per review.)

## Note

If the *stdout* pipe itself is the broken one, the warning write can re-SIGPIPE, so you'd get one line per frame while it stays broken (bounded, no recursion). For a broken game socket -- the normal case -- it logs once. Happy to rate-limit if you'd prefer.

## Testing

Builds; starts and runs normally (no spurious SIGPIPE). Branches off master, independent of the other crash fixes.