### PR TITLE
Reset video back buffer on reset to fix flicker

### DIFF
--- a/src/client/AuxLib.cpp
+++ b/src/client/AuxLib.cpp
@@ -733,6 +733,7 @@ void VideoPostProcessor::cloneBuffer() {
 
 void VideoPostProcessor::uninit() {
 	instance.m_videoSurface = NULL; // should never be used before resetVideo() is called
+	instance.m_videoBufferSurface = NULL; // else a restart keeps the old frame
 	instance.m_videoTexture = NULL;
 	instance.m_renderer = NULL;
 	instance.m_window = NULL;


### PR DESCRIPTION
## Problem

The menu flickers with broken, mixed old/new frames right after a **theme switch**, but not on a fresh start.

A theme switch restarts the engine, which runs `VideoPostProcessor::uninit()` then `resetVideo()`. `uninit()` resets `m_videoSurface` (so it is reallocated blank) but **not** `m_videoBufferSurface`, and `resetVideo()` deliberately keeps the latter (`// No need to reinit this`). So after a restart:

- `m_videoSurface` → fresh, blank
- `m_videoBufferSurface` → **still the previous theme's last frame**

Once the buffers swap, that old frame becomes the draw target, and the menu's partial redraws (only changed widgets) paint the new content on top of it → the mixed old+new frames. A fresh start allocates both buffers blank together, which is exactly why the flicker only appears after a theme switch.

## Fix

Reset `m_videoBufferSurface` in `uninit()` too, so `resetVideo()` reallocates it blank and a restart starts from the same clean state as a fresh start. One line, no change to the render/present path.

## Note

An earlier revision of this PR moved `cloneBuffer()` into `flipBuffers()` (sync the buffers on every swap). That also worked but was broader than needed and didn't explain the theme-switch-specificity; this targeted fix does. (The general un-synced submenu present paths exist but are invisible in practice -- they show blank, not stale content -- which is consistent with no flicker on a fresh start.)

## Testing

Builds; the app starts, renders the menu, and shuts down cleanly. I can't drive a theme switch headlessly to eyeball it, so please confirm the flicker is gone when you switch themes.