### PR TITLE
Limit recursion depth in the gusanos script parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ IF(OLX_TESTS)
 		${OLXROOTDIR}/tests/unit/test_loopback.cpp
 		${OLXROOTDIR}/tests/unit/test_challenge_table.cpp
 		${OLXROOTDIR}/tests/unit/test_CInput.cpp
+		${OLXROOTDIR}/tests/unit/test_omfgscript_parser.cpp
 		${ALL_SRCS} ${OLX_WIN_RESOURCES})
 	SET_TARGET_PROPERTIES(olx_tests PROPERTIES
 		RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"

--- a/src/gusanos/omfgscript/omfg_script.cpp
+++ b/src/gusanos/omfgscript/omfg_script.cpp
@@ -838,7 +838,17 @@ TokenBase* Parser::getProperty(std::string const& a, std::string const& b)
 
 bool Parser::run()
 {
-	pimpl->rule_lines();
+	// The parser is recursive-descent over untrusted input.
+	// A depth guard in the rules aborts a too-deeply-nested script
+	// via fatalError, which throws ParsingAborted.
+	// Catch it here so a malformed or malicious script fails to load
+	// instead of propagating out as an uncaught exception.
+	try {
+		pimpl->rule_lines();
+	}
+	catch(ParserImpl::ParsingAborted&) {
+		return false;
+	}
 	return pimpl->full();
 }
 

--- a/src/gusanos/omfgscript/omfg_script_parser.h
+++ b/src/gusanos/omfgscript/omfg_script_parser.h
@@ -888,6 +888,18 @@ begin = buffer;
 limit = buffer + newSize;
 }
 struct ParsingAborted : public std::exception { };
