### PR TITLE
Validate weapon index in ParseSpawnBonus

### DIFF
--- a/src/client/CClient_Parse.cpp
+++ b/src/client/CClient_Parse.cpp
@@ -1499,6 +1499,14 @@ void CClientNetEngine::ParseSpawnBonus(CBytestream *bs)
 		return;
 	}
 
+	// wpn comes from the untrusted server
+	// and is used below as an offset into the weapon array in CBonus::Spawn.
+	// Bound it, like the server already does.
+	if (type == BNS_WEAPON && (wpn < 0 || wpn >= game.gameScript()->GetNumWeapons()))  {
+		warnings << "CClientNetEngine::ParseSpawnBonus: invalid weapon index (" << wpn << ")" << endl;
+		return;
+	}
+
 	CVec p = CVec( (float)x, (float)y );
 
 	client->cBonuses[id].Spawn(p, type, wpn, game.gameScript());


### PR DESCRIPTION
Validate weapon index in ParseSpawnBonus

ParseSpawnBonus reads the weapon index from an S2C_SPAWNBONUS packet
(from the untrusted server)
and passed it to CBonus::Spawn,
which uses it as an offset into the weapon array (GetWeapons()+weapon),
with no bounds check.
type, id, x and y were all validated; wpn was not,
so a server could make the client read out of bounds.

Reject the packet when the index is outside [0, GetNumWeapons()),
the same check the server already applies.

Fixes #1061.
