### PR TITLE
Restore terminal to cooked mode on stdin-CLI exit

### DIFF
--- a/libs/linenoise/linenoise.cpp
+++ b/libs/linenoise/linenoise.cpp
@@ -105,6 +105,8 @@ static LinenoiseCompletionCallback *completionCallback = NULL;
 
 static struct termios orig_termios; /* in order to restore at exit */
 static int rawmode = 0; /* for atexit() function to check if restore is needed*/
+static int rawmode_everused = 0; /* whether orig_termios was ever captured */
+static int terminal_finalized = 0; /* once set, never go raw again (shutdown) */
 static int atexit_registered = 0; /* register atexit just 1 time */
 static size_t history_max_len = LINENOISE_DEFAULT_HISTORY_MAX_LEN;
 static std::vector<std::string> history;
@@ -124,6 +126,7 @@ bool linenoiseIsUnsupportedTerm() {
 int linenoiseEnableRawMode(int fd) {
     struct termios raw;
 
+	if (terminal_finalized) goto fatal; /* shutdown: never re-raw */
 	if (!isatty(fd)) goto fatal;
     if (!atexit_registered) {
         atexit(linenoiseAtExit);
@@ -137,6 +140,7 @@ int linenoiseEnableRawMode(int fd) {
 		orig_termios.c_iflag |= BRKINT | ICRNL | INPCK | ISTRIP | IXON;
 		orig_termios.c_oflag |= OPOST;
 		orig_termios.c_lflag |= ECHO | ICANON | IEXTEN | ISIG;
+		rawmode_everused = 1;
 	}
 
     raw = orig_termios;  /* modify the original mode */
@@ -167,6 +171,15 @@ fatal:
 void linenoiseDisableRawMode(int fd) {
     /* Don't even check the return value as it's too late. */
     if (rawmode && tcsetattr(fd,TCSAFLUSH,&orig_termios) != -1)
+        rawmode = 0;
+}
+
+/* Shutdown: restore cooked mode unconditionally,
+ * since the rawmode flag can desync across the CLI and tee threads,
+ * and latch raw off so nothing re-raws. */
+void linenoiseRestoreTerminal(int fd) {
+    terminal_finalized = 1;
+    if (rawmode_everused && tcsetattr(fd,TCSAFLUSH,&orig_termios) != -1)
         rawmode = 0;
 }
 

--- a/libs/linenoise/linenoise.h
+++ b/libs/linenoise/linenoise.h
@@ -55,6 +55,7 @@ int linenoiseHistoryLoad(const std::string& filename);
 
 int linenoiseEnableRawMode(int fd);
 void linenoiseDisableRawMode(int fd);
+void linenoiseRestoreTerminal(int fd);
 
 struct LinenoiseEnv {
 	int fd;

--- a/src/client/StdinCLISupport.cpp
+++ b/src/client/StdinCLISupport.cpp
@@ -21,6 +21,7 @@ Result initStdinCLISupport() {
 
 void quitStdinCLISupport() {}
 void activateStdinCLIHistory() {}
+void stdinCLIRestoreTerminal() {}
 
 StdinCLI_StdoutScope::StdinCLI_StdoutScope() {}
 StdinCLI_StdoutScope::~StdinCLI_StdoutScope() {}
@@ -174,6 +175,9 @@ void quitStdinCLISupport() {
 	SDL_WaitThread(stdinHandleThread, NULL);
 	stdinHandleThread = NULL;
 	hasStdinCLISupport = false;
+
+	// latch raw off now; teeStdoutQuit does the final restore once its thread is gone
+	linenoiseRestoreTerminal(linenoiseEnv.fd);
 }
 
 void activateStdinCLIHistory() {
@@ -182,6 +186,10 @@ void activateStdinCLIHistory() {
 	Mutex::ScopedLock lock(stdoutMutex);
 	linenoiseHistoryLoad(GetFullFileName(HistoryFilename));
 	historySupport = true;
+}
+
+void stdinCLIRestoreTerminal() {
+	linenoiseRestoreTerminal(linenoiseEnv.fd);
 }
 
 #endif // HAVE_LINENOISE

--- a/src/client/StdinCLISupport.h
+++ b/src/client/StdinCLISupport.h
@@ -8,6 +8,8 @@ void quitStdinCLISupport();
 void activateStdinCLIHistory(); // this must wait until we have the filesystem inited
 bool stdinCLIActive();
 
+void stdinCLIRestoreTerminal(); // restore cooked mode at shutdown, latch raw off
+
 // Use this whereever you want to print on stdout.
 // It does nothing if stdin CLI support is not available.
 struct StdinCLI_StdoutScope {

--- a/src/common/TeeStdoutHandler.cpp
+++ b/src/common/TeeStdoutHandler.cpp
@@ -248,6 +248,10 @@ void teeStdoutQuit(bool wait) {
 			if(teeStdoutInfo.thread) SDL_WaitThread(teeStdoutInfo.thread, NULL);
 		}
 
+		// tee and CLI threads are gone now;
+		// restore cooked mode, else the raw terminal (ONLCR off) staircases the messages below
+		stdinCLIRestoreTerminal();
+
 		// Recover stdout/err
 		dup2(teeStdoutInfo.oldstdout, STDOUT_FILENO);
 		dup2(teeStdoutInfo.oldstderr, STDERR_FILENO);

--- a/tests/headless/test_terminal.py
+++ b/tests/headless/test_terminal.py
@@ -1,0 +1,124 @@
+"""Terminal-restore test for the interactive stdin CLI.
+
+Unlike the rest of the suite,
+this runs a dedicated server with the stdin CLI active (no ``-disablestdincli``)
+on a real pty, then quits it and inspects the raw terminal bytes.
+
+Regression test for the shutdown staircase:
+the stdin CLI puts the terminal in linenoise raw mode (ONLCR off),
+and the tee-stdout handler thread re-enabled raw mode around each write,
+so the final shutdown messages used to print while the terminal was still raw.
+A bare "\n" is then not turned into "\r\n",
+so each message staircases down the screen instead of starting at column 0.
+"""
+
+import os
+import pty
+import select
+import signal
+import time
+
+import pytest
+
+from harness import GAMEDIR, SERVER_CONTROL, find_binary
+
+MARKER = b"Standard Out/Err recovered"
+PROMPT = b"OLX> "
+
+
+def _run_dedicated_on_pty(binary, home, port):
+    """Run a dedicated server with the stdin CLI active on a pty until it quits.
+
+    Hosts a lobby and stays there,
+    sends SIGINT once it is up,
+    and returns the raw terminal bytes collected until it exits.
+    """
+    env = dict(os.environ)
+    env["HOME"] = home
+    env["TERM"] = "xterm"  # make sure linenoise treats it as a supported terminal
+    env["OLX_PORT"] = str(port)
+    env["OLX_RUN_SECONDS"] = "120"
+    env["OLX_START_WHEN_WORMS"] = "99"  # stay in the lobby, never auto-start
+
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.chdir(GAMEDIR)
+        os.environ.clear()
+        os.environ.update(env)
+        os.execv(binary, [binary, "-dedicated", "-script", SERVER_CONTROL])
+        os._exit(127)
+
+    buf = bytearray()
+    start = time.time()
+    deadline = start + 60
+    lobby_at = None
+    sent = False
+    quit_at = None
+    eof = False
+    while time.time() < deadline:
+        r, _, _ = select.select([fd], [], [], 0.5)
+        if r:
+            try:
+                data = os.read(fd, 4096)
+            except OSError:
+                eof = True
+                break
+            if not data:
+                eof = True
+                break
+            buf += data
+            if lobby_at is None and b"state=Lobby" in buf:
+                lobby_at = time.time()
+        # Once the lobby is up and the prompt is drawn, ask it to quit.
+        if lobby_at is not None and not sent and time.time() - lobby_at > 2.0:
+            os.kill(pid, signal.SIGINT)
+            sent = True
+            quit_at = time.time()
+        if quit_at is not None and time.time() - quit_at > 25.0:
+            break
+
+    if not eof:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except OSError:
+            pass
+    try:
+        os.waitpid(pid, 0)
+    except OSError:
+        pass
+    return bytes(buf)
+
+
+def test_shutdown_messages_not_staircased(tmp_path):
+    """The final shutdown message prints at column 0, not staircased.
+
+    Runs on a pty with a supported TERM,
+    so the stdin CLI must activate and its prompt must appear;
+    if it does not, that is a real failure, not a skip.
+    """
+    binary = find_binary()
+    if binary is None:
+        pytest.fail("openlierox binary not found; build it first or set OLX_BINARY",
+                    pytrace=False)
+
+    raw = _run_dedicated_on_pty(binary, str(tmp_path), 23470)
+
+    assert PROMPT in raw, (
+        "stdin CLI never showed its prompt, so the raw-mode path was not exercised:\n"
+        + repr(raw[-300:])
+    )
+
+    idx = raw.find(MARKER)
+    assert idx >= 0, "shutdown recovery message never printed:\n" + repr(raw[-400:])
+
+    # Cooked shutdown ends the line at column 0:
+    # a CRLF (ONLCR on), or an explicit column-0 reset (ESC [ 0 G).
+    # A bare "\n" means raw mode: staircased.
+    nl = raw.find(b"\n", idx + len(MARKER))
+    assert nl >= 0, "no newline after the recovery message:\n" + repr(raw[idx:])
+    segment = raw[idx + len(MARKER):nl]
+    cooked = raw[nl - 1:nl] == b"\r" or b"\x1b[0G" in segment
+    assert cooked, (
+        "shutdown message printed in raw mode (staircased); "
+        "bytes around it: " + repr(raw[max(0, idx - 20):nl + 1])
+    )


### PR DESCRIPTION
## Problem

On the dedicated / stdin-CLI shutdown from a real terminal,
the final messages ("Standard Out/Err recovered", and the later ones)
printed staircased/indented instead of at column 0.

The stdin CLI puts the terminal in linenoise raw mode (ONLCR off),
so a bare `\n` is not turned into `\r\n`.
Two things kept the terminal raw when those messages printed:

- the tee-stdout handler runs as a thread (the stdin-CLI fallback in `teeStdoutInit`)
  that re-enables raw mode around each write via `StdinCLI_StdoutScope`,
  and it outlives `quitStdinCLISupport`;
- linenoise's internal `rawmode` flag can desync from the actual terminal
  (flag reads 0 while the tty is still raw),
  so a plain `linenoiseDisableRawMode` silently skips the restore.

linenoise otherwise only restores cooked mode via its late `atexit` handler,
which runs after the static destructors that print those messages.

## Fix

Add `linenoiseRestoreTerminal`,
which restores cooked mode unconditionally,
ignoring the desyncable `rawmode` flag,
and latches raw mode off,
so no lingering thread can re-enable it.
Call it once the input thread is joined (`quitStdinCLISupport`),
and again once the tee handler thread is gone (`teeStdoutQuit`),
just before the recovery message.

Purely a terminal-restore fix; unrelated to the tee-stdout exit crash from #1039.

## Testing

- New pty-based headless regression test (`tests/headless/test_terminal.py`)
  drives the interactive stdin CLI and checks the shutdown message is not staircased.
  It fails on master and passes with this change.
- Full headless suite (`./tests/headless/run.sh`) passes.
- A repeated-run pty harness went from staircasing every run on master
  to a clean restore on every run with the fix.
