### PR TITLE
Document macOS Gatekeeper first-run workaround

### DIFF
--- a/.github/workflows/master-release.yaml
+++ b/.github/workflows/master-release.yaml
@@ -97,6 +97,10 @@ jobs:
 
           - Branch: \`${GITHUB_REF_NAME}\`
           - Commit: ${GITHUB_SHA}
+
+          **macOS:** this build is not notarized, so on first launch Gatekeeper warns that OpenLieroX is from an "unidentified developer".
+          It is safe; allow it once with \`xattr -cr /path/to/OpenLieroX.app\`, then open it normally.
+          See [the README](https://github.com/openlierox/openlierox#macos-first-run).
           EOF
           )"
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,37 @@ OpenLieroX is based on Jason Boettcher's famous Liero Xtreme.
 
 Jason B. has released his work in 2006 under the zlib-licence and after some months of work, we ported and enhanced his work and got OpenLieroX.
 
+## Installing
+
+Prebuilt builds for Windows, macOS, Linux and Android are on the
+[releases page](https://github.com/openlierox/openlierox/releases).
+
+### macOS: first run
+
+The macOS build is not signed with an Apple Developer ID
+(that needs a paid Apple Developer account),
+so the first time you open it,
+macOS warns that OpenLieroX is from an "unidentified developer".
+It is safe; you just have to let macOS allow it once.
+The simplest way, in a terminal:
+
+```
+xattr -cr /path/to/OpenLieroX.app
+```
+
+then open the app normally.
+This removes the "quarantine" flag a browser download attaches,
+which is what triggers the warning.
+
+To avoid the warning entirely,
+download the zip from a terminal rather than the browser
+(files fetched with `curl` are never quarantined):
+
+```
+curl -L -o OpenLieroX.zip <url of the macOS .zip from the releases page>
+unzip OpenLieroX.zip
+```
+
 ## Compilation
 
 For more details, read here: <https://github.com/openlierox/openlierox/wiki/Compile-OpenLieroX>


### PR DESCRIPTION
Until the macOS build is notarized (which needs a paid Apple Developer ID), a downloaded copy trips Gatekeeper's "unidentified developer" warning. This documents how users get past it.

- **README** gets an "Installing" section (with the releases-page link) and a "macOS: first run" subsection. Simplest path: `xattr -cr /path/to/OpenLieroX.app` (drops the download quarantine flag that triggers the warning), then open normally. Also documents the `curl` download, which is never quarantined so there's no warning at all.
- **Release notes** (master-release.yaml) get a short macOS note with the one command + a link to the README section -- that's where users actually are when they hit the warning.

Not a code change; no notarization here. If/when you get an Apple Developer ID, I can wire up proper signing + notarization in CI and drop this note.

The homepage should link the README section too, but that's on the openlierox.net side.