### PR TITLE
Colour only error lines in the WASM on-page log

### DIFF
--- a/build/wasm/shell/shell.html
+++ b/build/wasm/shell/shell.html
@@ -70,7 +70,7 @@
     #log       { max-height: 25vh; overflow: auto; padding: 4px 10px;
                  background: #181818; font: 12px/1.3 monospace; white-space: pre-wrap;
                  align-self: stretch; }
-    #log.err   { color: #f99; }
+    #log .err  { color: #f99; }
   </style>
 </head>
 <body>
@@ -100,9 +100,13 @@
     const logEl    = document.getElementById("log");
 
     function appendLog(text, isErr) {
-      logEl.textContent += text + "\n";
+      // One line per node, so only error lines go red
+      // (a single stderr line must not colour every following note).
+      const line = document.createElement("div");
+      if (isErr) line.className = "err";
+      line.textContent = text;
+      logEl.appendChild(line);
       logEl.scrollTop = logEl.scrollHeight;
-      if (isErr) logEl.classList.add("err");
     }
 
     // Latch: once the data download is complete we show "Starting OpenLieroX…"


### PR DESCRIPTION
The WASM shell's on-page log panel turned **entirely** red once anything
was written to stderr, and stayed that way.

`appendLog` added an `err` class to the whole `#log` container on the
first stderr line and never removed it, and `#log.err` colours the whole
panel. So a single harmless warning during startup or game start
(for example a script object's `Number converted to integer may lose
precision` note) made every following line -- ordinary `n:` notes
included -- show red, which reads like an error cascade when nothing is
wrong.

Now each log line is its own element, and only the error lines get the
`err` class (`#log .err`), so notes stay in the normal colour.

Verified in a headless WASM run: after starting a local game, the notes
in the panel render white while only the stderr line is red.
