### PR TITLE
Re-seal macOS .app after adding libSDL3 (fixes #1037)

### DIFF
--- a/.github/workflows/package-macos.sh
+++ b/.github/workflows/package-macos.sh
@@ -141,6 +141,15 @@ fi
 # Re-signing here, after everything is in place, makes the seal cover it all.
 codesign --force --deep --sign - "$APP"
 
+# Sanity check the finished bundle: the signature must be valid and every
+# sealed resource must match its recorded hash. This is exactly what was
+# broken in #1037 (libSDL3 added after signing), so verify it now and fail
+# the build rather than ship a "damaged" app.
+if ! codesign --verify --deep --strict "$APP"; then
+    echo "ERROR: bundle code signature verification failed" >&2
+    exit 1
+fi
+
 # Zip uses tilde instead of underscore so e.g. "beta9" sorts correctly.
 VERSION="$(./get_version.sh | tr '_' '~')"
 ZIP="openlierox_${VERSION}_macos.zip"

--- a/.github/workflows/package-macos.sh
+++ b/.github/workflows/package-macos.sh
@@ -133,6 +133,14 @@ if [ "$leaked" -ne 0 ]; then
     exit 1
 fi
 
+# Seal the whole bundle with a fresh ad-hoc signature, last of all.
+# dylibbundler signs the binary and its bundled libs and seals the bundle,
+# but we add libSDL3.dylib afterwards,
+# which invalidates that seal ("a sealed resource is missing or invalid"),
+# so a downloaded (quarantined) app reads as "damaged and can't be opened" to Gatekeeper.
+# Re-signing here, after everything is in place, makes the seal cover it all.
+codesign --force --deep --sign - "$APP"
+
 # Zip uses tilde instead of underscore so e.g. "beta9" sorts correctly.
 VERSION="$(./get_version.sh | tr '_' '~')"
 ZIP="openlierox_${VERSION}_macos.zip"


### PR DESCRIPTION
Fixes #1037.

## Problem

The downloaded Mac build fails with **"OpenLieroX.app is damaged and can't be opened."**

`package-macos.sh` adds `libSDL3.dylib` to `Contents/Frameworks` **after** dylibbundler has already signed and sealed the bundle. Adding a file after the seal invalidates it:

```
$ codesign --verify --deep --strict OpenLieroX.app
OpenLieroX.app: a sealed resource is missing or invalid
```

(and `libSDL3.dylib` is absent from `Contents/_CodeSignature/CodeResources`). A **quarantined** copy (i.e. downloaded from a browser) with a broken seal is what Gatekeeper reports as "damaged".

## Fix

Re-sign the whole bundle ad-hoc as the **last** packaging step, after everything (including libSDL3) is in place:

```sh
codesign --force --deep --sign - "$APP"
```

After this:

```
$ codesign --verify --deep --strict OpenLieroX.app
OpenLieroX.app: valid on disk
OpenLieroX.app: satisfies its Designated Requirement
```

and `libSDL3.dylib` is now in the seal. Verified by running the full script and re-checking.

## Caveat / follow-up

The app is still only **ad-hoc signed, not notarized**, so a freshly downloaded copy will show the normal "unidentified developer" prompt (right-click → Open, or `xattr -cr OpenLieroX.app`) -- but it is no longer reported as *damaged*. Removing that prompt entirely needs Developer-ID signing + notarization (an Apple Developer account and CI secrets); happy to wire that up separately if wanted.

**Immediate workaround for the already-released 20260708.43 build:** `xattr -cr /path/to/OpenLieroX.app` then open.