+enum { MaxParseDepth = 128 };
+// The expression and property rules below are recursive-descent
+// and recurse on nesting characters ('(', '[', '{')
+// that an untrusted script fully controls.
+// DepthGuard bounds that recursion,
+// so a deeply nested script aborts the parse
+// instead of overflowing the stack.
+struct DepthGuard {
+	TGrammar* g;
+	DepthGuard(TGrammar* g_) : g(g_) { ++g->depth; }
+	~DepthGuard() { --g->depth; }
+};
 void fatalError(std::string const& msg = "Syntax error") {
 self->reportError(msg, self->getLoc());
 throw ParsingAborted();
@@ -1037,6 +1049,8 @@ rule_term(b);
 }
 }
 void rule_leaf(TokenBase::ptr& a) {
+DepthGuard depthGuard(this);
+if(depth > MaxParseDepth) { fatalError("expression nested too deeply"); return; }
 if(cur == 1) {
 next();
  a.reset(new INTEGER(*self, 1)); 
@@ -1135,7 +1149,9 @@ rule_parameter(params);
 }
 }
 void rule_prop(std::string const& prefix = "") {
- TokenBase::ptr v; 
+DepthGuard depthGuard(this);
+if(depth > MaxParseDepth) { fatalError("property blocks nested too deeply"); return; }
+ TokenBase::ptr v;
 Location propLoc(self->getLoc());
 if(!matchToken(16)) return;
 std::unique_ptr<STRING> name(static_cast<STRING*>(curData.release()));
@@ -1182,7 +1198,7 @@ rule_leaf(b);
 bool set_1[26];
 bool set_3[26];
 bool set_17[26];
-TGrammar() : cur(-1), curp(0), limit(0), marker(0), begin(0), buffer(0), line(1), state(0), syncTokens(false), error(false) {
+TGrammar() : cur(-1), curp(0), limit(0), marker(0), begin(0), buffer(0), line(1), state(0), syncTokens(false), error(false), depth(0) {
 memset(set_1, 0, sizeof(bool)*26);
 set_1[1] = true;
 set_1[2] = true;
@@ -1209,6 +1225,7 @@ int line;
 int state;
 bool syncTokens;
 bool error;
+int depth;
 #undef self
 };
 }

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -28,6 +28,9 @@ void test_ChallengeSurvivesStaleConnect();
 void test_ChallengeReissueIsIdempotent();
 void test_ChallengeConsumeRepeated();
 void test_KeyboardDownOnceFiresOncePerPress();
+void test_OmfgScriptDeepExpression();
+void test_OmfgScriptDeepPropertyBlocks();
+void test_OmfgScriptShallowOk();
 
 int main() {
 	printf("Running OLX unit tests...\n");
@@ -42,6 +45,9 @@ int main() {
 	test_ChallengeReissueIsIdempotent();
 	test_ChallengeConsumeRepeated();
 	test_KeyboardDownOnceFiresOncePerPress();
+	test_OmfgScriptDeepExpression();
+	test_OmfgScriptDeepPropertyBlocks();
+	test_OmfgScriptShallowOk();
 
 	if(g_olxTestFailures) {
 		printf("FAILED: %d check(s)\n", g_olxTestFailures);

--- a/tests/unit/test_omfgscript_parser.cpp
+++ b/tests/unit/test_omfgscript_parser.cpp
@@ -1,0 +1,48 @@
+/*
+ *  Unit tests for the gusanos omfgscript parser (omfg_script.h).
+ *  A gusanos mod is downloaded from the server and is thus untrusted,
+ *  so a pathologically nested script must abort the parse
+ *  rather than overflow the stack.
+ */
+
+#include "unittest.h"
+#include "gusanos/omfgscript/omfg_script.h"
+
+#include <sstream>
+#include <string>
+
+using namespace OmfgScript;
+
+// A deeply nested expression must abort the parse, not crash.
+// Before the recursion-depth guard each '(' recursed one level,
+// and enough of them overflowed the stack (SIGSEGV);
+// now the guard aborts via fatalError and run() returns false.
+void test_OmfgScriptDeepExpression() {
+	std::string src = "foo = ";
+	src += std::string(100000, '(');   // 100k unclosed parens
+	ActionFactory af;
+	std::istringstream ss(src);
+	Parser parser(ss, af, "test_deep_expr");
+	CHECK(!parser.run());              // returns (no crash) and fails to parse
+}
+
+// The same for deeply nested property blocks (rule_prop recurses on '{').
+void test_OmfgScriptDeepPropertyBlocks() {
+	std::string src;
+	for(int i = 0; i < 100000; ++i)
+		src += "a{";                   // a{a{a{...
+	ActionFactory af;
+	std::istringstream ss(src);
+	Parser parser(ss, af, "test_deep_props");
+	CHECK(!parser.run());
+}
+
+// A normal, shallow script still parses successfully:
+// the depth guard must not reject legitimate input.
+void test_OmfgScriptShallowOk() {
+	std::string src = "foo = (1 + 2) * 3\n";
+	ActionFactory af;
+	std::istringstream ss(src);
+	Parser parser(ss, af, "test_shallow");
+	CHECK(parser.run());
+}


### PR DESCRIPTION
Fixes #1057.

The gusanos omfgscript parser is recursive-descent and had no depth limit.
The expression and property rules recurse on nesting characters
that an untrusted file fully controls:

- `rule_prop` recurses on `{` (nested property blocks).
- `rule_expr` -> `rule_term` -> `rule_leaf` -> `rule_expr` recurses on `(` and `[`,
  and `rule_leaf` recurses on `(` for function arguments.

Every gusanos type loader
(`PartType::load`, `WeaponType::load`, `ExpType::load`, `LevelEffect::load`, `config.cfg`)
runs this parser on a mod downloaded from the server,
so a `.obj` / `.wpn` / `config.cfg` with deeply nested brackets
(for example `foo = ((((...`)
overflowed the stack and crashed the client.
A stack overflow cannot be caught by any surrounding handler.

### Fix

- A `DepthGuard` (RAII) increments a depth counter on entry to
  `rule_leaf` and `rule_prop` -- every deep recursion passes through one of them --
  and aborts via `fatalError` past `MaxParseDepth` (128).
- `Parser::run` now catches the resulting `ParsingAborted`,
  so an over-deep (or otherwise malformed) script fails to load
  instead of propagating an uncaught exception.

The guard lives in the checked-in generated header
(`omfg_script_parser.h`, generated from `.pg` by a 2006 tool the build does not run),
which is the artifact actually compiled.

### Verification

Added `tests/unit/test_omfgscript_parser.cpp` to the `olx_tests` target.
It parses 100k-deep `(` and `{` input,
plus a normal shallow script.
Confirmed fails-before-fix:
with the two source files reverted, the deep-input test segfaults (`exit 139`);
with the fix the suite returns `exit 0`,
the guard fires,
and the shallow script still parses.
Full build is clean (clang).
