### PR TITLE
Draw menus full width with a roaming cursor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ build/android/output/
 __pycache__
 *.pyc
 .pytest_cache
+
+# Offscreen menu-render dev output
+.render-home/
+.render-out/

--- a/include/AuxLib.h
+++ b/include/AuxLib.h
@@ -75,17 +75,17 @@ class VideoPostProcessor {
 protected:
 	SmartPointer<SDL_Window> m_window;
 	SmartPointer<SDL_Renderer> m_renderer;
-	SmartPointer<SDL_Texture> m_videoTexture;
-	SmartPointer<SDL_Surface> m_videoSurface;
-	SmartPointer<SDL_Surface> m_videoBufferSurface;
+	SmartPointer<SDL_Texture> m_videoTexture;         // GPU texture we present
+	// Double-buffered across the thread boundary:
+	// the gameloop draws one while the main thread presents the other (flipBuffers).
+	SmartPointer<SDL_Surface> m_videoSurface;         // draw target (front)
+	SmartPointer<SDL_Surface> m_videoBufferSurface;   // committed frame (back)
+	SmartPointer<SDL_Surface> m_videoPresentSurface;  // composed full frame; main-thread only, no handoff (composePresentFrame)
+	SmartPointer<SDL_Surface> m_leftGap, m_rightGap; // precomputed side-gap fills (buildSideGaps)
+	Uint32 m_sideGapKey = 0; // change key: rebuild the gaps only when it changes
 	int m_screenWidth = 640;
-	// The width the current frame's content is laid out for. Either the full
-	// screenWidth() (local games) or the base menuWidth / 640 (menus and
-	// network games, so a wider screen gives no gameplay advantage). When it is
-	// narrower than screenWidth() the content is drawn into the left columns
-	// and presented horizontally centered, with black bars on the sides.
-	// Set per-frame by the menu / gameplay draw. See render() and the mouse
-	// handling, and displayScreenWidth()/displayScreenOffsetX() below.
+	// Width the current frame is laid out for: screenWidth() (local),
+	// or menuWidth (menus/net, composed centered). Set per-frame.
 	int m_displayScreenWidth = 640;
 	// Snapshot of m_displayScreenWidth taken when a drawn frame is committed
 	// (flipBuffers, under the video mutex) and handed to render() via process(),
@@ -97,7 +97,10 @@ protected:
 	int m_committedDisplayScreenWidth = 640; // flipBuffers writes, process reads (both under mutex)
 	int m_renderDisplayScreenWidth = 640;    // main-thread only: process writes, render reads
 	static VideoPostProcessor instance;
-	
+
+	// Build m_videoPresentSurface from the drawn frame. Main thread, from process().
+	static void composePresentFrame();
+
 public:
 	// IMPORTANT: Don't call this while anyone else calls/accesses anything else here.
 	static void flipBuffers();
@@ -115,6 +118,17 @@ public:
 
 	bool initWindow();
 	bool resetVideo(); // this is called from SetVideoMode
+
+	// Precompute the side-gap fills from a menuWidth-wide theme background.
+	void buildSideGaps(const SmartPointer<SDL_Surface>& bg);
+
+	// Hook to draw screen-space overlays (task bar, FPS) onto the full-width frame.
+	// Runs on the main thread from composePresentFrame (see cOverlayFont).
+	typedef void (*ScreenOverlayFn)(SDL_Surface* screen);
+	static void setScreenOverlay(ScreenOverlayFn fn) { screenOverlay = fn; }
+private:
+	static ScreenOverlayFn screenOverlay;
+public:
 	
 	int screenWidth() const { return m_screenWidth; }
 	int screenHeight() const { return 480; }

--- a/include/AuxLib.h
+++ b/include/AuxLib.h
@@ -75,14 +75,15 @@ class VideoPostProcessor {
 protected:
 	SmartPointer<SDL_Window> m_window;
 	SmartPointer<SDL_Renderer> m_renderer;
-	SmartPointer<SDL_Texture> m_videoTexture;         // GPU texture we present
+	SmartPointer<SDL_Texture> m_videoTexture;         // GPU texture: the drawn band, uploaded each frame
 	// Double-buffered across the thread boundary:
 	// the gameloop draws one while the main thread presents the other (flipBuffers).
 	SmartPointer<SDL_Surface> m_videoSurface;         // draw target (front)
 	SmartPointer<SDL_Surface> m_videoBufferSurface;   // committed frame (back)
-	SmartPointer<SDL_Surface> m_videoPresentSurface;  // composed full frame; main-thread only, no handoff (composePresentFrame)
-	SmartPointer<SDL_Surface> m_leftGap, m_rightGap; // precomputed side-gap fills (buildSideGaps)
-	Uint32 m_sideGapKey = 0; // change key: rebuild the gaps only when it changes
+	SmartPointer<SDL_Surface> m_leftGap, m_rightGap;  // precomputed side-gap fills (buildSideGaps)
+	SmartPointer<SDL_Texture> m_leftGapTex, m_rightGapTex; // the gaps as GPU textures
+	Uint32 m_sideGapKey = 0;    // change key: rebuild the gap surfaces only when it changes
+	Uint32 m_sideGapTexKey = 0; // last key uploaded to the gap textures
 	int m_screenWidth = 640;
 	// Width the current frame is laid out for: screenWidth() (local),
 	// or menuWidth (menus/net, composed centered). Set per-frame.
@@ -98,8 +99,8 @@ protected:
 	int m_renderDisplayScreenWidth = 640;    // main-thread only: process writes, render reads
 	static VideoPostProcessor instance;
 
-	// Build m_videoPresentSurface from the drawn frame. Main thread, from process().
-	static void composePresentFrame();
+	// Upload the gap surfaces to the gap textures when they changed. Main thread.
+	void updateSideGapTextures();
 
 public:
 	// IMPORTANT: Don't call this while anyone else calls/accesses anything else here.
@@ -122,9 +123,9 @@ public:
 	// Precompute the side-gap fills from a menuWidth-wide theme background.
 	void buildSideGaps(const SmartPointer<SDL_Surface>& bg);
 
-	// Hook to draw screen-space overlays (task bar, FPS) onto the full-width frame.
-	// Runs on the main thread from composePresentFrame (see cOverlayFont).
-	typedef void (*ScreenOverlayFn)(SDL_Surface* screen);
+	// Hook to draw screen-space overlays (task bar, FPS) on top of the frame.
+	// Runs on the main thread from render() (see cOverlayFont).
+	typedef void (*ScreenOverlayFn)(SDL_Renderer* renderer);
 	static void setScreenOverlay(ScreenOverlayFn fn) { screenOverlay = fn; }
 private:
 	static ScreenOverlayFn screenOverlay;

--- a/include/Cursor.h
+++ b/include/Cursor.h
@@ -51,6 +51,7 @@ public:
 	~CCursor();
 private:
 	SmartPointer<SDL_Surface>	bmpCursor;
+	SmartPointer<SDL_Texture>	bmpCursorTex; // GPU texture, lazily from bmpCursor
 	CCursor			*cDown;
 	CCursor			*cUp;
 	int				iFrame;
@@ -63,7 +64,8 @@ private:
 	void			Init(int type);
 public:
 	void			Draw(SDL_Surface *dst);
-	void			DrawAdv(SDL_Surface *dst, int mouseX, int mouseY); // at an explicit position
+	void			DrawOnRenderer(SDL_Renderer *renderer, int mouseX, int mouseY); // GPU, at a screen position
+	void			InvalidateTexture(); // drop the GPU texture before the renderer is destroyed
 	INLINE bool		IsAnimated()  { return bAnimated; }
 	INLINE int		GetType()  { return iType; }
 	INLINE void		SetType(int _t)  { iType = _t; }
@@ -78,7 +80,8 @@ void ShutdownCursors();
 void SetGameCursor(int c);
 void SetGameCursor(CCursor *c);
 void DrawCursor(SDL_Surface *dst);
-void DrawCursorAt(SDL_Surface *dst, int x, int y); // at an explicit position
+void DrawCursorOnRenderer(SDL_Renderer *renderer, int x, int y); // GPU, at a screen position
+void InvalidateCursorTextures(); // before the renderer is destroyed
 int GetCursorHeight(int c);
 int GetCursorWidth(int c);
 INLINE int GetMaxCursorHeight()  { return iMaxCursorHeight; }

--- a/include/Cursor.h
+++ b/include/Cursor.h
@@ -63,6 +63,7 @@ private:
 	void			Init(int type);
 public:
 	void			Draw(SDL_Surface *dst);
+	void			DrawAdv(SDL_Surface *dst, int mouseX, int mouseY); // at an explicit position
 	INLINE bool		IsAnimated()  { return bAnimated; }
 	INLINE int		GetType()  { return iType; }
 	INLINE void		SetType(int _t)  { iType = _t; }
@@ -77,6 +78,7 @@ void ShutdownCursors();
 void SetGameCursor(int c);
 void SetGameCursor(CCursor *c);
 void DrawCursor(SDL_Surface *dst);
+void DrawCursorAt(SDL_Surface *dst, int x, int y); // at an explicit position
 int GetCursorHeight(int c);
 int GetCursorWidth(int c);
 INLINE int GetMaxCursorHeight()  { return iMaxCursorHeight; }

--- a/include/LieroX.h
+++ b/include/LieroX.h
@@ -46,6 +46,9 @@ struct lierox_t {
 							// it is not clamped unlike the above one
 	CFont	cFont;
 	CFont	cOutlineFont;
+	// Separate font copy for the main-thread screen overlay,
+	// so it never shares blit state with cFont (CFont is not thread-safe).
+	CFont	cOverlayFont;
 
 	bool	bVideoModeChanged;
 

--- a/include/TaskManager.h
+++ b/include/TaskManager.h
@@ -20,6 +20,7 @@
 #include "Mutex.h"
 
 class CFont;
+struct SDL_Renderer;
 #include "RefCounter.h"
 #include "util/Result.h"
 
@@ -97,9 +98,9 @@ public:
 	void finishQueuedTasks();
 	void dumpState(CmdLineIntf& cli) const;
 	
-	// Prints running task status on the surface, with the given font.
+	// Draws running task status on the renderer, with the given font.
 	// Implemented in MenuSystem.cpp.
-	void renderTasksStatus(SDL_Surface* s, CFont& font);
+	void renderTasksStatus(SDL_Renderer* r, CFont& font);
 };
 
 extern TaskManager* taskManager;

--- a/include/TaskManager.h
+++ b/include/TaskManager.h
@@ -18,6 +18,8 @@
 #include <boost/shared_ptr.hpp>
 #include "ThreadPool.h"
 #include "Mutex.h"
+
+class CFont;
 #include "RefCounter.h"
 #include "util/Result.h"
 
@@ -95,9 +97,9 @@ public:
 	void finishQueuedTasks();
 	void dumpState(CmdLineIntf& cli) const;
 	
-	// Prints all tasks with a status text on the surface.
-	// We do this in the menu. This function is implemented in MenuSystem.cpp.
-	void renderTasksStatus(SDL_Surface* s);
+	// Prints running task status on the surface, with the given font.
+	// Implemented in MenuSystem.cpp.
+	void renderTasksStatus(SDL_Surface* s, CFont& font);
 };
 
 extern TaskManager* taskManager;

--- a/src/client/AuxLib.cpp
+++ b/src/client/AuxLib.cpp
@@ -644,15 +644,6 @@ bool VideoPostProcessor::resetVideo() {
 		}
 	}
 
