### PR TITLE
Migrate Mutex and Condition off SDL to std

### DIFF
--- a/include/Condition.h
+++ b/include/Condition.h
@@ -1,8 +1,8 @@
 /*
 	Condition wrapper
-	
+
 	OpenLieroX
-	
+
 	code under LGPL
 	created 11-05-2009
 */
@@ -10,25 +10,25 @@
 #ifndef __OLX__CONDITION_H__
 #define __OLX__CONDITION_H__
 
-#include <SDL_mutex.h>
+#include <condition_variable>
+#include <chrono>
 #include "Mutex.h"
 
+// Thin wrapper over std::condition_variable_any,
+// which can wait on any lock()/unlock() type -- here our Mutex.
 class Condition {
 private:
-	SDL_cond* cond;
+	std::condition_variable_any cond;
 public:
-	Condition() { cond = SDL_CreateCond(); }
-	~Condition() { SDL_DestroyCond(cond); cond = NULL; }
-	
-	void signal() { SDL_CondSignal(cond); }
-	void broadcast() { SDL_CondBroadcast(cond); }
-#ifdef DEBUG
-	void wait(Mutex& mutex);
-	bool wait(Mutex& mutex, Uint32 ms);
-#else
-	void wait(Mutex& mutex) { SDL_CondWait(cond, mutex.m_mutex); }
-	bool wait(Mutex& mutex, Uint32 ms) { return SDL_CondWaitTimeout(cond, mutex.m_mutex, ms) != SDL_MUTEX_TIMEDOUT; }
-#endif
+	void signal() { cond.notify_one(); }
+	void broadcast() { cond.notify_all(); }
+
+	// mutex must be held by the caller;
+	// it is released while waiting and reacquired before returning.
+	void wait(Mutex& mutex) { cond.wait(mutex); }
+	bool wait(Mutex& mutex, unsigned int ms) {
+		return cond.wait_for(mutex, std::chrono::milliseconds(ms)) == std::cv_status::no_timeout;
+	}
 };
 
 #endif

--- a/include/Mutex.h
+++ b/include/Mutex.h
@@ -10,22 +10,20 @@
 #ifndef __MUTEX_H__
 #define __MUTEX_H__
 
-#include <SDL_mutex.h>
+#include <mutex>
+#ifdef DEBUG
+#include <thread>
+#endif
 #include "CodeAttributes.h"
