### PR TITLE
Make teeStdoutInit idempotent to avoid orphaned tee at exit

### DIFF
--- a/src/common/TeeStdoutHandler.cpp
+++ b/src/common/TeeStdoutHandler.cpp
@@ -143,6 +143,11 @@ int threadedTeeStdout(void*) {
 }
 
 void teeStdoutInit() {
+	// Idempotent: a theme-switch restart runs this again while the tee is still up.
+	// Re-initialising would orphan the old tee, which then crashes at exit on teeOlxOutputFile.
+	if(teeStdoutInfo.thread || teeStdoutInfo.proc)
+		return;
+
 	int pipe_to_handler[2];
 
 	if(stdinCLIActive()) {


### PR DESCRIPTION
## Problem

Crash at exit in the tee-stdout thread:

```
Thread 'tee stdout' Crashed:
0  _platform_strlen
1  teeOlxOutputToFileHandler(int)   TeeStdoutHandler.cpp
2  threadedTeeStdout(void*)
3  SDL_RunThread
```

`teeStdoutInit()` runs on every startup, including after a theme-switch **restart** (`goto startpoint` in main.cpp), but `teeStdoutQuit()` only runs once at final exit. So each restart started a *second* tee (thread or forked process) and re-redirected stdout, **orphaning** the previous tee: it kept reading its old pipe, outlived `teeOlxOutputFile`, and crashed at exit dereferencing it (`strlen` on the freed/NULLed pointer). This only bites after at least one restart -- e.g. switching the theme -- and only in the threaded tee mode (stdin is a TTY); the forked mode leaks similarly.

## Fix

Return early from `teeStdoutInit()` if a tee is already up. The existing tee and its stdout/stderr redirect survive a restart, so there is exactly one tee for the process lifetime, cleaned up by the single `teeStdoutQuit()` at exit. `teeStdoutFile()` still updates the per-run log filename.

## Testing

Builds. I could not reproduce the threaded-tee path locally (my runs pipe stdin, so they take the forked path), so this rests on the code analysis above -- please verify by switching theme and quitting. Independent of the other crash-fix PRs; branches off master.