### PR TITLE
Reject out-of-range gusanos number literals

### DIFF
--- a/src/gusanos/omfgscript/omfg_script_parser.h
+++ b/src/gusanos/omfgscript/omfg_script_parser.h
@@ -84,7 +84,13 @@ struct INTEGER : public Token {
 typedef std::unique_ptr<INTEGER> ptr;
 #define CONSTRUCT(b_, e_) INTEGER(T& g, char const* b_, char const* e_)
 
-	CONSTRUCT(b, e) : Token(g) { v = lexical_cast<int>(std::string(b, e)); }
+	// The literal comes from an untrusted mod. lexical_cast throws
+	// bad_lexical_cast when the value does not fit; degrade to a reported
+	// error and 0 rather than let the exception escape and crash the client.
+	CONSTRUCT(b, e) : Token(g), v(0) {
+		try { v = lexical_cast<int>(std::string(b, e)); }
+		catch(boost::bad_lexical_cast&) { g.semanticError("integer literal out of range"); }
+	}
 	
 	INTEGER(T& g, int i) : Token(g), v(i) {}
 	
@@ -114,7 +120,10 @@ struct NUMBER : public Token {
 typedef std::unique_ptr<NUMBER> ptr;
 #define CONSTRUCT(b_, e_) NUMBER(T& g, char const* b_, char const* e_)
 
-	CONSTRUCT(b, e) : Token(g) { v = lexical_cast<double>(std::string(b, e)); }
+	CONSTRUCT(b, e) : Token(g), v(0) {
+		try { v = lexical_cast<double>(std::string(b, e)); }
+		catch(boost::bad_lexical_cast&) { g.semanticError("number literal out of range"); }
+	}
 	
 	virtual double toDouble()
 	{ return v; }

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -31,6 +31,8 @@ void test_KeyboardDownOnceFiresOncePerPress();
 void test_OmfgScriptDeepExpression();
 void test_OmfgScriptDeepPropertyBlocks();
 void test_OmfgScriptShallowOk();
+void test_OmfgScriptHugeIntegerLiteral();
+void test_OmfgScriptHugeNumberFirstToken();
 
 int main() {
 	printf("Running OLX unit tests...\n");
@@ -48,6 +50,8 @@ int main() {
 	test_OmfgScriptDeepExpression();
 	test_OmfgScriptDeepPropertyBlocks();
 	test_OmfgScriptShallowOk();
+	test_OmfgScriptHugeIntegerLiteral();
+	test_OmfgScriptHugeNumberFirstToken();
 
 	if(g_olxTestFailures) {
 		printf("FAILED: %d check(s)\n", g_olxTestFailures);

--- a/tests/unit/test_omfgscript_parser.cpp
+++ b/tests/unit/test_omfgscript_parser.cpp
@@ -46,3 +46,28 @@ void test_OmfgScriptShallowOk() {
 	Parser parser(ss, af, "test_shallow");
 	CHECK(parser.run());
 }
+
+// An out-of-range integer literal in a mod must not crash the parser.
+// lexical_cast<int> throws bad_lexical_cast, which used to escape uncaught
+// out of run(); now it degrades to a semantic error, so run() just returns.
+// (Reaching the end of the test without aborting is the assertion.)
+void test_OmfgScriptHugeIntegerLiteral() {
+	std::string src = "foo = 99999999999\n";
+	ActionFactory af;
+	std::istringstream ss(src);
+	Parser parser(ss, af, "test_huge_int");
+	parser.run();
+	CHECK(true);
+}
+
+// The same throw can happen while the parser constructor reads the first token,
+// before run() is ever called.
+// A file that starts with an out-of-range number must not crash during construction.
+void test_OmfgScriptHugeNumberFirstToken() {
+	std::string src = "999999999999999999999999999999\n";
+	ActionFactory af;
+	std::istringstream ss(src);
+	Parser parser(ss, af, "test_huge_first");
+	parser.run();
+	CHECK(true);
+}


### PR DESCRIPTION
Fixes #1059.

Follow-up to #1058.
The omfgscript `INTEGER` / `NUMBER` token constructors
convert a literal with `boost::lexical_cast`,
which throws `boost::bad_lexical_cast` when the value does not fit the target type:

```cpp
CONSTRUCT(b, e) : Token(g) { v = lexical_cast<int>(std::string(b, e)); }
```

A gusanos mod is downloaded from the server (untrusted),
so a literal such as `ammo = 99999999999` threw an exception that nothing caught,
and the client aborted with `terminate ... bad_lexical_cast`.

`#1058` added a `catch(ParsingAborted)` in `Parser::run()`,
but that does not catch `bad_lexical_cast`,
and the throw can happen in the `ParserImpl` constructor's first `next()`
(when the file starts with a number), before `run()` is even called.
So the exception escapes uncaught.

The fix catches `bad_lexical_cast` at the throw site (the two constructors),
turning a bad literal into a reported `semanticError` and a `0` value
instead of an uncaught exception. `boost::lexical_cast` is exception-based
with no non-throwing variant in this boost version,
so a targeted catch at the point of use is the natural fix.

### Verification

Extended `tests/unit/test_omfgscript_parser.cpp` with two regression tests:
a huge integer inside a property (`foo = 99999999999`, throws during `run()`),
and a file that starts with an out-of-range number (throws during construction).
Confirmed fails-before-fix: reverting just the header aborts the suite
(`exit 134`, `terminate ... bad_lexical_cast`);
with the fix the suite returns `exit 0` and the guard reports the bad literals.
Full build is clean (clang).