-	// The frame we present (composePresentFrame); allocated once.
-	if(!m_videoPresentSurface.get()) {
-		m_videoPresentSurface = GetCopiedImage(m_videoSurface);
-		if(!m_videoPresentSurface.get()) {
-			errors << "failed to init video present surface: " << SDL_GetError() << endl;
-			return false;
-		}
-	}
-
 	return true;
 }
 
@@ -675,12 +666,25 @@ void VideoPostProcessor::process() {
 	// This runs under the video mutex; render() does not.
 	get()->m_renderDisplayScreenWidth = get()->m_committedDisplayScreenWidth;
 
-	// Pipeline: game draws m_videoSurface -> flip -> m_videoBufferSurface,
-	// composed here into m_videoPresentSurface, then uploaded to m_videoTexture.
-	composePresentFrame();
-
-	void* pixels = get()->m_videoPresentSurface->pixels;
+	// Upload the drawn band; render() assembles the final frame on the GPU.
+	void* pixels = get()->m_videoBufferSurface->pixels;
 	SDL_UpdateTexture(get()->m_videoTexture.get(), NULL, pixels, get()->screenWidth() * sizeof (uint32_t));
+
+	get()->updateSideGapTextures();
+}
+
+// Upload the precomputed gap strips to textures when buildSideGaps produced new ones.
+void VideoPostProcessor::updateSideGapTextures() {
+	if(m_sideGapKey == m_sideGapTexKey && m_leftGapTex.get() && m_rightGapTex.get())
+		return;
+	m_sideGapTexKey = m_sideGapKey;
+	if(m_leftGap.get() && m_rightGap.get() && m_renderer.get()) {
+		m_leftGapTex = SDL_CreateTextureFromSurface(m_renderer.get(), m_leftGap.get());
+		m_rightGapTex = SDL_CreateTextureFromSurface(m_renderer.get(), m_rightGap.get());
+	} else {
+		m_leftGapTex = NULL;
+		m_rightGapTex = NULL;
+	}
 }
 
 // Fill a gap strip by extending a 1px edge column, cross-fading from sharp
@@ -769,51 +773,6 @@ void VideoPostProcessor::buildSideGaps(const SmartPointer<SDL_Surface>& bg) {
 	blurGapStrip(m_rightGap.get(), rightCol.get(), 0, offset - 1);
 }
 
