### PR TITLE
Fix double keypress for wasm keyboard controls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ IF(OLX_TESTS)
 		${OLXROOTDIR}/tests/unit/test_Version.cpp
 		${OLXROOTDIR}/tests/unit/test_loopback.cpp
 		${OLXROOTDIR}/tests/unit/test_challenge_table.cpp
+		${OLXROOTDIR}/tests/unit/test_CInput.cpp
 		${ALL_SRCS} ${OLX_WIN_RESOURCES})
 	SET_TARGET_PROPERTIES(olx_tests PROPERTIES
 		RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"

--- a/src/client/CInput.cpp
+++ b/src/client/CInput.cpp
@@ -1028,18 +1028,16 @@ void CInput::handleKeyEvent(const KeyboardEvent& ev) {
 // Update down-once state for non-keyboard bindings (polled each frame)
 void CInput::updateDownOnceForNonKeyboard() {
 	for(std::vector<Binding>::iterator b = m_bindings.begin(); b != m_bindings.end(); ++b) {
-#ifdef __EMSCRIPTEN__
-		// On wasm keyboard bindings are also polled each frame via
-		// Binding::isDown (see the SDL_GetKeyboardState branch there), so
-		// they ride the same edge-derivation logic the gamepad uses. This
-		// is what makes held keys register the same frame the simulation
-		// runs, without the OLX mainQueue round-trip.
-		if(!b->isUsed())
-			continue;
-#else
+		// Skip keyboard bindings, on wasm too.
+		// Their edge state (nDownOnce/nUp/bDown) is derived from the key
+		// event queue in handleKeyEvent, which runs on all platforms.
+		// Re-deriving it here from the polled state double-counts every press:
+		// the wasUp() branch below fires again on release, so e.g. the rope
+		// would shoot once on key-down and once on key-up (#972).
+		// The wasm held-key latency shortcut lives in Binding::isDown, which
+		// still polls the keyboard directly; only the edges are event-driven.
 		if(!b->isUsed() || b->isKeyboard())
 			continue;
-#endif
 
 		// HINT: It is possible that wasUp() and !Down (a case which is not covered in further code)
 		if(b->wasUp() && !b->bDown) {
@@ -1079,15 +1077,9 @@ void CInput::updateDownOnceForNonKeyboard() {
 // Update up state for non-keyboard bindings (polled each frame)
 void CInput::updateUpForNonKeyboard() {
 	for(std::vector<Binding>::iterator b = m_bindings.begin(); b != m_bindings.end(); ++b) {
-#ifdef __EMSCRIPTEN__
-		// See updateDownOnceForNonKeyboard: keyboard bindings are polled
-		// each frame on wasm, so don't skip them here.
-		if(!b->isUsed())
-			continue;
-#else
+		// Skip keyboard bindings, on wasm too; see updateDownOnceForNonKeyboard.
 		if(!b->isUsed() || b->isKeyboard())
 			continue;
-#endif
 		if(b->isDown() && !b->bDown)
 			b->nUp++;
 	}

--- a/tests/unit/test_CInput.cpp
+++ b/tests/unit/test_CInput.cpp
@@ -1,0 +1,53 @@
+/*
+ *  Unit tests for the CInput control-mapping edge handling (CInput.h).
+ */
+
+#include "unittest.h"
+#include "CInput.h"
+#include "InputEvents.h"
+
+#include <SDL.h>
+
+namespace {
+
+// One tick of the input pipeline, in the order ProcessEvents runs it:
+// key events first,
+// then the per-frame poll for non-keyboard bindings,
+// then the game reads the control and resets it.
+void inputTick(CInput& inp, const KeyboardEvent* ev) {
+	if(ev) inp.handleKeyEvent(*ev);
+	inp.updateUpForNonKeyboard();
+	inp.updateDownOnceForNonKeyboard();
+}
+
+}
+
+// A keyboard control fires isDownOnce() exactly once per physical press:
+// on the key-down frame, and never again on key-up.
+// Regression test for #972 ("double key presses, one on key-up and one on key-down"):
+// on the wasm port the per-frame poll re-derived a down-once edge
+// for keyboard bindings on release,
+// so a rope-key tap shot the rope twice.
+void test_KeyboardDownOnceFiresOncePerPress() {
+	CInput inp;
+	inp.Setup("x");
+	CHECK(inp.isKeyboard());
+
+	KeyboardEvent down; down.sym = SDLK_x; down.down = true;
+	KeyboardEvent up;   up.sym   = SDLK_x; up.down   = false;
+
+	// Frame with the key going down: fires.
+	inputTick(inp, &down);
+	CHECK(inp.isDownOnce());
+	inp.reset();
+
+	// Frame with the key held (no new event): must not fire again.
+	inputTick(inp, NULL);
+	CHECK(!inp.isDownOnce());
+	inp.reset();
+
+	// Frame with the key going up: must not fire.
+	inputTick(inp, &up);
+	CHECK(!inp.isDownOnce());
+	inp.reset();
+}

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -27,6 +27,7 @@ void test_ChallengeIssueThenConsume();
 void test_ChallengeSurvivesStaleConnect();
 void test_ChallengeReissueIsIdempotent();
 void test_ChallengeConsumeRepeated();
+void test_KeyboardDownOnceFiresOncePerPress();
 
 int main() {
 	printf("Running OLX unit tests...\n");
@@ -40,6 +41,7 @@ int main() {
 	test_ChallengeSurvivesStaleConnect();
 	test_ChallengeReissueIsIdempotent();
 	test_ChallengeConsumeRepeated();
+	test_KeyboardDownOnceFiresOncePerPress();
 
 	if(g_olxTestFailures) {
 		printf("FAILED: %d check(s)\n", g_olxTestFailures);


### PR DESCRIPTION
Fixes #972.

## Symptom

On the web (wasm) build, keyboard controls fire twice per press:
once on key-down and once on key-up.
Most visibly, tapping the rope key spawns the rope twice.
Text fields are unaffected,
because they read the character (TEXTINPUT) path, not control edges.

## Cause

The wasm port polls keyboard bindings each frame in
`updateDownOnceForNonKeyboard` / `updateUpForNonKeyboard`
(the native build skips keyboard bindings there),
in addition to the event-driven `handleKeyEvent`.

So a keyboard binding gets its down-once edge from two sources:

- `handleKeyEvent` sets `nDownOnce` on key-down (correct), and
- the poll's `if(b->wasUp() && !b->bDown) nDownOnce++` fires again on key-up.

That second, phantom edge is the duplicate,
so a control read via `isDownOnce()` (rope, jump, fire, weapon-switch)
triggers a second time on release.

## Fix

Skip keyboard bindings in both poll functions on all platforms,
as the native build already does.
Keyboard edge state now comes solely from `handleKeyEvent`,
which runs on wasm too.
The wasm held-key latency shortcut stays in `Binding::isDown`
(the `SDL_GetKeyboardState` poll is untouched),
so movement responsiveness is unchanged;
only the edge derivation is event-driven.
This also unifies the wasm and native code paths.

## Test

Adds `tests/unit/test_CInput.cpp`,
which drives a full down/hold/up cycle through the input pipeline
and asserts `isDownOnce()` fires exactly once per press.
It fails when the keyboard-skip is removed (the old wasm behaviour)
and passes with the fix.

## Verification

- `olx_tests`: all pass, including the new test.
- `./tests/headless/run.sh`: all 10 pass.
- Manual wasm run of the Introduction game:
  with instrumentation, one rope press produced two `Shoot()` calls before
  and exactly one after; held-key movement still works.
