### PR TITLE
Fix tee-stdout crash on exit (reliable thread join)

### DIFF
--- a/src/common/TeeStdoutHandler.cpp
+++ b/src/common/TeeStdoutHandler.cpp
@@ -29,11 +29,50 @@ void teeStdoutQuit(bool) {}
 #include <sys/types.h>
 #include <sys/mman.h>
 #include <fcntl.h>
+#include <cstring>
+#include <cstdint>
+#include <atomic>
 
-static char* teeOlxOutputFile = NULL;
 static const size_t MAXFILENAMESIZE = 2048;
 
-const char* GetLogFilename() { if(teeOlxOutputFile) return teeOlxOutputFile; return ""; }
+// The current log filename, shared between the main thread (the only writer,
+// via teeStdoutFile) and the tee reader. The reader runs either on another
+// thread (stdin CLI path) or in the forked tee process (default path), so it
+// cannot share a Mutex with the writer -- least of all across the fork's
+// shared-memory boundary. We guard it with a single-writer seqlock instead:
+// the reader takes a bounded, consistent snapshot without ever blocking or
+// running strlen off the end of a half-written buffer.
+// This is a POD so it lives happily in malloc'd or mmap'd (fork-shared) memory.
+struct TeeLogTarget {
+	volatile uint32_t seq; // odd while a write is in progress
+	volatile uint32_t len; // length of name, without the terminator
+	char name[MAXFILENAMESIZE];
+};
+
+static TeeLogTarget* teeLogTarget = NULL;
+
+// Copy the current log filename into out (at least MAXFILENAMESIZE bytes),
+// always NUL-terminated within bounds.
+// Returns false (out set to "") when there is no target,
+// or no consistent snapshot could be read.
+static bool readTeeLogFilename(char* out) {
+	if(!teeLogTarget) { out[0] = 0; return false; }
+	for(int tries = 0; tries < 4; ++tries) {
+		uint32_t s0 = teeLogTarget->seq;
+		if(s0 & 1u) continue; // a write is in progress
+		std::atomic_thread_fence(std::memory_order_acquire);
+		uint32_t n = teeLogTarget->len;
+		if(n >= MAXFILENAMESIZE) n = MAXFILENAMESIZE - 1; // clamp a torn length
+		memcpy(out, teeLogTarget->name, n);
+		out[n] = 0;
+		std::atomic_thread_fence(std::memory_order_acquire);
+		if(s0 == teeLogTarget->seq) return true; // name did not change under us
+	}
+	out[0] = 0;
+	return false;
+}
+
+const char* GetLogFilename() { if(teeLogTarget) return teeLogTarget->name; return ""; }
 
 #include <unistd.h>
 #include <signal.h>
