### PR TITLE
Reject path traversal in HTTP file downloads

### DIFF
--- a/src/common/FileDownload.cpp
+++ b/src/common/FileDownload.cpp
@@ -64,6 +64,18 @@ void CHttpDownloader::Start(const std::string& filename, const std::string& dest
 		return;
 	}
 
+	// filename can come straight from the server
+	// (e.g. the mod path from ParseUpdateLobbyGame)
+	// and is used below to build the local destination path.
+	// Reject anything that could escape the download directory
+	// (".." , absolute paths, and so on),
+	// the same validation the UDP downloader already applies.
+	if (!CUdpFileDownloader::isPathValid(filename))  {
+		Unlock();
+		SetDlError(FILEDL_ERROR_NO_FILE);
+		return;
+	}
+
 	if (dest_dir.size() == 0)  {
 		Unlock();
 		SetDlError(FILEDL_ERROR_NO_DEST);


### PR DESCRIPTION
Fixes #1055.

`CHttpDownloader::Start` built the local destination path
by concatenating the download directory with a filename,
and opened it for writing, with no path validation:

```cpp
sFileName = filename;
sDestPath = dest_dir + "/" + filename;
tFile = OpenGameFile(sDestPath, "wb");
```

That filename can come straight from the server.
`ParseUpdateLobbyGame` (`CClient_Parse.cpp:1744`) reads the mod path raw
(`modInfo.path = bs->readString();`),
`Menu_Net_Join.cpp:863` passes it to `CClient::DownloadMod`,
and that calls `StartFileDownload(name + ".zip", "./")`.
`OpenGameFile` keeps `..` components literal and lets the OS resolve them,
so a mod path like `../../../foo` writes `./../../../foo.zip`,
escaping the working directory (an arbitrary-write primitive,
gated on the user clicking "Download Mod").

The fix validates the filename in `Start` with the existing
`CUdpFileDownloader::isPathValid`,
which the UDP downloader already applies to every path it handles.
It rejects `..`, absolute paths, `cfg/`, reserved names and the like,
while still allowing ordinary map/mod names (its symbol set includes
spaces, dots and dashes),
so a traversal path is rejected before any file is opened,
and every caller of the HTTP downloader is protected at the sink.

### Verification

Builds clean (clang).
No fails-before-fix unit test:
exercising `Start` needs the download-manager and networking state stood up,
which the unit-test target cannot do cheaply,
so this is verified by code reasoning and the build.
`isPathValid` itself is unchanged and already in use.
