### PR TITLE
Gate Google Play publish on the tests

### DIFF
--- a/.github/workflows/master-release.yaml
+++ b/.github/workflows/master-release.yaml
@@ -19,10 +19,12 @@ jobs:
     uses: ./.github/workflows/package-android.yml
     secrets: inherit
 
-  # Publish to the Play Store only on merge, after the Android build has
-  # produced and uploaded the signed bundle. PRs build but never publish.
+  # Publish to the Play Store only on merge,
+  # after the Android build has produced and uploaded the signed bundle,
+  # and only once the tests pass: a build with failing tests must not reach users.
+  # PRs build but never publish.
   publish-google-play:
-    needs: android
+    needs: [android, headless-tests]
     uses: ./.github/workflows/publish-to-google-play.yaml
     secrets: inherit
 


### PR DESCRIPTION
## What

Make the `publish-google-play` job depend on `headless-tests`
in addition to the Android build.

## Why

`publish-google-play` previously only had `needs: android`,
so it published the signed bundle to the Play Store as soon as the Android build finished,
regardless of whether the tests passed.
This actually fired: in run [28949141035](https://github.com/openlierox/openlierox/actions/runs/28949141035)
the Play Store publish ran and succeeded even though the headless tests had failed (timed out).

The `release` job that publishes the GitHub release was already gated on `headless-tests`;
this gives the Play Store publish the same gate,
so a build with failing tests never reaches users.

## Note for reviewers

`headless-tests` is a single job with two dependents now (`publish-google-play` and `release`);
`needs:` only adds a dependency edge, so it still runs once, not twice.

Out of scope for this PR: the headless-tests timeout in that run
(the Linux headless suite exceeded its 30 min limit) is a separate issue worth investigating on its own.
