### PR TITLE
Bound gusanos effect-map sizes against overflow

### DIFF
--- a/src/gusanos/part_type.cpp
+++ b/src/gusanos/part_type.cpp
@@ -178,10 +178,19 @@ PartType::~PartType()
 void PartType::touch()
 {
 #ifndef DEDICATED_ONLY
+	// distort_size and light_size come from the mod,
+	// which is downloaded from the server and thus untrusted.
+	// Their products (width*height*4 and width*2) are computed in int
+	// and overflow for huge or negative values,
+	// which would under-size the buffers the loops below write into.
+	// Reject implausible sizes.
+	const int MaxGenSize = 4096;
 	if(!distortion && !distortionGen.empty())
 	{
 		LuaReference f = distortionGen.get();
-		if(f.isSet(luaIngame))
+		if(f.isSet(luaIngame)
+		   && distortionSize.x >= 0 && distortionSize.x <= MaxGenSize
+		   && distortionSize.y >= 0 && distortionSize.y <= MaxGenSize)
 		{
 			DistortionMap* d = new DistortionMap;
 			int width = distortionSize.x;
@@ -214,12 +223,15 @@ void PartType::touch()
 	if(!lightHax && !lightGen.empty())
 	{
 		LuaReference f = lightGen.get();
-		if(f.isSet(luaIngame))
+		if(f.isSet(luaIngame)
+		   && lightSize.x >= 0 && lightSize.x <= MaxGenSize
+		   && lightSize.y >= 0 && lightSize.y <= MaxGenSize)
 		{
 			int width = lightSize.x;
 			int height = lightSize.y;
 			
 			ALLEGRO_BITMAP* l = create_bitmap_ex(8, width*2, height*2);
+			if(!l) return; // allocation failed; this is the last effect, so just bail
 			
 			int hwidth = width / 2;
 			int hheight = height / 2;


### PR DESCRIPTION
Fixes #1053.

`PartType::touch()` generates a distortion or light effect
whose buffer is sized from the mod's `distort_size` / `light_size` properties.
A gusanos mod is downloaded from the server, so those values are attacker-controlled.

The distortion path did:

```cpp
int width = distortionSize.x, height = distortionSize.y;
d->map.resize(width * height * 4);      // int multiply
for(int y = 0; y < height*2; ++y)
for(int x = 0; x < width*2;  ++x)
    d->map[y * width*2 + x] = ...;      // writes (width*2)*(height*2)
```

`width * height * 4` is an `int` multiply.
A large value overflows to a small or negative number,
so `resize` allocated fewer elements than the loop then wrote:
a heap out-of-bounds write.
The `light_size` path had the same overflow in `create_bitmap_ex(8, width*2, height*2)`
and never checked the result before writing pixels.

The generator only runs when the mod also binds `distort_gen` / `light_gen`
to a lua function, so it is gated behind the mod shipping lua,
hence medium rather than high severity.

### Fix

- Extend the existing `f.isSet(luaIngame)` guards to also require
  `0 <= size <= 4096` on both axes,
  so an out-of-range size skips the (optional) effect instead of overflowing.
- NULL-check `create_bitmap_ex` before writing through it.

### Verification

Builds clean (clang).
No fails-before-fix unit test:
`touch()` needs a live lua state and a loaded `PartType`,
which the unit-test target cannot construct cheaply,
so this is verified by code reasoning and the build.
