### PR TITLE
Bound Teeworlds header counts, add a load test, drop debug dumps

### DIFF
--- a/src/common/MapLoader_Teeworlds.cpp
+++ b/src/common/MapLoader_Teeworlds.cpp
@@ -761,8 +761,6 @@ struct ML_Teeworlds : MapLoad {
 				}
 				x += tiles[c].skip;
 			}
-
-		SaveSurface(img.image, "tiletex-" + itoa(group) + "-" + itoa(layer) + ".png", FMT_PNG, "");
 	}
 
 	void renderQuads(int group, int layer, TWLayer& l, int RenderFlags) {
@@ -776,9 +774,8 @@ struct ML_Teeworlds : MapLoad {
 			debugPrint(l);
 			return;
 		}
-		TWImage& img = images[l.quadLayer.image_id];
-
-		SaveSurface(img.image, "quads-" + itoa(group) + "-" + itoa(layer) + ".png", FMT_PNG, "");
+		// Quad layers are only background images;
+		// the loader draws them via createParalax, so there is nothing to render here.
 	}
 
 	void renderMap(int renderType, const SmartPointer<SDL_Surface>& surf) {

--- a/src/common/MapLoader_Teeworlds.cpp
+++ b/src/common/MapLoader_Teeworlds.cpp
@@ -385,6 +385,33 @@ struct ML_Teeworlds : MapLoad {
 				teeHeader.m_NumRawData * 4; // uncompressed sizes
 	}
 
+	// The item/data counts and sizes come straight from the file header.
+	// A malicious map can declare huge counts to force an enormous resize
+	// (a bad_alloc, which terminates the process),
+	// so require the whole declared structure to fit within the actual file.
+	// Every term is non-negative, so this also bounds each count on its own.
+	Result validateHeaderSizes() {
+		if(teeHeader.m_NumItemTypes < 0 || teeHeader.m_NumItems < 0
+		   || teeHeader.m_NumRawData < 0
+		   || teeHeader.m_ItemSize < 0 || teeHeader.m_DataSize < 0)
+			return "Teeworlds header has a negative count or size";
+		if(fseek(fp, 0, SEEK_END) != 0)
+			return "Teeworlds header: cannot seek to end of file";
+		int64_t fileSize = ftell(fp);
+		if(fseek(fp, 36, SEEK_SET) != 0) // back to just after the 36-byte header
+			return "Teeworlds header: seek failed";
+		int64_t declared =
+				36 // CDatafileHeader
+				+ (int64_t)teeHeader.m_NumItemTypes * 12 // CDatafileItemType
+				+ (int64_t)teeHeader.m_NumItems * 4 // item offsets
+				+ (int64_t)teeHeader.m_NumRawData * 8 // data offsets + uncompressed sizes
+				+ (int64_t)teeHeader.m_ItemSize // item data
+				+ (int64_t)teeHeader.m_DataSize; // raw data
+		if(fileSize < 0 || declared > fileSize)
+			return "Teeworlds header declares more data than the file contains";
+		return true;
+	}
+
 	CDatafileItemType* getItemType(ItemType type) {
 		foreach(t, itemTypes) {
 			if(t->m_Type == type)
@@ -1005,20 +1032,16 @@ struct ML_Teeworlds : MapLoad {
 		m->Type = MPT_IMAGE;
 		m->m_config = LevelConfig();
 
-		if(teeHeader.m_NumItemTypes < 0)
-			return "invalid numItemTypes";
+		if(NegResult r = validateHeaderSizes()) return r.res;
+
 		itemTypes.resize(teeHeader.m_NumItemTypes);
 		for(int i = 0; i < teeHeader.m_NumItemTypes; ++i)
 			itemTypes[i].read(fp);
 
-		if(teeHeader.m_NumItems < 0)
-			return "invalid numItems";
 		itemOffsets.resize(teeHeader.m_NumItems);
 		for(int i = 0; i < teeHeader.m_NumItems; ++i)
 			itemOffsets[i].read(fp);
 
-		if(teeHeader.m_NumRawData < 0)
-			return "invalid numRawData";
 		dataOffsets.resize(teeHeader.m_NumRawData);
 		for(int i = 0; i < teeHeader.m_NumRawData; ++i)
 			dataOffsets[i].read(fp);

--- a/tests/headless/test_teeworlds_map.py
+++ b/tests/headless/test_teeworlds_map.py
@@ -1,0 +1,20 @@
+"""A shipped Teeworlds (.map) level loads and a round starts on it.
+
+Regression guard for the Teeworlds map-loader bounds checks
+(the header/offset validation around #1050 / #1051):
+a real, valid Teeworlds map must still load, not be rejected.
+"""
+
+
+def test_teeworlds_map_loads_and_starts(network_game):
+    server = network_game.start_server(
+        OLX_MAP="ctf1.map",      # a small shipped Teeworlds map
+        OLX_GAMETYPE="Death Match",
+        OLX_BOTS=2,              # enough to start a round, which forces the load
+        OLX_RUN_SECONDS=30,
+    )
+    assert server.wait_for("SERVER_PLAYING", timeout=60), (
+        "server did not start a round on the Teeworlds map:\n" + server.read_log()
+    )
+    log = server.read_log()
+    assert "could not load level" not in log.lower(), log


### PR DESCRIPTION
Fixes #1050.

Follow-up to #1022.
That PR bounded the per-item offset arithmetic in the Teeworlds loader
but left the header counts themselves unbounded, which is the same DoS class.

A Teeworlds `.map` header declares `m_NumItemTypes`, `m_NumItems`, `m_NumRawData`
and the sizes `m_ItemSize` / `m_DataSize`.
`parseData` only checked the counts for a negative value before `resize`,
so a tiny crafted file could declare billions of items,
the `resize` would throw `bad_alloc`,
and with no `try`/`catch` around map loading the client terminates.

`validateHeaderSizes()` now rejects any negative count or size
and requires the whole declared structure to fit within the actual file:

```cpp
int64_t declared =
        36                                       // CDatafileHeader
        + (int64_t)m_NumItemTypes * 12           // CDatafileItemType
        + (int64_t)m_NumItems * 4                // item offsets
        + (int64_t)m_NumRawData * 8              // data offsets + uncompressed sizes
        + (int64_t)m_ItemSize                    // item data
        + (int64_t)m_DataSize;                   // raw data
if(fileSize < 0 || declared > fileSize)
        return "...";
```

Because every term is non-negative,
this bounds each count on its own, proportional to the bytes the attacker transferred,
without a magic constant, and it cannot reject a valid map
(a real file always contains at least what it declares).

### Positive load test, and a debug-dump cleanup

A second commit adds a headless test
(`tests/headless/test_teeworlds_map.py`)
that hosts a dedicated server on a shipped Teeworlds map (`ctf1.map`)
and starts a round,
so a real, valid Teeworlds map is exercised end to end.
This is the regression guard that the new bounds do not reject a valid map.

Writing it surfaced that the loader dumped a debug PNG
(`tiletex-*.png` / `quads-*.png`) into the current directory on every map load,
from leftover `SaveSurface` calls in `renderTilemap` / `renderQuads`.
That same commit removes them.

### Verification

Builds clean (clang).
The full headless suite passes (12 tests), including the new one.
There is no fails-before-fix test for the bound itself:
a crafted malicious `.map` fixture plus a `MapLoad` harness
is more than the unit-test target can set up cheaply,
so the negative case is covered by code reasoning,
and the positive case (a valid map still loads) by the headless test above.
