### PR TITLE
Defer SIGINT/SIGTERM handling out of the signal handler

### DIFF
--- a/include/EventQueue.h
+++ b/include/EventQueue.h
@@ -30,6 +30,7 @@ enum SDLUserEvent {
 // bDedicated must be set before we can call this
 void InitEventQueue();
 void ShutdownEventQueue();
+void ProcessPendingQuitSignal();
 
 
 

--- a/src/common/EventQueue.cpp
+++ b/src/common/EventQueue.cpp
@@ -226,37 +226,46 @@ static void InitQuitSignalHandler()
 	SetConsoleMode(stdin, ENABLE_PROCESSED_INPUT);
 }
 
+// The console-control handler runs on its own thread, so it pushes the quit
+// event directly; nothing to do from the main loop here.
+void ProcessPendingQuitSignal() {}
+
 #else // MacOSX, Linux, Unix
 
 #include <signal.h>
 
+static volatile sig_atomic_t gotQuitSignal = 0;
+
 static void QuitSignalHandler(int sig)
 {
-	if(mainQueue) {
-		SDL_Event event;
-		event.type = SDL_QUIT;
-		mainQueue->push(event);
-	} else {
-		warnings << "got quit-signal and mainQueue is not set" << endl;
-	}
-	// Don't set game.state here.
-	// This runs asynchronously in signal context,
-	// on whatever thread caught the signal,
-	// which is usually not the gameloop thread.
-	// game.state is an Attr,
-	// and assigning it runs the attribute-update machinery
-	// (locks, allocation, and a gameloop-thread assertion),
-	// which is neither reentrant nor async-signal-safe.
-	// Doing it here asserted or raced against the gameloop,
-	// and crashed on quit.
-	// The pushed SDL_QUIT event sets game.state = S_Quit via EvHndl_Quit,
-	// on the gameloop thread where ProcessEvents() dispatches it.
+	// Runs asynchronously in signal context,
+	// on whatever thread caught the signal:
+	// only async-signal-safe operations are allowed here.
+	// Just record it.
+	// Pushing the event takes the queue mutex, and logging takes the log mutex;
+	// both are unsafe here (deadlock) and were done in this handler before.
+	// ProcessPendingQuitSignal() does that from the main loop instead.
+	gotQuitSignal = 1;
 }
 
 static void InitQuitSignalHandler()
 {
 	signal(SIGINT, QuitSignalHandler);
 	signal(SIGTERM, QuitSignalHandler);
+}
+
+void ProcessPendingQuitSignal()
+{
+	if(!gotQuitSignal) return;
+	gotQuitSignal = 0;
+	if(mainQueue) {
+		SDL_Event event;
+		event.type = SDL_QUIT;
+		mainQueue->push(event);
+	} else
+		warnings << "got quit-signal and mainQueue is not set" << endl;
+	// The pushed SDL_QUIT sets game.state = S_Quit via EvHndl_Quit, on the
+	// gameloop thread where ProcessEvents() dispatches it.
 }
 
 #endif

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -693,6 +693,7 @@ void Game::frame() {
 	SetCrashHandlerReturnPoint("main game loop");
 
 	ReportPendingSigpipe(); // log any SIGPIPE recorded by the signal handler
+	ProcessPendingQuitSignal(); // act on a SIGINT/SIGTERM the handler recorded
 
 	// Timing
 	tLX->currentTime = GetTime();


### PR DESCRIPTION
Follow-up to the SIGPIPE fix (#1031): the same async-signal-safety issue in another handler, as discussed.

## Problem

`QuitSignalHandler` ([EventQueue.cpp](src/common/EventQueue.cpp)) runs in signal context but calls `mainQueue->push()` (takes the queue mutex) and, in the else branch, logs via `warnings` (takes the log mutex). Neither is async-signal-safe: if SIGINT/SIGTERM lands while a thread holds that mutex, the handler deadlocks. The author already handled this for `game.state` (there's a comment explaining why the handler pushes an event instead of assigning it), but the `push` and the log themselves were still done in the handler.

## Fix

Same pattern as #1031: the handler only sets a `volatile sig_atomic_t` flag. `ProcessPendingQuitSignal()`, called from `Game::frame`, pushes the SDL_QUIT event and logs from the main loop, where taking those mutexes is safe. Behaviour is unchanged -- the pushed event still sets `game.state = S_Quit` via `EvHndl_Quit` -- only the timing moves from signal context to the next frame.

The WIN32 console-control handler runs on its own thread (not signal context), so it keeps pushing directly; `ProcessPendingQuitSignal()` is a no-op there.

## Testing

Sent SIGINT to a running build (before the point it would quit on its own): it drove a clean shutdown via the new deferred path (`Shutting me down… / Good Bye… / Standard Out/Err recovered`), no crash or hang. Branches off master, independent of the other fixes.