### PR TITLE
Support the WASM build and headless test on macOS

### DIFF
--- a/build/wasm/fetch-dependencies.sh
+++ b/build/wasm/fetch-dependencies.sh
@@ -78,13 +78,24 @@ PYEOF
 fi
 
 # boost-hdr: symlink to whatever boost headers the host system has.
+# Linux keeps them under /usr/include; macOS Homebrew puts them in its prefix.
 if [ ! -e boost-hdr/boost ]; then
     mkdir -p boost-hdr
-    if [ -d /usr/include/boost ]; then
-        ln -sfn /usr/include/boost boost-hdr/boost
-        echo "boost-hdr -> /usr/include/boost"
+    boost_inc=""
+    for cand in \
+        /usr/include/boost \
+        "$(brew --prefix boost 2>/dev/null)/include/boost" \
+        /opt/homebrew/include/boost \
+        /usr/local/include/boost
+    do
+        if [ -d "$cand" ]; then boost_inc="$cand"; break; fi
+    done
+    if [ -n "$boost_inc" ]; then
+        ln -sfn "$boost_inc" boost-hdr/boost
+        echo "boost-hdr -> $boost_inc"
     else
-        echo "WARNING: /usr/include/boost not found. Install libboost-dev." >&2
+        echo "WARNING: boost headers not found." >&2
+        echo "         Install libboost-dev (Linux) or 'brew install boost' (macOS)." >&2
     fi
 fi
 

--- a/build/wasm/run-headless.py
+++ b/build/wasm/run-headless.py
@@ -34,13 +34,28 @@ for tok in sys.argv[3:]:
         SCRIPT.append((float(parts[1]), parts[2], ":".join(parts[3:])))
 
 
+def find_chrome() -> str:
+    """Locate a Chrome/Chromium binary: PATH names first, then the macOS app."""
+    candidates = [
+        "google-chrome", "google-chrome-stable", "chromium", "chromium-browser",
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    ]
+    for c in candidates:
+        if os.sep in c:
+            if os.path.exists(c):
+                return c
+        elif shutil.which(c):
+            return c
+    return "google-chrome"  # not found; let the launch fail with a clear error
+
+
 def main() -> int:
     shutil.rmtree(PROFILE,   ignore_errors=True)
     shutil.rmtree(SHOTS_DIR, ignore_errors=True)
     os.makedirs(SHOTS_DIR, exist_ok=True)
 
     chrome = subprocess.Popen([
-        "google-chrome",
+        find_chrome(),
         "--headless=new",
         # Keep GPU on — disabling it falls back to a software path
         # that hides issues real Chrome users hit (e.g. WebGL-related


### PR DESCRIPTION
Two spots in the WASM tooling assumed a Linux host,
so the build and the headless harness didn't work on macOS out of the box.
Both surfaced while verifying the #1030 fix in a real WASM build on a Mac.

- **`fetch-dependencies.sh`** linked boost only from `/usr/include/boost`.
  On macOS Homebrew keeps the headers under its prefix,
  so the build failed to find boost.
  Now it also checks `brew --prefix boost`, `/opt/homebrew`, and `/usr/local`.

- **`run-headless.py`** launched `google-chrome`,
  which isn't on `PATH` on macOS (Chrome ships as an `.app`,
  and it can't be launched via a `PATH` symlink because it resolves its
  framework relative to the real binary).
  It now falls back to the app's binary when no `PATH` name is found.

Linux behaviour is unchanged: `/usr/include/boost` and a `PATH` `google-chrome`
are still tried first.

Verified on macOS: the WASM target builds, boots headless to the main menu,
and drives two consecutive local games.
