### PR TITLE
Migrate stdin CLI thread off SDL to std::thread

### DIFF
--- a/src/client/StdinCLISupport.cpp
+++ b/src/client/StdinCLISupport.cpp
@@ -1,7 +1,9 @@
-#include <SDL_thread.h>
+#include <thread>
+#include <system_error>
 #include "StdinCLISupport.h"
 #include "ThreadPool.h"
 #include "Mutex.h"
+#include "AuxLib.h" // setCurThreadName
 #include "OLXCommand.h"
 #include "Debug.h"
 #include "InputEvents.h"
@@ -120,6 +122,7 @@ bool linenoiseCompletionCallbackFunc(const std::string& buf, LinenoiseCompletion
 }
 
 int handleStdin(void*) {
+	setCurThreadName("stdin");
 	while(!linenoiseEnv.hadReadError) {
 		bool useHistory = false;
 		std::string buf;
@@ -143,7 +146,7 @@ int handleStdin(void*) {
 	return 0;
 }
 
-static SDL_Thread* stdinHandleThread = NULL;
+static std::thread stdinHandleThread;
 
 Result initStdinCLISupport() {
 	if(!isatty(STDIN_FILENO))
@@ -154,9 +157,14 @@ Result initStdinCLISupport() {
 
 	linenoiseSetCompletionCallback(linenoiseCompletionCallbackFunc);
 
-	stdinHandleThread = SDL_CreateThread(handleStdin, "stdin", NULL);
-	if(stdinHandleThread == NULL)
-		return "couldn't create thread";
+	// std::thread rather than SDL_CreateThread,
+	// so quitStdinCLISupport() can join it reliably at exit (see #995);
+	// the thread names itself via setCurThreadName() from inside.
+	try {
+		stdinHandleThread = std::thread(handleStdin, (void*)NULL);
+	} catch(const std::system_error& e) {
+		return std::string("couldn't create thread: ") + e.what();
+	}
 
 	hasStdinCLISupport = true;
 	return true;
@@ -164,15 +172,15 @@ Result initStdinCLISupport() {
 
 void quitStdinCLISupport() {
 	if(!hasStdinCLISupport) return;
-	if(!stdinHandleThread) return;
+	if(!stdinHandleThread.joinable()) return;
 
 	notes << "wait for StdinCLI quit" << endl;
 	{
 		Mutex::ScopedLock lock(stdoutMutex);
 		quit = true;
 	}
-	SDL_WaitThread(stdinHandleThread, NULL);
-	stdinHandleThread = NULL;
+	// A real join: it returns only once the thread has fully finished.
+	stdinHandleThread.join();
 	hasStdinCLISupport = false;
 }
 


### PR DESCRIPTION
## What

Migrate the stdin-CLI reader thread off SDL to `std::thread`,
joined with `std::thread::join()` instead of `SDL_WaitThread`.
Next step of #995, mirroring the tee-stdout migration in #1039.

## Why

`quitStdinCLISupport()` runs at exit, after `SDL_Quit()`,
and `SDL_WaitThread` can return before the thread has actually finished
(the unreliable join #989 hit).
`std::thread::join()` is a real join and needs no SDL,
so the reader is reliably joined at shutdown.

The reader stays responsive to the `quit` flag through its existing 10ms
`select` loop, so the join cannot hang.
`quitStdinCLISupport()` is called on both the normal exit path
([main.cpp](../blob/master/src/main.cpp)) and the crash path
([CrashHandler.cpp](../blob/master/src/client/CrashHandler.cpp)),
so the static `std::thread` is always joined before static destruction,
which is what keeps a joinable `std::thread` from calling `std::terminate()`.

`std::thread` has no name argument, so the reader names itself
via `setCurThreadName("stdin")` from inside, same as #1039.

## Testing

- Release build clean,
  including the real `HAVE_LINENOISE` path (the changed code).
- Standard headless suite: 10/10 pass.
  That suite runs with `-disablestdincli`,
  so it does not exercise this thread,
  but it confirms no build or shutdown regression.
- Drove the binary under a pseudo-terminal
  so `isatty()` is true and the CLI thread is actually created.
  Confirmed via the `stdinCLIActive()`-gated
  "teeStdout: save multithreaded fallback" marker
  ([TeeStdoutHandler.cpp:163](../blob/master/src/common/TeeStdoutHandler.cpp#L163)),
  which only prints once the thread exists.
  A non-tty control run does not print it,
  confirming the marker tracks the CLI thread.

A full clean `rc 0` exit with the CLI active was not scriptable headlessly.
A dedicated server's shutdown is SIGKILL-prone by design
(the test harness SIGKILLs it for that reason),
and the one clean signal path (SIGINT -> SDL_QUIT)
is disrupted by linenoise's raw-mode terminal handling.
Both predate this change and are orthogonal to it.
The join safety here rests on the structure above
plus parity with the already-merged #1039.
