### PR TITLE
Release game content in ShutdownLieroX to avoid exit crash

### DIFF
--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -91,6 +91,17 @@ void Game::init() {
 	prepareMenu();
 }
 
+void Game::uninit() {
+	// Free the loaded content now (via the SmartPointers, so exactly once),
+	// while graphics/sound/cache are still up.
+	// Otherwise ~Game frees it at exit during static destruction,
+	// where those subsystems are already gone and it crashes.
+	m_gameMod = NULL;
+	m_gameMap = NULL;
+	m_gameMode = NULL;
+	m_wpnRest = NULL;
+}
+
 void Game::startServer(bool localGame) {
 	m_isServer = true;
 	m_isLocalGame = localGame;

--- a/src/game/Game.h
+++ b/src/game/Game.h
@@ -43,6 +43,7 @@ public:
 	Game();
 
 	void init();
+	void uninit(); // release loaded content; call at shutdown (see Game.cpp)
 	void startServer(bool localGame);
 	void startClient();
 	void startGame();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -820,7 +820,13 @@ static void ShutdownLoading()  {
 void ShutdownLieroX()
 {
 	notes << "Shutting me down..." << endl;
-	
+
+	// Free the loaded game content while all subsystems are still up
+	// (see Game::uninit), so it is not torn down in ~Game at exit.
+	// Skip on a restart: the engine keeps running and reuses game.
+	if(!bRestartGameAfterQuit)
+		game.uninit();
+
 	// Options
 	// Save already here in case some other method crashes
 	if(!bDedicated) // only save if not in dedicated mode


### PR DESCRIPTION
## Problem

Crash on exit:

```
SmartPointer_ObjectDeinit<CGameScript>(CGameScript*)
SmartPointer<CGameScript>::reset()
Game::~Game()
__cxa_finalize_ranges  ->  exit
```

`game` is a global. Its destructor frees the loaded content (mod/map/mode/weapon restrictions) via SmartPointers. On exit that runs at `__cxa_finalize`, where the subsystems those destructors depend on (e.g. `~CGameScript`) are already torn down, so it crashes. A static-destruction-order fiasco -- the mirror of #1027.

## Fix

Add `Game::uninit()`, which releases that content via its SmartPointers (freed exactly once), and call it early in `ShutdownLieroX` while all subsystems are still up. Skipped on a theme-restart, where the engine keeps running and reuses `game`.

## Testing

An auto-quit Lua demo drove a full clean shutdown: `game.uninit()` runs during `ShutdownLieroX` and frees the `CGameScript` with no crash (confirming the destructors are fine while subsystems are alive), and the process then runs through `__cxa_finalize`/`~Game` and exits with code 0. (Verified together with #1031, which was needed to reach a clean exit at all.)

Independent of #1027 and #1031; branches off master.