### PR TITLE
Bound the gusanos lua round() format buffer

### DIFF
--- a/src/gusanos/lua/bindings-math.cpp
+++ b/src/gusanos/lua/bindings-math.cpp
@@ -63,9 +63,14 @@ int l_floor(lua_State* L)
 
 int l_round(lua_State* L)
 {
+	// d is the precision, taken from an untrusted mod.
+	// Clamp it, and use snprintf,
+	// so neither a huge precision nor a huge value can overflow the buffer.
 	int d = lua_tointeger(L, 2);
-	char buffer[256];
-	sprintf(buffer, "%.*f", d, lua_tonumber(L, 1));
+	if(d < 0) d = 0;
+	else if(d > 99) d = 99;
+	char buffer[512];
+	snprintf(buffer, sizeof(buffer), "%.*f", d, lua_tonumber(L, 1));
 	lua_pushstring(L, buffer);
 	return 1;
 }


### PR DESCRIPTION
Bound the gusanos lua round() format buffer

l_round formatted a number into a 256-byte stack buffer with sprintf
and a precision taken straight from the mod.
round(x, 5000) wrote far past the buffer,
and even precision 0 overflows for a large magnitude.
A gusanos mod is downloaded from the server, so this is attacker-controlled.

Clamp the precision and use snprintf,
so neither a huge precision nor a huge value can overflow.

Fixes #1063.