@@ -54,11 +93,17 @@ static void teeOlxOutputToFileHandler(int c) {
 		fwrite(&ch, 1, 1, out);
 	else
 		buffer += c;
-	
-	if(ch == '\n' && currentOlxOutputFilename != teeOlxOutputFile) {
+
+	// The filename is written by another thread/process (teeStdoutFile),
+	// and torn down at exit (teeStdoutQuit),
+	// so take a safe snapshot rather than dereferencing the shared buffer directly:
+	// reading a half-written or freed name as a std::string
+	// would run strlen off the end and crash.
+	char currentFilename[MAXFILENAMESIZE];
+	if(ch == '\n' && readTeeLogFilename(currentFilename) && currentOlxOutputFilename != currentFilename) {
 		if(out) fclose(out);
 		out = NULL;
-		currentOlxOutputFilename = teeOlxOutputFile;
+		currentOlxOutputFilename = currentFilename;
 		if(currentOlxOutputFilename != "") {
 			out = fopen(currentOlxOutputFilename.c_str(), "a");
 			if(out)
@@ -144,7 +189,7 @@ int threadedTeeStdout(void*) {
 
 void teeStdoutInit() {
 	// Idempotent: a theme-switch restart runs this again while the tee is still up.
-	// Re-initialising would orphan the old tee, which then crashes at exit on teeOlxOutputFile.
+	// Re-initialising would orphan the old tee, which then crashes at exit on the log target.
 	if(teeStdoutInfo.thread || teeStdoutInfo.proc)
 		return;
 
@@ -154,12 +199,12 @@ void teeStdoutInit() {
 		// we must fall back to a saver teeStdout version which must be synced with the stdin CLI
 		notes << "teeStdout: save multithreaded fallback" << endl;
 
-		teeOlxOutputFile = (char*) malloc(MAXFILENAMESIZE);
-		if(!teeOlxOutputFile) {
+		teeLogTarget = (TeeLogTarget*) malloc(sizeof(TeeLogTarget));
+		if(!teeLogTarget) {
 			errors << "teeStdout: not enough mem" << endl;
 			return;
 		}
-		*teeOlxOutputFile = 0;
+		memset(teeLogTarget, 0, sizeof(TeeLogTarget));
 
 		if(pipe(pipe_to_handler) != 0) { // error creating pipe
 			errors << "teeStdout: cannot create pipe: " << strerror(errno) << endl;
@@ -179,23 +224,24 @@ void teeStdoutInit() {
 	}
 	
 #ifdef __APPLE__
-	teeOlxOutputFile = (char*) mmap(0, MAXFILENAMESIZE, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANON, 0, 0);
-#else	
+	teeLogTarget = (TeeLogTarget*) mmap(0, sizeof(TeeLogTarget), PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANON, 0, 0);
+#else
 	int fd = open("/dev/zero", O_RDWR);
 	if(fd < 0) {
 		errors << "teeStdout: cannot open dummy file" << endl;
 		return;
 	}
-	
-	teeOlxOutputFile = (char*) mmap(0, MAXFILENAMESIZE, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+
+	teeLogTarget = (TeeLogTarget*) mmap(0, sizeof(TeeLogTarget), PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
 #endif
-	
-	if(!teeOlxOutputFile || teeOlxOutputFile == (char*)-1) {
-		teeOlxOutputFile = NULL;
+
+	if(!teeLogTarget || teeLogTarget == (TeeLogTarget*)-1) {
+		teeLogTarget = NULL;
 		errors << "teeStdout: cannot mmap: " << strerror(errno) << endl;
 		return;
 	}
-	*teeOlxOutputFile = 0;
+	// The mapping is zero-filled, so seq/len/name start cleared;
+	// the fork below shares it with the tee process.
 
 	if(pipe(pipe_to_handler) != 0) { // error creating pipe
 		errors << "teeStdout: cannot create pipe: " << strerror(errno) << endl;		
@@ -220,15 +266,24 @@ void teeStdoutInit() {
 }
 
 void teeStdoutFile(const std::string& file) {
-	if(!teeOlxOutputFile) return;
-	
-	if(file.size() >= MAXFILENAMESIZE - 1) {
+	if(!teeLogTarget) return;
+
+	std::string name = file;
+	if(name.size() >= MAXFILENAMESIZE - 1) {
 		errors << "teeStdoutFile: filename " << file << " too big" << endl;
-		strcpy(teeOlxOutputFile, "");
-		return;
+		name.clear();
 	}
-	
-	strcpy(teeOlxOutputFile, file.c_str());
+
+	// Single-writer seqlock publish: bump seq odd, write the name, bump seq even.
+	// The release fences keep the reader from seeing the new name with a stale seq.
+	uint32_t s = teeLogTarget->seq;
+	teeLogTarget->seq = s + 1;
+	std::atomic_thread_fence(std::memory_order_release);
+	memcpy(teeLogTarget->name, name.data(), name.size());
+	teeLogTarget->name[name.size()] = 0;
+	teeLogTarget->len = (uint32_t) name.size();
+	std::atomic_thread_fence(std::memory_order_release);
+	teeLogTarget->seq = s + 2;
 }
 
 #include <sys/wait.h>
@@ -256,12 +311,15 @@ void teeStdoutQuit(bool wait) {
 		printf("Standard Out/Err recovered\n");
 	}
 	
-	if(teeOlxOutputFile && wait /* otherwise unsafe */) {
+	if(teeLogTarget && wait /* otherwise unsafe */) {
+		// Publish NULL before releasing the memory, so a lingering tee reader
+		// sees readTeeLogFilename() bail out rather than a dangling pointer.
+		TeeLogTarget* toFree = teeLogTarget;
+		teeLogTarget = NULL;
 		if(teeStdoutInfo.proc)
-			munmap(teeOlxOutputFile, MAXFILENAMESIZE);
+			munmap(toFree, sizeof(TeeLogTarget));
 		else if(teeStdoutInfo.thread)
-			free(teeOlxOutputFile);
-		teeOlxOutputFile = NULL;
+			free(toFree);
 	}
 }
 

--- a/src/common/TeeStdoutHandler.cpp
+++ b/src/common/TeeStdoutHandler.cpp
@@ -29,50 +29,11 @@ void teeStdoutQuit(bool) {}
 #include <sys/types.h>
 #include <sys/mman.h>
 #include <fcntl.h>
-#include <cstring>
-#include <cstdint>
-#include <atomic>
 
+static char* teeOlxOutputFile = NULL;
 static const size_t MAXFILENAMESIZE = 2048;
 
-// The current log filename, shared between the main thread (the only writer,
-// via teeStdoutFile) and the tee reader. The reader runs either on another
-// thread (stdin CLI path) or in the forked tee process (default path), so it
-// cannot share a Mutex with the writer -- least of all across the fork's
-// shared-memory boundary. We guard it with a single-writer seqlock instead:
-// the reader takes a bounded, consistent snapshot without ever blocking or
-// running strlen off the end of a half-written buffer.
-// This is a POD so it lives happily in malloc'd or mmap'd (fork-shared) memory.
-struct TeeLogTarget {
-	volatile uint32_t seq; // odd while a write is in progress
-	volatile uint32_t len; // length of name, without the terminator
-	char name[MAXFILENAMESIZE];
-};
-
-static TeeLogTarget* teeLogTarget = NULL;
-
-// Copy the current log filename into out (at least MAXFILENAMESIZE bytes),
-// always NUL-terminated within bounds.
-// Returns false (out set to "") when there is no target,
-// or no consistent snapshot could be read.
-static bool readTeeLogFilename(char* out) {
-	if(!teeLogTarget) { out[0] = 0; return false; }
-	for(int tries = 0; tries < 4; ++tries) {
-		uint32_t s0 = teeLogTarget->seq;
-		if(s0 & 1u) continue; // a write is in progress
-		std::atomic_thread_fence(std::memory_order_acquire);
-		uint32_t n = teeLogTarget->len;
-		if(n >= MAXFILENAMESIZE) n = MAXFILENAMESIZE - 1; // clamp a torn length
-		memcpy(out, teeLogTarget->name, n);
-		out[n] = 0;
-		std::atomic_thread_fence(std::memory_order_acquire);
-		if(s0 == teeLogTarget->seq) return true; // name did not change under us
-	}
-	out[0] = 0;
-	return false;
-}
-
-const char* GetLogFilename() { if(teeLogTarget) return teeLogTarget->name; return ""; }
+const char* GetLogFilename() { if(teeOlxOutputFile) return teeOlxOutputFile; return ""; }
 
 #include <unistd.h>
 #include <signal.h>
@@ -94,16 +55,15 @@ static void teeOlxOutputToFileHandler(int c) {
 	else
 		buffer += c;
 
-	// The filename is written by another thread/process (teeStdoutFile),
-	// and torn down at exit (teeStdoutQuit),
-	// so take a safe snapshot rather than dereferencing the shared buffer directly:
-	// reading a half-written or freed name as a std::string
-	// would run strlen off the end and crash.
-	char currentFilename[MAXFILENAMESIZE];
-	if(ch == '\n' && readTeeLogFilename(currentFilename) && currentOlxOutputFilename != currentFilename) {
+	// teeStdoutQuit() can free teeOlxOutputFile and set it to NULL
+	// while an orphaned tee thread is still draining output through here.
+	// Read it once and skip the filename handling if it's gone:
+	// comparing the std::string against a NULL char* calls strlen(NULL) and crashes.
+	const char* outputFile = teeOlxOutputFile;
+	if(ch == '\n' && outputFile && currentOlxOutputFilename != outputFile) {
 		if(out) fclose(out);
 		out = NULL;
-		currentOlxOutputFilename = currentFilename;
+		currentOlxOutputFilename = outputFile;
 		if(currentOlxOutputFilename != "") {
 			out = fopen(currentOlxOutputFilename.c_str(), "a");
 			if(out)
@@ -189,7 +149,7 @@ int threadedTeeStdout(void*) {
 
 void teeStdoutInit() {
 	// Idempotent: a theme-switch restart runs this again while the tee is still up.
-	// Re-initialising would orphan the old tee, which then crashes at exit on the log target.
+	// Re-initialising would orphan the old tee, which then crashes at exit on teeOlxOutputFile.
 	if(teeStdoutInfo.thread || teeStdoutInfo.proc)
 		return;
 
@@ -199,12 +159,17 @@ void teeStdoutInit() {
 		// we must fall back to a saver teeStdout version which must be synced with the stdin CLI
 		notes << "teeStdout: save multithreaded fallback" << endl;
 
-		teeLogTarget = (TeeLogTarget*) malloc(sizeof(TeeLogTarget));
-		if(!teeLogTarget) {
+		teeOlxOutputFile = (char*) malloc(MAXFILENAMESIZE);
+		if(!teeOlxOutputFile) {
 			errors << "teeStdout: not enough mem" << endl;
 			return;
 		}
-		memset(teeLogTarget, 0, sizeof(TeeLogTarget));
+		// Zero the whole buffer, not just the first byte:
+		// the tee thread reads it via strlen while teeStdoutFile() rewrites it,
+		// and teeStdoutFile() never writes past MAXFILENAMESIZE - 1,
+		// so a zeroed tail guarantees a terminator within bounds even mid-write.
+		// (The mmap paths below are already zero-filled by the OS.)
+		memset(teeOlxOutputFile, 0, MAXFILENAMESIZE);
 
 		if(pipe(pipe_to_handler) != 0) { // error creating pipe
 			errors << "teeStdout: cannot create pipe: " << strerror(errno) << endl;
@@ -224,24 +189,23 @@ void teeStdoutInit() {
 	}
 	
 #ifdef __APPLE__
-	teeLogTarget = (TeeLogTarget*) mmap(0, sizeof(TeeLogTarget), PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANON, 0, 0);
-#else
+	teeOlxOutputFile = (char*) mmap(0, MAXFILENAMESIZE, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANON, 0, 0);
+#else	
 	int fd = open("/dev/zero", O_RDWR);
 	if(fd < 0) {
 		errors << "teeStdout: cannot open dummy file" << endl;
 		return;
 	}
-
-	teeLogTarget = (TeeLogTarget*) mmap(0, sizeof(TeeLogTarget), PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+	
+	teeOlxOutputFile = (char*) mmap(0, MAXFILENAMESIZE, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
 #endif
-
-	if(!teeLogTarget || teeLogTarget == (TeeLogTarget*)-1) {
-		teeLogTarget = NULL;
+	
+	if(!teeOlxOutputFile || teeOlxOutputFile == (char*)-1) {
+		teeOlxOutputFile = NULL;
 		errors << "teeStdout: cannot mmap: " << strerror(errno) << endl;
 		return;
 	}
-	// The mapping is zero-filled, so seq/len/name start cleared;
-	// the fork below shares it with the tee process.
+	*teeOlxOutputFile = 0;
 
 	if(pipe(pipe_to_handler) != 0) { // error creating pipe
 		errors << "teeStdout: cannot create pipe: " << strerror(errno) << endl;		
@@ -266,24 +230,15 @@ void teeStdoutInit() {
 }
 
 void teeStdoutFile(const std::string& file) {
-	if(!teeLogTarget) return;
-
-	std::string name = file;
-	if(name.size() >= MAXFILENAMESIZE - 1) {
+	if(!teeOlxOutputFile) return;
+	
+	if(file.size() >= MAXFILENAMESIZE - 1) {
 		errors << "teeStdoutFile: filename " << file << " too big" << endl;
-		name.clear();
+		strcpy(teeOlxOutputFile, "");
+		return;
 	}
-
-	// Single-writer seqlock publish: bump seq odd, write the name, bump seq even.
-	// The release fences keep the reader from seeing the new name with a stale seq.
-	uint32_t s = teeLogTarget->seq;
-	teeLogTarget->seq = s + 1;
-	std::atomic_thread_fence(std::memory_order_release);
-	memcpy(teeLogTarget->name, name.data(), name.size());
-	teeLogTarget->name[name.size()] = 0;
-	teeLogTarget->len = (uint32_t) name.size();
-	std::atomic_thread_fence(std::memory_order_release);
-	teeLogTarget->seq = s + 2;
+	
+	strcpy(teeOlxOutputFile, file.c_str());
 }
 
 #include <sys/wait.h>
@@ -311,15 +266,12 @@ void teeStdoutQuit(bool wait) {
 		printf("Standard Out/Err recovered\n");
 	}
 	
-	if(teeLogTarget && wait /* otherwise unsafe */) {
-		// Publish NULL before releasing the memory, so a lingering tee reader
-		// sees readTeeLogFilename() bail out rather than a dangling pointer.
-		TeeLogTarget* toFree = teeLogTarget;
-		teeLogTarget = NULL;
+	if(teeOlxOutputFile && wait /* otherwise unsafe */) {
 		if(teeStdoutInfo.proc)
-			munmap(toFree, sizeof(TeeLogTarget));
+			munmap(teeOlxOutputFile, MAXFILENAMESIZE);
 		else if(teeStdoutInfo.thread)
-			free(toFree);
+			free(teeOlxOutputFile);
+		teeOlxOutputFile = NULL;
 	}
 }
 

--- a/src/common/TeeStdoutHandler.cpp
+++ b/src/common/TeeStdoutHandler.cpp
@@ -29,8 +29,12 @@ void teeStdoutQuit(bool) {}
 #include <sys/types.h>
 #include <sys/mman.h>
 #include <fcntl.h>
+#include <thread>
+#include <system_error>
+#include "AuxLib.h" // setCurThreadName
 
 static char* teeOlxOutputFile = NULL;
+static bool teeOlxOutputFileIsMmap = false; // false: malloc'd (thread path), true: mmap'd (fork path)
 static const size_t MAXFILENAMESIZE = 2048;
 
 const char* GetLogFilename() { if(teeOlxOutputFile) return teeOlxOutputFile; return ""; }
@@ -106,13 +110,13 @@ static void teeOlxOutputHandler(int in, int out) {
 }
 
 struct TeeStdoutInfo {
-	SDL_Thread* thread;
+	std::thread thread;
 	pid_t proc;
 	int pipestart;
 	int pipeend;
 	int oldstdout;
 	int oldstderr;
-	TeeStdoutInfo() : thread(NULL), proc(0), pipestart(-1), pipeend(-1), oldstdout(-1), oldstderr(-1) {}
+	TeeStdoutInfo() : proc(0), pipestart(-1), pipeend(-1), oldstdout(-1), oldstderr(-1) {}
 	void initPipeEnd(int pipeend_) {
 		pipeend = pipeend_;
 		oldstdout = dup(STDOUT_FILENO);
@@ -131,6 +135,7 @@ static TeeStdoutInfo teeStdoutInfo;
 #include <cstring>
 
 int threadedTeeStdout(void*) {
+	setCurThreadName("tee stdout");
 	while( true ) {
 		char buf[1024];
 		ssize_t num = read(teeStdoutInfo.pipestart, buf, sizeof(buf)/sizeof(char));
@@ -150,7 +155,7 @@ int threadedTeeStdout(void*) {
 void teeStdoutInit() {
 	// Idempotent: a theme-switch restart runs this again while the tee is still up.
 	// Re-initialising would orphan the old tee, which then crashes at exit on teeOlxOutputFile.
-	if(teeStdoutInfo.thread || teeStdoutInfo.proc)
+	if(teeStdoutInfo.thread.joinable() || teeStdoutInfo.proc)
 		return;
 
 	int pipe_to_handler[2];
@@ -179,9 +184,14 @@ void teeStdoutInit() {
 		teeStdoutInfo.pipestart = pipe_to_handler[0];
 		teeStdoutInfo.initPipeEnd(pipe_to_handler[1]);
 
-		teeStdoutInfo.thread = SDL_CreateThread(threadedTeeStdout, "tee stdout", NULL);
-		if(!teeStdoutInfo.thread) {
-			errors << "teeStdout: failed to create thread" << endl;
+		// std::thread rather than SDL_CreateThread,
+		// so teeStdoutQuit() can join it reliably at exit:
+		// SDL_WaitThread can return early (see #989),
+		// and by then SDL_Quit() has already run.
+		try {
+			teeStdoutInfo.thread = std::thread(threadedTeeStdout, (void*)NULL);
+		} catch(const std::system_error& e) {
+			errors << "teeStdout: failed to create thread: " << e.what() << endl;
 			return;
 		}
 
@@ -205,6 +215,7 @@ void teeStdoutInit() {
 		errors << "teeStdout: cannot mmap: " << strerror(errno) << endl;
 		return;
 	}
+	teeOlxOutputFileIsMmap = true;
 	*teeOlxOutputFile = 0;
 
 	if(pipe(pipe_to_handler) != 0) { // error creating pipe
@@ -245,18 +256,24 @@ void teeStdoutFile(const std::string& file) {
 
 // NOTE: We are calling this also when we crashed, so be sure that we only do save operations here!
 void teeStdoutQuit(bool wait) {
-	if(teeStdoutInfo.proc || teeStdoutInfo.thread) {
+	if(teeStdoutInfo.proc || teeStdoutInfo.thread.joinable()) {
 		if(wait)
 			notes << "wait for teeStdout handler quit" << endl;
 		close(STDOUT_FILENO);
 		close(STDERR_FILENO);
 		if(teeStdoutInfo.pipestart >= 0) close(teeStdoutInfo.pipestart);
 		close(teeStdoutInfo.pipeend);
-		// The forked process should quit itself now.
+		// The forked process / thread should quit itself now.
 		if(wait) {
 			if(teeStdoutInfo.proc) waitpid(teeStdoutInfo.proc, NULL, 0);
-			if(teeStdoutInfo.thread) SDL_WaitThread(teeStdoutInfo.thread, NULL);
+			// A real join: unlike SDL_WaitThread it returns only once the
+			// thread has fully finished, so freeing below cannot race it.
+			if(teeStdoutInfo.thread.joinable()) teeStdoutInfo.thread.join();
 		}
+		// On the crash path we must not block; detach so the destructor of the
+		// static teeStdoutInfo cannot call std::terminate() on a joinable thread.
+		else if(teeStdoutInfo.thread.joinable())
+			teeStdoutInfo.thread.detach();
 
 		// Recover stdout/err
 		dup2(teeStdoutInfo.oldstdout, STDOUT_FILENO);
@@ -265,11 +282,11 @@ void teeStdoutQuit(bool wait) {
 		close(teeStdoutInfo.oldstderr);
 		printf("Standard Out/Err recovered\n");
 	}
-	
+
 	if(teeOlxOutputFile && wait /* otherwise unsafe */) {
-		if(teeStdoutInfo.proc)
+		if(teeOlxOutputFileIsMmap)
 			munmap(teeOlxOutputFile, MAXFILENAMESIZE);
-		else if(teeStdoutInfo.thread)
+		else
 			free(teeOlxOutputFile);
 		teeOlxOutputFile = NULL;
 	}


### PR DESCRIPTION
## Problem

Crash at exit in the tee-stdout thread, the same signature as #1034:

```
Thread 'tee stdout' Crashed:
0  _platform_strlen
1  teeOlxOutputToFileHandler(int)   TeeStdoutHandler.cpp
2  threadedTeeStdout(void*)
3  SDL_RunThread
```

`teeOlxOutputToFileHandler()` compares a `std::string` against the raw
`teeOlxOutputFile` pointer, which runs `strlen` on it. That faults when
the pointer is bad. The interesting question is *how* the tee thread is
still alive to read it at exit.

## Root cause

`teeStdoutQuit()` frees the buffer only after "joining" the tee thread.
But the threaded (stdin-CLI) path created it with `SDL_CreateThread` and
joined with `SDL_WaitThread`, which can return *before* the thread has
actually finished -- the same unreliable join #989 hit
("SDL_WaitThread can return before the worker has actually left
threadWrapper ... This is the crash on exit, #961"). On top of that,
`teeStdoutQuit()` runs at the very end of `real_main`, well after
`ShutdownLieroX()` has already called `SDL_Quit()`. So the join can
return early and the following `free()` races the still-running handler
-- that is the orphaned-thread read behind the crash. It's the threaded
path only; the forked default path joins with `waitpid()` (a real wait)
and the child has its own address space, so it was never affected.

## Fix

Create the tee thread with `std::thread` instead of `SDL_CreateThread`.
`std::thread::join()` is a real join -- it returns only once the thread
has fully terminated, so the `free()` that follows can no longer race
it -- and it needs no SDL, so running after `SDL_Quit()` is fine. This
removes the SDL lifetime coupling for this thread (the direction #995
asks for). Details:

- crash path (`wait == false`) `detach()`s rather than joins, since a
  joinable `std::thread` would call `std::terminate()` when the static
  `teeStdoutInfo` is destroyed;
- the thread names itself via the existing `setCurThreadName()`;
- the malloc-vs-mmap free choice, which used to key off the old thread
  pointer, is now recorded explicitly in a flag.

Plus two guards for a *separate* race that is independent of the join
-- `teeStdoutFile()` rewrites the filename buffer in place with
`strcpy` while the tee thread reads it:

- read `teeOlxOutputFile` once and skip if NULL (no `strlen(NULL)`);
- zero the whole malloc'd buffer. `teeStdoutFile()` never writes past
  `MAXFILENAMESIZE - 1`, so a zeroed tail always leaves a terminator in
  bounds even mid-`strcpy`; a torn read then yields a stale filename,
  never a fault. (The mmap paths were already zero-filled by the OS.)

The branch's earlier commits explored a seqlock and then a
guard-plus-zeroing approach; this is the final shape.

## Testing

Builds; the headless suite passes (10/10).

The headless harness always passes `-disablestdincli`, so it only
exercises the forked path. To exercise the threaded path -- the one in
the crash trace -- I ran `openlierox -dedicated` under a pseudo-TTY
(so `stdinCLIActive()` is true), confirmed via the `teeStdout: save
multithreaded fallback` log that the `std::thread` path was taken, then
`SIGTERM`'d it: clean shutdown, `Standard Out/Err recovered` printed,
exit code 0, no hang on the join and no crash.
