### PR TITLE
Retry release publish on transient 403

### DIFF
--- a/.github/workflows/master-release.yaml
+++ b/.github/workflows/master-release.yaml
@@ -144,9 +144,35 @@ jobs:
           # --prerelease=false is explicit: a release flagged as a prerelease
           # cannot also be marked --latest (GitHub returns "Latest release
           # cannot be draft or prerelease.").
-          gh release create "$VERSION" "${ASSETS[@]}" \
-            --title "OpenLieroX ${VERSION_FULL}" \
-            --notes "$NOTES" \
-            --prerelease=false \
-            --latest \
-            --target "$GITHUB_SHA"
+          publish() {
+            # Start each attempt from a clean slate:
+            # if an earlier attempt created the release but failed partway
+            # (e.g. a dropped asset upload),
+            # remove it so the retry is not rejected with "release already exists".
+            if gh release view "$VERSION" >/dev/null 2>&1; then
+              gh release delete "$VERSION" --yes --cleanup-tag
+            fi
+            gh release create "$VERSION" "${ASSETS[@]}" \
+              --title "OpenLieroX ${VERSION_FULL}" \
+              --notes "$NOTES" \
+              --prerelease=false \
+              --latest \
+              --target "$GITHUB_SHA"
+          }
+
+          # The releases API intermittently returns a spurious 403
+          # ("Resource not accessible by integration") even with the right permissions.
+          # Retry a few times with a growing backoff
+          # so a single hiccup does not lose the build's release.
+          attempt=1
+          max_attempts=5
+          until publish; do
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "gh release create failed after ${max_attempts} attempts" >&2
+              exit 1
+            fi
+            delay=$((attempt * 15))
+            echo "Publish attempt ${attempt}/${max_attempts} failed; retrying in ${delay}s..." >&2
+            sleep "$delay"
+            attempt=$((attempt + 1))
+          done


### PR DESCRIPTION
## Problem

The `Latest master` release job failed on
[run 28970859713](https://github.com/openlierox/openlierox/actions/runs/28970859713/job/85971255737)
with:

```
HTTP 403: Resource not accessible by integration (https://api.github.com/repos/openlierox/openlierox/releases)
```

This is not a permissions problem:
the workflow already grants `contents: write`,
and the builds immediately before (`20260708.48`) and after (`20260708.51`)
published fine with the identical workflow.
Only `20260708.50` is missing.
The releases API just returned a spurious, transient 403 on that one call.

## Fix

Wrap the `gh release create` in a retry loop
with a growing backoff (15s, 30s, 45s, 60s; up to 5 attempts),
so a single hiccup no longer loses the build's release.

Each attempt starts from a clean slate:
if an earlier attempt created the release but failed partway
(e.g. a dropped asset upload),
the release and its tag are deleted first
so the retry is not rejected with "release already exists".

If every attempt fails the step still exits non-zero,
so a real outage surfaces instead of passing silently.

Only affects the release workflow; takes effect on the next master build.
