### PR TITLE
Cluster worms in gameplay test to fix respawn flake

### DIFF
--- a/tests/headless/test_gameplay.py
+++ b/tests/headless/test_gameplay.py
@@ -43,6 +43,9 @@ def test_bots_play_a_round_and_state_syncs_to_a_client(network_game):
         OLX_BOTS=3,              # three bots so combat is lively and reliable
         OLX_EMIT_STATE=1,        # report every worm's state each poll
         OLX_START_WHEN_WORMS=4,  # start once the three bots and the client are in
+        # Cluster worms at one spot so they fight at once;
+        # random spawns can delay the first kill past the timeout, causing flakes.
+        OLX_SPAWN_CLOSE=1,
         OLX_RUN_SECONDS=90,
     )
     assert server.wait_for("SERVER_LOBBY", timeout=30), server.read_log()


### PR DESCRIPTION
## Problem

`test_bots_play_a_round_and_state_syncs_to_a_client` is flaky.
A [master run](https://github.com/openlierox/openlierox/actions/runs/28943369661/job/85870878465)
failed on `wait_for("SERVER_RESPAWN", timeout=60)`,
even though the log shows a worm did die and respawn --
the respawn just landed right at the round deadline,
after the wait had already given up.

## Cause

Nothing regressed; it is inherent variance and this run drew the unlucky tail.
Bots spawn at uniformly random spots across the whole map
(`CMap::FindSpot` picks `rnd()*Width, rnd()*Height`),
so a kill -- and the respawn that follows -- can take most of the 90s round
to land, or not land in time.
On top of that the killing blow and frame timing are also nondeterministic,
so a worm can hover at low HP for a long time before it finally dies.

## Fix

The control script already has `OLX_SPAWN_CLOSE`,
which clusters every worm at one `findSpot` at round start.
Enabling it makes combat (and a kill) happen at point-blank within seconds,
leaving the rest of the round to observe the respawn.
The tolerant, property-based assertions are unchanged --
they are still the right design given real-time frame jitter,
which a fixed RNG seed could not remove anyway
(the game runs as two real processes over the network in wall-clock time).

## Verification

Ran the gameplay test 8x locally: all pass, each finishing in 22-43s
(versus the failing run, where the first kill only came at ~88s).
Full headless suite: 10 passed.