-// Compose the presented frame from the drawn m_videoBufferSurface. Main thread.
-void VideoPostProcessor::composePresentFrame() {
-	SDL_Surface* src = get()->m_videoBufferSurface.get();
-	SDL_Surface* dst = get()->m_videoPresentSurface.get();
-	if(!src || !dst) return;
-
-	const int w = get()->screenWidth();
-	const int h = get()->screenHeight();
-	int dw = get()->m_renderDisplayScreenWidth;
-	if(dw <= 0 || dw > w) dw = w;
-	int offset = (w - dw) / 2;
-	if(offset < 0) offset = 0;
-
-	if(offset == 0) {
-		// Content already fills the width (local game / 4:3): straight copy (cursor baked in).
-		DrawImageAdv(dst, src, 0, 0, 0, 0, w, h);
-	} else {
-		// Content is dw wide in the left columns; copy it to the center.
-		// The mouse is shifted by the same offset (HandleMouseState), so clicks line up.
-		DrawImageAdv(dst, src, 0, 0, offset, 0, dw, h);
-
-		// Fill the side gaps with the precomputed strips, or a plain edge stretch
-		// before the theme is loaded / on a size mismatch.
-		if(get()->m_leftGap.get() && get()->m_leftGap->w == offset && get()->m_rightGap.get()) {
-			CopySurface(dst, get()->m_leftGap,  0, 0, 0,           0, offset, h);
-			CopySurface(dst, get()->m_rightGap, 0, 0, offset + dw, 0, offset, h);
-		} else {
-			SDL_Rect ls = { 0, 0, 1, h }, ld = { 0, 0, offset, h };
-			SDL_BlitScaled(src, &ls, dst, &ld);
-			SDL_Rect rs = { dw - 1, 0, 1, h }, rd = { offset + dw, 0, w - (offset + dw), h };
-			SDL_BlitScaled(src, &rs, dst, &rd);
-		}
-	}
-
-	// Screen-space overlays (task bar, FPS), full width, on top.
-	if(screenOverlay) screenOverlay(dst);
-
-	// Draw the cursor on top at its true position, so it roams the gaps.
-	// (Centered frames skip the in-band bake; see Cursor.cpp.)
-	if(offset > 0) {
-		mouse_t* m = GetMouse();
-		DrawCursorAt(dst, m->X + offset, m->Y); // menu-local X -> screen X
-	}
-}
-
 void VideoPostProcessor::render() {
 	//TestCircleDrawing(psScreen);
 	//TestPolygonDrawing(psScreen);
@@ -821,11 +780,54 @@ void VideoPostProcessor::render() {
 	//DrawLoadingAni(psScreen, 320, 260, 10, 10, Color(255,0,0), Color(0,255,0), LAT_CAKE);
 
 	if(!get()->m_renderer.get()) return;
+	SDL_Renderer* r = get()->m_renderer.get();
+	SDL_Texture* band = get()->m_videoTexture.get();
 
-	SDL_RenderClear(get()->m_renderer.get());
-	// The texture already holds the full composed frame; blit it 1:1.
-	SDL_RenderCopy(get()->m_renderer.get(), get()->m_videoTexture.get(), NULL, NULL);
-	SDL_RenderPresent(get()->m_renderer.get());
+	// Clear to black; the overlay leaves the draw color set, so pin it each frame.
+	SDL_SetRenderDrawColor(r, 0, 0, 0, 255);
+	SDL_RenderClear(r);
+
+	// Assemble the frame on the GPU: side gaps, then the (centered) band, then the cursor.
+	const int w = get()->screenWidth();
+	const int h = get()->screenHeight();
+	int dw = get()->m_renderDisplayScreenWidth;
+	if(dw <= 0 || dw > w) dw = w;
+	int offset = (w - dw) / 2;
+	if(offset < 0) offset = 0;
+
+	if(offset > 0) {
+		SDL_Rect leftDst  = { 0, 0, offset, h };
+		SDL_Rect rightDst = { offset + dw, 0, w - (offset + dw), h };
+		if(get()->m_leftGapTex.get() && get()->m_rightGapTex.get()) {
+			// Precomputed blurred strips.
+			SDL_RenderCopy(r, get()->m_leftGapTex.get(),  NULL, &leftDst);
+			SDL_RenderCopy(r, get()->m_rightGapTex.get(), NULL, &rightDst);
+		} else {
+			// Fallback before the theme is loaded: stretch the band's edge columns.
+			SDL_Rect leftSrc  = { 0, 0, 1, h };
+			SDL_Rect rightSrc = { dw - 1, 0, 1, h };
+			SDL_RenderCopy(r, band, &leftSrc,  &leftDst);
+			SDL_RenderCopy(r, band, &rightSrc, &rightDst);
+		}
+		// The band is dw wide in the left columns; present it centered.
+		// The mouse is shifted by the same offset (HandleMouseState), so clicks line up.
+		SDL_Rect bandSrc = { 0, 0, dw, h };
+		SDL_Rect bandDst = { offset, 0, dw, h };
+		SDL_RenderCopy(r, band, &bandSrc, &bandDst);
+
+		// Cursor on top at its true position, so it roams the gaps.
+		// (Centered frames skip the in-band bake; see Cursor.cpp.)
+		mouse_t* m = GetMouse();
+		DrawCursorOnRenderer(r, m->X + offset, m->Y); // menu-local X -> screen X
+	} else {
+		// Content already fills the width (local game / 4:3); cursor is baked in.
+		SDL_RenderCopy(r, band, NULL, NULL);
+	}
+
+	// Screen-space overlays (task bar, FPS), full width, on top.
+	if(screenOverlay) screenOverlay(r);
+
+	SDL_RenderPresent(r);
 
 #ifdef __EMSCRIPTEN__
 	// The very first presented frame means the wasm app is actually up on
@@ -855,12 +857,16 @@ void VideoPostProcessor::cloneBuffer() {
 void VideoPostProcessor::uninit() {
 	instance.m_videoSurface = NULL; // should never be used before resetVideo() is called
 	instance.m_videoBufferSurface = NULL; // else a restart keeps the old frame
-	instance.m_videoPresentSurface = NULL; // same: else a restart presents the old frame
 	instance.m_leftGap = NULL; // rebuilt for the new theme/size by buildSideGaps
 	instance.m_rightGap = NULL;
 	instance.m_sideGapKey = 0; // force that rebuild after a restart/resize
+	instance.m_sideGapTexKey = 0;
 
+	// GPU textures below belong to m_renderer; drop them all before it dies.
 	instance.m_videoTexture = NULL;
+	instance.m_leftGapTex = NULL;
+	instance.m_rightGapTex = NULL;
+	InvalidateCursorTextures();
 	instance.m_renderer = NULL;
 	instance.m_window = NULL;
 }

--- a/src/client/AuxLib.cpp
+++ b/src/client/AuxLib.cpp
@@ -68,6 +68,7 @@
 #include "GfxPrimitives.h"
 #include "FindFile.h"
 #include "InputEvents.h"
+#include "Cursor.h"
 #include "StringUtils.h"
 #include "sound/SoundsBase.h"
 #include "Version.h"
@@ -344,6 +345,7 @@ void ProcessScreenshots()
 // ---------------- VideoPostProcessor ---------------------------------------------------------
 
 VideoPostProcessor VideoPostProcessor::instance;
+VideoPostProcessor::ScreenOverlayFn VideoPostProcessor::screenOverlay = NULL;
 
 
 bool VideoPostProcessor::initWindow() {
@@ -641,7 +643,16 @@ bool VideoPostProcessor::resetVideo() {
 			return false;
 		}
 	}
-	
+
+	// The frame we present (composePresentFrame); allocated once.
+	if(!m_videoPresentSurface.get()) {
+		m_videoPresentSurface = GetCopiedImage(m_videoSurface);
+		if(!m_videoPresentSurface.get()) {
+			errors << "failed to init video present surface: " << SDL_GetError() << endl;
+			return false;
+		}
+	}
+
 	return true;
 }
 
@@ -659,12 +670,148 @@ void VideoPostProcessor::flipBuffers() {
 
 void VideoPostProcessor::process() {
 	ProcessScreenshots();
-	
-	void* pixels = get()->m_videoBufferSurface->pixels;
-	SDL_UpdateTexture(get()->m_videoTexture.get(), NULL, pixels, get()->screenWidth() * sizeof (uint32_t));
+
 	// Hand the committed frame's layout width to the main-thread-only render().
 	// This runs under the video mutex; render() does not.
 	get()->m_renderDisplayScreenWidth = get()->m_committedDisplayScreenWidth;
+
+	// Pipeline: game draws m_videoSurface -> flip -> m_videoBufferSurface,
+	// composed here into m_videoPresentSurface, then uploaded to m_videoTexture.
+	composePresentFrame();
+
+	void* pixels = get()->m_videoPresentSurface->pixels;
+	SDL_UpdateTexture(get()->m_videoTexture.get(), NULL, pixels, get()->screenWidth() * sizeof (uint32_t));
+}
+
+// Fill a gap strip by extending a 1px edge column, cross-fading from sharp
+// (nearX, next to the band) to vertically blurred (farX, the screen edge).
+static void blurGapStrip(SDL_Surface* gap, SDL_Surface* col, int nearX, int farX) {
+	const int h = gap->h;
+	if(h > 512 || farX == nearX) return;
+
+	const int colPitch = col->pitch, gapPitch = gap->pitch;
+	const Uint8* colPix = (const Uint8*)col->pixels;
+	Uint8* gapPix = (Uint8*)gap->pixels;
+
+	// The edge column, and a vertically box-blurred copy of it.
+	Uint32 sharp[512], blurred[512];
+	for(int y = 0; y < h; y++)
+		sharp[y] = *(const Uint32*)(colPix + y*colPitch);
+	const int R = 40; // blur radius at the screen edge
+	for(int y = 0; y < h; y++) {
+		int sum[4] = {0,0,0,0}, cnt = 0;
+		for(int k = -R; k <= R; k++) {
+			int yy = y + k;
+			if(yy < 0 || yy >= h) continue;
+			const Uint8* p = (const Uint8*)&sharp[yy];
+			for(int c = 0; c < 4; c++) sum[c] += p[c];
+			cnt++;
+		}
+		Uint8* o = (Uint8*)&blurred[y];
+		for(int c = 0; c < 4; c++) o[c] = (Uint8)(sum[c] / cnt);
+	}
+
+	for(int x = 0; x < gap->w; x++) {
+		float t = (float)(x - nearX) / (float)(farX - nearX);
+		if(t < 0) t = 0; else if(t > 1) t = 1;
+		t *= t; // stay sharp near the band, blur harder toward the edge
+		const int t256 = (int)(t * 256.0f + 0.5f);
+		for(int y = 0; y < h; y++) {
+			const Uint8* a = (const Uint8*)&sharp[y];
+			const Uint8* b = (const Uint8*)&blurred[y];
+			Uint8* o = gapPix + y*gapPitch + x*4;
+			for(int c = 0; c < 4; c++)
+				o[c] = (Uint8)((a[c]*(256 - t256) + b[c]*t256) >> 8);
+		}
+	}
+}
+
+// Precompute the side-gap fills from a menuWidth-wide menu background.
+// Cheap to call every frame: rebuilds only when the edge columns or offset change.
+void VideoPostProcessor::buildSideGaps(const SmartPointer<SDL_Surface>& bg) {
+	const int offset = (m_screenWidth - menuWidth) / 2;
+	const int h = screenHeight();
+	if(!bg.get() || offset <= 0 || bg->w < menuWidth || bg->h < h
+	   || bg->format->BytesPerPixel != 4) {
+		m_leftGap = NULL; m_rightGap = NULL; m_sideGapKey = 0;
+		return;
+	}
+
+	// Change key: hash of the edge columns + offset; skip the rebuild if unchanged.
+	Uint32 key = 2166136261u ^ (Uint32)offset;
+	const Uint8* bgPix = (const Uint8*)bg->pixels;
+	const int lastX = menuWidth - 1;
+	for(int y = 0; y < h; y++) {
+		const Uint8* row = bgPix + y*bg->pitch;
+		key = (key ^ *(const Uint32*)(row)) * 16777619u;
+		key = (key ^ *(const Uint32*)(row + lastX*4)) * 16777619u;
+	}
+	if(key == m_sideGapKey && m_leftGap.get() && m_rightGap.get()) return;
+	m_sideGapKey = key;
+
+	// Pull the two edge columns into 1px surfaces of our format (converts once).
+	SmartPointer<SDL_Surface> leftCol = create_32bpp_sdlsurface__allegroformat(1, h);
+	SmartPointer<SDL_Surface> rightCol = create_32bpp_sdlsurface__allegroformat(1, h);
+	m_leftGap = create_32bpp_sdlsurface__allegroformat(offset, h);
+	m_rightGap = create_32bpp_sdlsurface__allegroformat(offset, h);
+	if(!leftCol.get() || !rightCol.get() || !m_leftGap.get() || !m_rightGap.get()) {
+		m_leftGap = NULL; m_rightGap = NULL;
+		return;
+	}
+	SDL_Rect ls = { 0, 0, 1, h }, cd = { 0, 0, 1, h };
+	SDL_BlitSurface(bg.get(), &ls, leftCol.get(), &cd);
+	SDL_Rect rs = { menuWidth - 1, 0, 1, h };
+	SDL_BlitSurface(bg.get(), &rs, rightCol.get(), &cd);
+
+	// Left gap: sharp at its inner edge (adjacent to the band), blurred at x=0.
+	blurGapStrip(m_leftGap.get(), leftCol.get(), offset - 1, 0);
+	// Right gap: sharp at x=0 (adjacent to the band), blurred at its outer edge.
+	blurGapStrip(m_rightGap.get(), rightCol.get(), 0, offset - 1);
+}
+
+// Compose the presented frame from the drawn m_videoBufferSurface. Main thread.
+void VideoPostProcessor::composePresentFrame() {
+	SDL_Surface* src = get()->m_videoBufferSurface.get();
+	SDL_Surface* dst = get()->m_videoPresentSurface.get();
+	if(!src || !dst) return;
+
+	const int w = get()->screenWidth();
+	const int h = get()->screenHeight();
+	int dw = get()->m_renderDisplayScreenWidth;
+	if(dw <= 0 || dw > w) dw = w;
+	int offset = (w - dw) / 2;
+	if(offset < 0) offset = 0;
+
+	if(offset == 0) {
+		// Content already fills the width (local game / 4:3): straight copy (cursor baked in).
+		DrawImageAdv(dst, src, 0, 0, 0, 0, w, h);
+	} else {
+		// Content is dw wide in the left columns; copy it to the center.
+		// The mouse is shifted by the same offset (HandleMouseState), so clicks line up.
+		DrawImageAdv(dst, src, 0, 0, offset, 0, dw, h);
+
+		// Fill the side gaps with the precomputed strips, or a plain edge stretch
+		// before the theme is loaded / on a size mismatch.
+		if(get()->m_leftGap.get() && get()->m_leftGap->w == offset && get()->m_rightGap.get()) {
+			CopySurface(dst, get()->m_leftGap,  0, 0, 0,           0, offset, h);
+			CopySurface(dst, get()->m_rightGap, 0, 0, offset + dw, 0, offset, h);
+		} else {
+			SDL_Rect ls = { 0, 0, 1, h }, ld = { 0, 0, offset, h };
+			SDL_BlitScaled(src, &ls, dst, &ld);
+			SDL_Rect rs = { dw - 1, 0, 1, h }, rd = { offset + dw, 0, w - (offset + dw), h };
+			SDL_BlitScaled(src, &rs, dst, &rd);
+		}
+	}
+
+	// Screen-space overlays (task bar, FPS), full width, on top.
+	if(screenOverlay) screenOverlay(dst);
+
+	// Draw the cursor on top at its true position, so it roams the gaps.
+	// (Centered frames skip the in-band bake; see Cursor.cpp.)
+	if(offset > 0) {
+		mouse_t* m = GetMouse();
+		DrawCursorAt(dst, m->X + offset, m->Y); // menu-local X -> screen X
+	}
 }
 
 void VideoPostProcessor::render() {
@@ -672,38 +819,12 @@ void VideoPostProcessor::render() {
 	//TestPolygonDrawing(psScreen);
 	//DrawLoadingAni(psScreen, 320, 260, 50, 50, Color(128,128,128), Color(128,128,128,128), LAT_CIRCLES);
 	//DrawLoadingAni(psScreen, 320, 260, 10, 10, Color(255,0,0), Color(0,255,0), LAT_CAKE);
-	
+
 	if(!get()->m_renderer.get()) return;
 
 	SDL_RenderClear(get()->m_renderer.get());
-	// Use the layout width captured for this frame (see process()), not the live
-	// displayScreenWidth(), which the game thread may already have moved on.
-	const int dw = get()->m_renderDisplayScreenWidth;
-	int centerOffset = (get()->m_screenWidth - dw) / 2;
-	if(centerOffset < 0) centerOffset = 0;
-	if(centerOffset > 0) {
-		// The frame's content (a menu, or a network game) is only dw wide
-		// and is drawn into the left dw columns of the (wider) video surface.
-		// Present just that region, centered,
-		// so it appears in the middle of the screen.
-		// The mouse is shifted by the same offset (see HandleMouseState)
-		// so clicks still line up.
-		const int h = get()->screenHeight();
-		// Fill the side gaps by stretching the frame's own edge columns outward,
-		// so the theme's background continues there instead of black bars.
-		SDL_Rect leftSrc = { 0, 0, 1, h };
-		SDL_Rect leftDst = { 0, 0, centerOffset, h };
-		SDL_RenderCopy(get()->m_renderer.get(), get()->m_videoTexture.get(), &leftSrc, &leftDst);
-		SDL_Rect rightSrc = { dw - 1, 0, 1, h };
-		SDL_Rect rightDst = { centerOffset + dw, 0, get()->screenWidth() - (centerOffset + dw), h };
-		SDL_RenderCopy(get()->m_renderer.get(), get()->m_videoTexture.get(), &rightSrc, &rightDst);
-
-		SDL_Rect src = { 0, 0, dw, h };
-		SDL_Rect dst = { centerOffset, 0, dw, h };
-		SDL_RenderCopy(get()->m_renderer.get(), get()->m_videoTexture.get(), &src, &dst);
-	} else {
-		SDL_RenderCopy(get()->m_renderer.get(), get()->m_videoTexture.get(), NULL, NULL);
-	}
+	// The texture already holds the full composed frame; blit it 1:1.
+	SDL_RenderCopy(get()->m_renderer.get(), get()->m_videoTexture.get(), NULL, NULL);
 	SDL_RenderPresent(get()->m_renderer.get());
 
 #ifdef __EMSCRIPTEN__
@@ -734,6 +855,11 @@ void VideoPostProcessor::cloneBuffer() {
 void VideoPostProcessor::uninit() {
 	instance.m_videoSurface = NULL; // should never be used before resetVideo() is called
 	instance.m_videoBufferSurface = NULL; // else a restart keeps the old frame
+	instance.m_videoPresentSurface = NULL; // same: else a restart presents the old frame
+	instance.m_leftGap = NULL; // rebuilt for the new theme/size by buildSideGaps
+	instance.m_rightGap = NULL;
+	instance.m_sideGapKey = 0; // force that rebuild after a restart/resize
+
 	instance.m_videoTexture = NULL;
 	instance.m_renderer = NULL;
 	instance.m_window = NULL;

--- a/src/client/CClient.cpp
+++ b/src/client/CClient.cpp
@@ -1596,7 +1596,7 @@ void CClient::SetupViewports(CWorm *w1, CWorm *w2, int type1, int type2)
 	
 	// Non-widescreen games are constrained to the base menuWidth so that a
 	// wider screen gives no gameplay advantage (the narrower view is composed
-	// centered, side gaps edge-filled, see composePresentFrame). Widescreen
+	// centered, side gaps edge-filled, see render()). Widescreen
 	// games use the full screen width. Set the display width up front so the
 	// viewports are sized from it (the gameplay draw keeps it updated too).
 	VideoPostProcessor::get()->setDisplayScreenWidth(

--- a/src/client/CClient.cpp
+++ b/src/client/CClient.cpp
@@ -1595,8 +1595,8 @@ void CClient::SetupViewports(CWorm *w1, CWorm *w2, int type1, int type2)
 	}
 	
 	// Non-widescreen games are constrained to the base menuWidth so that a
-	// wider screen gives no gameplay advantage (the narrower view is presented
-	// centered with black bars, see VideoPostProcessor::render). Widescreen
+	// wider screen gives no gameplay advantage (the narrower view is composed
+	// centered, side gaps edge-filled, see composePresentFrame). Widescreen
 	// games use the full screen width. Set the display width up front so the
 	// viewports are sized from it (the gameplay draw keeps it updated too).
 	VideoPostProcessor::get()->setDisplayScreenWidth(
@@ -1718,7 +1718,7 @@ void CClient::SetupViewports(const std::vector<CWorm*>& worms, int type)
 	}
 
 	// See the note in the 2-arg overload: non-widescreen games are constrained
-	// to menuWidth (centered with black bars); widescreen uses the full width.
+	// to menuWidth (composed centered, side gaps edge-filled); widescreen uses the full width.
 	VideoPostProcessor::get()->setDisplayScreenWidth(
 		game.useWideScreen() ? VideoPostProcessor::get()->screenWidth()
 		                     : VideoPostProcessor::menuWidth);

--- a/src/client/CClient_Draw.cpp
+++ b/src/client/CClient_Draw.cpp
@@ -416,7 +416,7 @@ void CClient::DrawBox(SDL_Surface * dst, int x, int y, int w)
 void CClient::Draw(const SmartPointer<SDL_Surface>& bmpDest)
 {
 	// Widescreen games use the full screen width; others are constrained to the
-	// base menuWidth (presented centered, with black bars) so that a wider
+	// base menuWidth (composed centered, side gaps edge-filled) so that a wider
 	// screen gives no gameplay advantage. This also overrides the menuWidth set
 	// by Menu_Frame once we are in a widescreen game.
 	VideoPostProcessor::get()->setDisplayScreenWidth(

--- a/src/client/Cursor.cpp
+++ b/src/client/Cursor.cpp
@@ -84,7 +84,7 @@ bool InitializeCursors()
 // Shutdown the cursors
 void ShutdownCursors()
 {
-	tCurrentCursor = NULL; // else it dangles past the free below (e.g. composePresentFrame)
+	tCurrentCursor = NULL; // else it dangles past the free below (e.g. render())
 
 	// Free all the cursor structures
 	for (byte i=0; i<CURSOR_COUNT; i++)
@@ -128,7 +128,7 @@ void SetGameCursor(CCursor *c)
 /////////////////
 // Draw game cursor
 void DrawCursor(SDL_Surface * dst) {
-	// On centered frames composePresentFrame() draws the cursor (see there),
+	// On centered frames render() draws the cursor (see there),
 	// so skip the in-band bake here to keep the gap-filling edge columns clean.
 	if (VideoPostProcessor::get()->displayScreenOffsetX() > 0)
 		return;
@@ -137,10 +137,17 @@ void DrawCursor(SDL_Surface * dst) {
 }
 
 /////////////////
-// Draw game cursor at an explicit position
-void DrawCursorAt(SDL_Surface * dst, int x, int y) {
+// Draw game cursor on the renderer at an explicit screen position
+void DrawCursorOnRenderer(SDL_Renderer * renderer, int x, int y) {
 	if (tCurrentCursor)
-		tCurrentCursor->DrawAdv(dst, x, y);
+		tCurrentCursor->DrawOnRenderer(renderer, x, y);
+}
+
+// Drop cursor GPU textures before the renderer is destroyed (VideoPostProcessor::uninit).
+void InvalidateCursorTextures() {
+	for (byte i = 0; i < CURSOR_COUNT; i++)
+		if (tCursors[i])
+			tCursors[i]->InvalidateTexture();
 }
 
 ///////////////////
@@ -249,14 +256,6 @@ CCursor::~CCursor()
 // Draw the cursor
 void CCursor::Draw(SDL_Surface * dst)
 {
-	mouse_t *Mouse = GetMouse();
-	DrawAdv(dst, Mouse->X, Mouse->Y);
-}
-
-//////////////////
-// Draw the cursor at an explicit position
-void CCursor::DrawAdv(SDL_Surface * dst, int mouseX, int mouseY)
-{
 	// Check
 	if (!dst || !bmpCursor.get())
 		return;
@@ -267,21 +266,21 @@ void CCursor::DrawAdv(SDL_Surface * dst, int mouseX, int mouseY)
 	if (Mouse->FirstDown)  // Mouse down
 	{
 		if (cDown)  {
-			cDown->DrawAdv(dst, mouseX, mouseY);
+			cDown->Draw(dst);
 			return;
 		}
 	}
 	else if (Mouse->Up) // Mouse up
 	{
 		if (cUp)  {
-			cUp->DrawAdv(dst, mouseX, mouseY);
+			cUp->Draw(dst);
 			return;
 		}
 	}
 
 	// Image position
-	int X = mouseX;
-	int Y = mouseY;
+	int X = Mouse->X;
+	int Y = Mouse->Y;
 
 	// Change the position depending on the type
 	switch (iType)  {
@@ -311,4 +310,66 @@ void CCursor::DrawAdv(SDL_Surface * dst, int mouseX, int mouseY)
 
 	// Draw the cursor
 	DrawImageAdv(dst,bmpCursor,iFrame*iFrameWidth,0,X,Y,iFrameWidth,bmpCursor.get()->h);
+}
+
+//////////////////
+// Drop the GPU texture (recursive to the up/down states)
+void CCursor::InvalidateTexture()
+{
+	bmpCursorTex = NULL;
+	if (cDown) cDown->InvalidateTexture();
+	if (cUp) cUp->InvalidateTexture();
+}
+
+//////////////////
+// Draw the cursor on the renderer at an explicit screen position
+void CCursor::DrawOnRenderer(SDL_Renderer * renderer, int mouseX, int mouseY)
+{
+	if (!renderer || !bmpCursor.get())
+		return;
+
+	mouse_t *Mouse = GetMouse();
+
+	// Special states first (mirrors Draw)
+	if (Mouse->FirstDown) {
+		if (cDown) { cDown->DrawOnRenderer(renderer, mouseX, mouseY); return; }
+	}
+	else if (Mouse->Up) {
+		if (cUp) { cUp->DrawOnRenderer(renderer, mouseX, mouseY); return; }
+	}
+
+	// Lazily upload the (color-keyed) cursor surface to a texture.
+	if (!bmpCursorTex.get()) {
+		bmpCursorTex = SDL_CreateTextureFromSurface(renderer, bmpCursor.get());
+		if (!bmpCursorTex.get()) return;
+		SDL_SetTextureBlendMode(bmpCursorTex.get(), SDL_BLENDMODE_BLEND);
+	}
+
+	int X = mouseX;
+	int Y = mouseY;
+	switch (iType) {
+	case CUR_ARROW:
+	case CUR_TEXT:
+		break;
+	case CUR_SPLITTER:
+		X -= iFrameWidth / 2;
+		break;
+	case CUR_AIM:
+		X -= iFrameWidth / 2;
+		Y -= bmpCursor.get()->h / 2;
+		break;
+	default:
+		break;
+	}
+
+	// Process animating (mirrors Draw)
+	if ((tLX->currentTime - fAnimationSwapTime).seconds() >= fCursorFrameTime) {
+		iFrame++;
+		iFrame %= iNumFrames;
+		fAnimationSwapTime = tLX->currentTime;
+	}
+
+	SDL_Rect src = { iFrame*iFrameWidth, 0, iFrameWidth, bmpCursor.get()->h };
+	SDL_Rect dst = { X, Y, iFrameWidth, bmpCursor.get()->h };
+	SDL_RenderCopy(renderer, bmpCursorTex.get(), &src, &dst);
 }

--- a/src/client/Cursor.cpp
+++ b/src/client/Cursor.cpp
@@ -17,6 +17,7 @@
 
 #include "FindFile.h"
 #include "InputEvents.h"
+#include "AuxLib.h"
 #include "GfxPrimitives.h"
 #include "ConfigHandler.h"
 #include "Cursor.h"
@@ -83,6 +84,8 @@ bool InitializeCursors()
 // Shutdown the cursors
 void ShutdownCursors()
 {
+	tCurrentCursor = NULL; // else it dangles past the free below (e.g. composePresentFrame)
+
 	// Free all the cursor structures
 	for (byte i=0; i<CURSOR_COUNT; i++)
 		if (tCursors[i])  {
@@ -93,6 +96,7 @@ void ShutdownCursors()
 	if (tAnimTimer)  {
 		tAnimTimer->stop();
 		delete tAnimTimer;
+		tAnimTimer = NULL;
 	}
 }
 
@@ -124,8 +128,19 @@ void SetGameCursor(CCursor *c)
 /////////////////
 // Draw game cursor
 void DrawCursor(SDL_Surface * dst) {
+	// On centered frames composePresentFrame() draws the cursor (see there),
+	// so skip the in-band bake here to keep the gap-filling edge columns clean.
+	if (VideoPostProcessor::get()->displayScreenOffsetX() > 0)
+		return;
 	if (tCurrentCursor)
 		tCurrentCursor->Draw(dst);
+}
+
+/////////////////
+// Draw game cursor at an explicit position
+void DrawCursorAt(SDL_Surface * dst, int x, int y) {
+	if (tCurrentCursor)
+		tCurrentCursor->DrawAdv(dst, x, y);
 }
 
 ///////////////////
@@ -234,6 +249,14 @@ CCursor::~CCursor()
 // Draw the cursor
 void CCursor::Draw(SDL_Surface * dst)
 {
+	mouse_t *Mouse = GetMouse();
+	DrawAdv(dst, Mouse->X, Mouse->Y);
+}
+
+//////////////////
+// Draw the cursor at an explicit position
+void CCursor::DrawAdv(SDL_Surface * dst, int mouseX, int mouseY)
+{
 	// Check
 	if (!dst || !bmpCursor.get())
 		return;
@@ -244,21 +267,21 @@ void CCursor::Draw(SDL_Surface * dst)
 	if (Mouse->FirstDown)  // Mouse down
 	{
 		if (cDown)  {
-			cDown->Draw(dst);
+			cDown->DrawAdv(dst, mouseX, mouseY);
 			return;
 		}
 	}
 	else if (Mouse->Up) // Mouse up
 	{
 		if (cUp)  {
-			cUp->Draw(dst);
+			cUp->DrawAdv(dst, mouseX, mouseY);
 			return;
 		}
 	}
 
 	// Image position
-	int X = Mouse->X;
-	int Y = Mouse->Y;
+	int X = mouseX;
+	int Y = mouseY;
 
 	// Change the position depending on the type
 	switch (iType)  {

--- a/src/client/DeprecatedGUI/Graphics.cpp
+++ b/src/client/DeprecatedGUI/Graphics.cpp
@@ -333,6 +333,11 @@ bool LoadFonts()  {
 	if(!tLX->cOutlineFont.Load("data/gfx/out_font.png",true))
 		return false;
 
+	// Overlay font: a second copy for the main-thread overlay (see LieroX.h).
+	tLX->cOverlayFont.SetVSpacing(0);
+	if(!tLX->cOverlayFont.Load("data/gfx/font.png",true))
+		return false;
+
 	return true;
 }
 
@@ -345,6 +350,7 @@ void ShutdownGraphics()
 	if (tLX)  {
 		tLX->cFont.Shutdown();
 		tLX->cOutlineFont.Shutdown();
+		tLX->cOverlayFont.Shutdown();
 	}
 }
 

--- a/src/client/DeprecatedGUI/MenuSystem.cpp
+++ b/src/client/DeprecatedGUI/MenuSystem.cpp
@@ -109,6 +109,8 @@ static bool Menu_InitSockets() {
 
 menu_t::menu_t() : cSkin(CGameSkin::WormSkin(), true) {}
 
+static void Menu_DrawScreenOverlay(SDL_Surface* screen); // registered in Menu_Initialize
+
 ///////////////////
 // Initialize the menu system
 bool Menu_Initialize()
@@ -142,6 +144,9 @@ bool Menu_Initialize()
 	tMenu->bmpMainBack_common = LoadGameImage("data/frontend/background_common.png");
 	if (!tMenu->bmpMainBack_common.get())
 		tMenu->bmpMainBack_common = tMenu->bmpMainBack_wob;
+
+	// Draw the task-status bar and FPS in screen space (full display width).
+	VideoPostProcessor::setScreenOverlay(&Menu_DrawScreenOverlay);
 
 
 	tMenu->bmpBuffer = gfxCreateSurface(640,480);
@@ -253,6 +258,24 @@ void Menu_SetSkipStart(int s)
     bSkipStart = s;
 }
 	
+// Draw the task-status bar and FPS full width,
+// on the main thread (the VideoPostProcessor screen overlay).
+// Uses cOverlayFont, not cFont,
+// so it doesn't race the gameloop's font drawing (CFont is not thread-safe).
+static void Menu_DrawScreenOverlay(SDL_Surface* screen) {
+	if(!screen || !tLX) return;
+	if(game.state >= Game::S_Preparing) return; // menus only, as before
+
+	if(taskManager)
+		taskManager->renderTasksStatus(screen, tLX->cOverlayFont);
+
+#ifdef DEBUG
+	if(tLX->fDeltaTime != TimeDiff())
+		tLX->cOverlayFont.Draw(screen, 0, 0, tLX->clWhite,
+			"FPS: " + itoa((int)(1.0f/tLX->fDeltaTime.seconds())));
+#endif
+}
+
 void Menu_Frame() {
 	if(bDedicated) {
 		ServerList::get()->process();
@@ -268,6 +291,10 @@ void Menu_Frame() {
 	// Menus are authored for menuWidth and presented centered on the screen.
 	// (Overwritten by the gameplay draw, see CClient::Draw.)
 	VideoPostProcessor::get()->setDisplayScreenWidth(VideoPostProcessor::menuWidth);
+
+	// Keep the side bars in sync with this menu's background.
+	// (buildSideGaps only rebuilds when the edges change; a game keeps the last.)
+	VideoPostProcessor::get()->buildSideGaps(tMenu->bmpBuffer);
 
 	// Check if user pressed screenshot key
 	if (tLX->cTakeScreenshot.isDownOnce())  {
@@ -319,16 +346,8 @@ void Menu_Frame() {
 	if(tMenu->iMenuType != MNU_NETWORK)
 		ServerList::get()->process();
 	
-	// DEBUG: show FPS
-#ifdef DEBUG
-	if(tLX->fDeltaTime != TimeDiff()) {
-		Menu_redrawBufferRect(0, 0, 100, 20);
-		tLX->cFont.Draw(VideoPostProcessor::videoSurface().get(), 0, 0, tLX->clWhite, "FPS: " + itoa((int)(1.0f/tLX->fDeltaTime.seconds())));
-	}
-#endif
+	// Task-status bar and FPS are drawn full width by Menu_DrawScreenOverlay, not here.
 
-	taskManager->renderTasksStatus(VideoPostProcessor::videoSurface().get());
-	
 	if (!tMenu->bForbidConsole)  {
 		Con_Process(tLX->fDeltaTime);
 		Con_Draw(VideoPostProcessor::videoSurface().get());
@@ -1509,7 +1528,7 @@ void Menu_Current_Shutdown() {
 
 
 
-void TaskManager::renderTasksStatus(SDL_Surface* s) {
+void TaskManager::renderTasksStatus(SDL_Surface* s, CFont& font) {
 	std::list<std::string> statusTxts;
 	
 	static const unsigned int MaxEntries = 4;
@@ -1529,12 +1548,12 @@ void TaskManager::renderTasksStatus(SDL_Surface* s) {
 		static const int StatusLoadingLeft = 5;
 		static const int StatusLeft = 30;
 		static const int StatusTop = 5;
-		const int StatusHeight = tLX->cFont.GetHeight() + 5;
+		const int StatusHeight = font.GetHeight() + 5;
 		DrawRectFill(s, 0, 0, s->w, StatusTop + StatusHeight * (int)statusTxts.size(), Color(42,73,145,180));
-		
+
 		int y = StatusTop;
 		for(std::list<std::string>::iterator i = statusTxts.begin(); i != statusTxts.end(); ++i) {
-			tLX->cFont.Draw(s, StatusLeft, y, Color(255,255,255), *i);
+			font.Draw(s, StatusLeft, y, Color(255,255,255), *i);
 			y += StatusHeight;
 		}
 	

--- a/src/client/DeprecatedGUI/MenuSystem.cpp
+++ b/src/client/DeprecatedGUI/MenuSystem.cpp
@@ -109,7 +109,7 @@ static bool Menu_InitSockets() {
 
 menu_t::menu_t() : cSkin(CGameSkin::WormSkin(), true) {}
 
-static void Menu_DrawScreenOverlay(SDL_Surface* screen); // registered in Menu_Initialize
+static void Menu_DrawScreenOverlay(SDL_Renderer* renderer); // registered in Menu_Initialize
 
 ///////////////////
 // Initialize the menu system
@@ -258,20 +258,73 @@ void Menu_SetSkipStart(int s)
     bSkipStart = s;
 }
 	
+// --- GPU overlay primitives -----------------------------------------------
+// Immediate-mode helpers for the screen overlay, main thread only:
+// a blended fill rect, and content-sized surfaces blitted as textures.
+
+static void overlayFillRect(SDL_Renderer* r, int x, int y, int w, int h, Color c) {
+	SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_BLEND);
+	SDL_SetRenderDrawColor(r, c.r, c.g, c.b, c.a);
+	SDL_Rect rect = { x, y, w, h };
+	SDL_RenderFillRect(r, &rect);
+}
+
+// Blit an alpha (transparent-background) surface as a texture at (x,y).
+// Raw upload into a matching-format texture (like the main video texture),
+// not CreateTextureFromSurface -- its conversion mis-renders on Metal (magenta text).
+static void overlayBlit(SDL_Renderer* r, const SmartPointer<SDL_Surface>& s, int x, int y) {
+	if(!s.get()) return;
+	SmartPointer<SDL_Texture> tex = SDL_CreateTexture(r, s->format->format,
+		SDL_TEXTUREACCESS_STREAMING, s->w, s->h);
+	if(!tex.get()) return;
+	SDL_SetTextureBlendMode(tex.get(), SDL_BLENDMODE_BLEND);
+	SDL_UpdateTexture(tex.get(), NULL, s->pixels, s->pitch);
+	SDL_Rect dst = { x, y, s->w, s->h };
+	SDL_RenderCopy(r, tex.get(), NULL, &dst);
+}
+
+// Fresh alpha surface cleared to the content colour at alpha 0,
+// not transparent black -- else AA edges blend their RGB toward black
+// and the text looks muddy.
+static SmartPointer<SDL_Surface> overlayScratch(int w, int h, Color col) {
+	SmartPointer<SDL_Surface> s = gfxCreateSurfaceAlpha(w, h);
+	if(s.get())
+		SDL_FillRect(s.get(), NULL, SDL_MapRGBA(s->format, col.r, col.g, col.b, 0));
+	return s;
+}
+
+static void overlayDrawText(SDL_Renderer* r, CFont& font, int x, int y, Color col, const std::string& text) {
+	if(text.empty()) return;
+	const int w = font.GetWidth(text), h = font.GetHeight();
+	if(w <= 0 || h <= 0) return;
+	SmartPointer<SDL_Surface> s = overlayScratch(w, h, col);
+	if(!s.get()) return;
+	font.Draw(s.get(), 0, 0, col, text);
+	overlayBlit(r, s, x, y);
+}
+
+// Draw the running-tasks loading ani centered at (cx,cy), radius rx/ry.
+static void overlayDrawLoadingAni(SDL_Renderer* r, int cx, int cy, int rx, int ry, Color fg, Color bg) {
+	SmartPointer<SDL_Surface> s = overlayScratch(2*rx + 2, 2*ry + 2, fg);
+	if(!s.get()) return;
+	DrawLoadingAni(s.get(), rx, ry, rx, ry, fg, bg, LAT_CIRCLES);
+	overlayBlit(r, s, cx - rx, cy - ry);
+}
+
 // Draw the task-status bar and FPS full width,
 // on the main thread (the VideoPostProcessor screen overlay).
 // Uses cOverlayFont, not cFont,
 // so it doesn't race the gameloop's font drawing (CFont is not thread-safe).
-static void Menu_DrawScreenOverlay(SDL_Surface* screen) {
-	if(!screen || !tLX) return;
+static void Menu_DrawScreenOverlay(SDL_Renderer* renderer) {
+	if(!renderer || !tLX) return;
 	if(game.state >= Game::S_Preparing) return; // menus only, as before
 
 	if(taskManager)
-		taskManager->renderTasksStatus(screen, tLX->cOverlayFont);
+		taskManager->renderTasksStatus(renderer, tLX->cOverlayFont);
 
 #ifdef DEBUG
 	if(tLX->fDeltaTime != TimeDiff())
-		tLX->cOverlayFont.Draw(screen, 0, 0, tLX->clWhite,
+		overlayDrawText(renderer, tLX->cOverlayFont, 0, 0, tLX->clWhite,
 			"FPS: " + itoa((int)(1.0f/tLX->fDeltaTime.seconds())));
 #endif
 }
@@ -1528,9 +1581,9 @@ void Menu_Current_Shutdown() {
 
 
 
-void TaskManager::renderTasksStatus(SDL_Surface* s, CFont& font) {
+void TaskManager::renderTasksStatus(SDL_Renderer* r, CFont& font) {
 	std::list<std::string> statusTxts;
-	
+
 	static const unsigned int MaxEntries = 4;
 	{
 		ScopedLock lock(mutex);
@@ -1543,21 +1596,27 @@ void TaskManager::renderTasksStatus(SDL_Surface* s, CFont& font) {
 			}
 		}
 	}
-	
-	if(!statusTxts.empty()) {
-		static const int StatusLoadingLeft = 5;
-		static const int StatusLeft = 30;
-		static const int StatusTop = 5;
-		const int StatusHeight = font.GetHeight() + 5;
-		DrawRectFill(s, 0, 0, s->w, StatusTop + StatusHeight * (int)statusTxts.size(), Color(42,73,145,180));
 
-		int y = StatusTop;
-		for(std::list<std::string>::iterator i = statusTxts.begin(); i != statusTxts.end(); ++i) {
-			font.Draw(s, StatusLeft, y, Color(255,255,255), *i);
-			y += StatusHeight;
-		}
-	
-		static const int StatusLoadingSize = 9;
-		DrawLoadingAni(s, StatusLoadingLeft + StatusLoadingSize, StatusHeight * (int)statusTxts.size() - StatusLoadingSize, StatusLoadingSize, StatusLoadingSize, Color(255,255,255), Color(128,128,128), LAT_CIRCLES);
+	if(statusTxts.empty()) return;
+
+	static const int StatusLoadingLeft = 5;
+	static const int StatusLeft = 30;
+	static const int StatusTop = 5;
+	static const int StatusLoadingSize = 9;
+	const int StatusHeight = font.GetHeight() + 5;
+	const int count = (int)statusTxts.size();
+	const int screenW = VideoPostProcessor::get()->screenWidth();
+
+	// Full-width translucent bar behind the status lines.
+	DeprecatedGUI::overlayFillRect(r, 0, 0, screenW, StatusTop + StatusHeight * count, Color(42,73,145,180));
+
+	int y = StatusTop;
+	for(std::list<std::string>::iterator i = statusTxts.begin(); i != statusTxts.end(); ++i) {
+		DeprecatedGUI::overlayDrawText(r, font, StatusLeft, y, Color(255,255,255), *i);
+		y += StatusHeight;
 	}
+
+	DeprecatedGUI::overlayDrawLoadingAni(r, StatusLoadingLeft + StatusLoadingSize,
+		StatusHeight * count - StatusLoadingSize, StatusLoadingSize, StatusLoadingSize,
+		Color(255,255,255), Color(128,128,128));
 }

--- a/src/client/InputEvents.cpp
+++ b/src/client/InputEvents.cpp
@@ -558,7 +558,7 @@ static void HandleMouseState() {
 		// The mouse coordinates are only translated in the mouse events.
 		// That is why we track the coordinates in there.
 		// The mouse can be in the side area outside the centered band;
-		// composePresentFrame() fills it and draws the cursor there.
+		// render() fills it and draws the cursor there.
 		// SDL_SetRelativeMouseMode is not an option here
 		// because it is somewhat buggy (seems like the mouse is captured)
 		// and it grabs the mouse in window mode which we don't want.

--- a/src/client/InputEvents.cpp
+++ b/src/client/InputEvents.cpp
@@ -557,17 +557,12 @@ static void HandleMouseState() {
 		// it ignores the render logical size via SDL_RenderSetLogicalSize().
 		// The mouse coordinates are only translated in the mouse events.
 		// That is why we track the coordinates in there.
-		// However, that still has the problem that the mouse coordinates
-		// can be in the letterboxing (black) area, i.e. outside
-		// our logical screen.
-		// SDL_SetRelativeMouseMode is also not really an option
+		// The mouse can be in the side area outside the centered band;
+		// composePresentFrame() fills it and draws the cursor there.
+		// SDL_SetRelativeMouseMode is not an option here
 		// because it is somewhat buggy (seems like the mouse is captured)
 		// and it grabs the mouse in window mode which we don't want.
-		// In fullscreen mode, we could warp the mouse back to the center
-		// on each frame and then use this relative mouse mode.
 		// See: https://forums.libsdl.org/viewtopic.php?t=10690
-		// However, later, we could just remove the letterboxing area
-		// by having a bigger virtual screen, so this problem goes away.
 		
 		Mouse.Button = SDL_GetMouseState(NULL,NULL); // Doesn't call libX11 funcs, so it's safe to call not from video thread
 		Mouse.X = mouseX;


### PR DESCRIPTION
Since the widescreen support,
menus stayed 640 wide and were presented centered,
with the sides either black or a 1px smeared edge column,
and the mouse cursor was confined to that 640-wide band.

This makes menus use the whole display.

## What changed

- **Full-width present.**
  We now compose the presented frame ourselves (`composePresentFrame`):
  the drawn content is centered,
  the side gaps are filled,
  and the cursor is drawn at its true screen position,
  then the full-width frame is presented 1:1.
  So the cursor roams the whole display,
  not just the centered band.

- **Themed side bars, per menu.**
  The side gaps are precomputed from each menu's own background
  (`buildSideGaps`):
  its edge columns are extended outward
  and blurred toward the screen edge.
  It only rebuilds when the background actually changes,
  so there is no per-frame work,
  and no live overlay (FPS, cursor, widgets) can leak into the sides.
  A game just keeps the last menu's bars
  (only network play is centered in-game).

- **Full-width status overlay.**
  The task-status bar and the FPS counter are drawn in screen space,
  over the whole width,
  by a main-thread overlay hook.
  It uses a separate font copy (`cOverlayFont`),
  so it never shares blit state with the gameloop's `cFont`
  (`CFont` is not thread-safe).

- **Theme switch.**
  The back and present buffers are reset on video reset,
  so a theme-switch restart starts from a clean frame,
  and `ShutdownCursors` drops the dangling current-cursor pointer.

## Testing

- Headless test suite passes (`./tests/headless/run.sh`).
- Menu visuals checked offscreen at forced widescreen widths;
  theme switch, per-menu side bars, cursor roaming,
  and the full-width status bar checked in the running app.

A small offscreen menu-render harness was used to verify the visuals;
it will follow as a separate PR (it is orthogonal dev tooling).