-
-#define INVALID_THREAD_ID (Uint32)-1
-
-class Condition;
 
 // Mutex wrapper class with some extra debugging checks
 class Mutex : DontCopyTag {
-	friend class Condition;
 private:
-	SDL_mutex *m_mutex;
+	std::mutex m_mutex;
 
 #ifdef DEBUG
-	volatile unsigned long m_lockedThread;  // Thread that keeps the lock
-	
+	std::thread::id m_lockedThread;  // thread that holds the lock, or default-constructed if none
+
 	void _lock_pre();
 	void _lock_post();
 	void _unlock_pre();
@@ -34,19 +32,14 @@ private:
 
 public:
 #ifdef DEBUG
-	Mutex();
 	~Mutex();
 	void lock();
 	void unlock();
-
-	static void test();
 #else
-	Mutex()			{ m_mutex = SDL_CreateMutex(); }
-	~Mutex()		{ if(m_mutex) SDL_DestroyMutex(m_mutex); }
-	void lock()		{ SDL_LockMutex(m_mutex); }
-	void unlock()	{ SDL_UnlockMutex(m_mutex); }
+	void lock()		{ m_mutex.lock(); }
+	void unlock()	{ m_mutex.unlock(); }
 #endif
-	
+
 	struct ScopedLock : DontCopyTag {
 		Mutex& mutex;
 		ScopedLock(Mutex& m) : mutex(m) { mutex.lock(); }

--- a/src/common/Debug_GetCallstack.cpp
+++ b/src/common/Debug_GetCallstack.cpp
@@ -68,6 +68,7 @@
 #include <execinfo.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h> // memmove
 #endif
 
 #if HAVE_EXECINFO

--- a/src/common/Mutex.cpp
+++ b/src/common/Mutex.cpp
@@ -7,113 +7,60 @@
 	code under LGPL
 */
 
-#include <SDL_thread.h>
+#include <thread>
 
 #include "Mutex.h"
-#include "Condition.h"
 #include "Debug.h"
 
 #ifdef DEBUG
 
 void Mutex::_lock_pre() {
-	// Get the current thread ID, if the thread ID is the same as the one already set, we've called
-	// lock() twice from the same thread
-	if (m_lockedThread == SDL_ThreadID())  {
+	// If the current thread already holds the lock,
+	// lock() was called twice from the same thread, which deadlocks.
+	if (m_lockedThread == std::this_thread::get_id())  {
 		errors << "Called mutex lock twice from the same thread, this will cause a deadlock" << endl;
 		assert(false);
 	}
 }
 
 void Mutex::_lock_post() {
-	m_lockedThread = SDL_ThreadID();  // We hold the lock now
+	m_lockedThread = std::this_thread::get_id();  // we hold the lock now
 }
 
 void Mutex::_unlock_pre() {
-	// Make sure the mutex is released from the same thread it was locked in
-	if (m_lockedThread != SDL_ThreadID())  {
+	// The mutex must be released from the same thread that locked it.
+	if (m_lockedThread != std::this_thread::get_id())  {
 		errors << "Releasing the mutex in other thread than locking it, this will cause a deadlock" << endl;
 		assert(false);
 	}
-	m_lockedThread = INVALID_THREAD_ID;  // Lock released
+	m_lockedThread = std::thread::id();  // lock released
 }
 
 void Mutex::_unlock_post() {
 	// Nothing to do.
 }
 
-Mutex::Mutex()
+Mutex::~Mutex()
 {
-	m_mutex = SDL_CreateMutex(); 
-	m_lockedThread = INVALID_THREAD_ID;
-}
-
-Mutex::~Mutex()	
-{ 
-	SDL_DestroyMutex(m_mutex);  
-
-	// If there's a thread set, we're destroying a locked mutex
-	if (m_lockedThread != INVALID_THREAD_ID)  {
+	// If a thread still holds the lock, we're destroying a locked mutex.
+	if (m_lockedThread != std::thread::id())  {
 		errors << "Destroyed a locked mutex" << endl;
 		assert(false);
 	}
 }
 
-void Mutex::lock()		
+void Mutex::lock()
 {
 	_lock_pre();
-	SDL_LockMutex(m_mutex);
+	m_mutex.lock();
 	_lock_post();
 }
 
-void Mutex::unlock()	
+void Mutex::unlock()
 {
 	_unlock_pre();
-	SDL_UnlockMutex(m_mutex);
+	m_mutex.unlock();
 	_unlock_post();
 }
-
-void Condition::wait(Mutex& mutex) {
-	mutex._unlock_pre();
-	mutex._unlock_post();
-	SDL_CondWait(cond, mutex.m_mutex);
-	mutex._lock_pre();
-	mutex._lock_post();
-}
-
-bool Condition::wait(Mutex& mutex, Uint32 ms) {
-	mutex._unlock_pre();
-	mutex._unlock_post();
-	bool ret = SDL_CondWaitTimeout(cond, mutex.m_mutex, ms) != SDL_MUTEX_TIMEDOUT;
-	mutex._lock_pre();
-	mutex._lock_post();
-	return ret;
-}
-
-// Testing stuff
-/*
-int thread_release_main(void *m)
-{
-	Mutex *mutex = (Mutex *)m;
-	mutex->lock();
-	return 0;
-}
-
-
-void Mutex::test()
-{
-	Mutex mtx;
-
-	// Lock in one thread and unlock in another one
-	SDL_Thread *rel = SDL_CreateThread(thread_release_main, "Mutex test", &mtx);
-	SDL_WaitThread(rel, NULL);
-	mtx.unlock();
-
-	// Deadlock
-	mtx.lock();
-	mtx.lock();
-
-	//mtx.lock();  // Lock and then destroy
-}
-*/
 
 #endif


### PR DESCRIPTION
## What

Migrate the `Mutex` and `Condition` wrappers off SDL to the C++ standard library:
`SDL_mutex` → `std::mutex`,
`SDL_cond` → `std::condition_variable_any`.

Next step of #995, after #1043 (ThreadPool).

## Why this shape

`std::condition_variable_any` can wait on any `lock()`/`unlock()` type,
so it maps directly onto the existing `Mutex` abstraction.
That means **no caller changes**:
every `Mutex::ScopedLock` / `Mutex::lock()` / `unlock()` site keeps working as-is
(this is why the diff is only the three wrapper files).
Plain `std::condition_variable` would have forced `std::unique_lock` on every caller.

The DEBUG lock-ownership checks now track the owner with a `std::thread::id`
(a default-constructed id means "no owner"),
replacing the `SDL_ThreadID()` / `INVALID_THREAD_ID` sentinel.
Because `condition_variable_any::wait()` drives the mutex
through those same `lock()`/`unlock()` calls,
the ownership checks now apply during a wait automatically,
so `Condition` no longer needs its own DEBUG variant or friendship with `Mutex`.

Also removes the commented-out `Mutex::test()` and its `SDL_CreateThread` usage:
dead code, never called.

Note: `Condition` is not currently used anywhere in the tree;
it is migrated (not removed) to keep the wrapper pair consistent and SDL-free.

## Scope

`ReadWriteLock` and its standalone `ScopedLock` are intentionally left out.
That `ScopedLock` wraps a raw `SDL_mutex*`
shared by ~a dozen files that still hold raw SDL mutexes,
so it belongs with that later batch.

## Testing

- Release build clean.
- DEBUG path (the `std::thread::id` ownership tracking) syntax-checked with `-DDEBUG`
  against the real include flags, since the default Release build does not compile it.
- `./tests/headless/run.sh`: 10/10 pass.
  The `Mutex` wrapper is exercised throughout (HTTP, Networking, TaskManager, Console, ...).
