### PR TITLE
Require worm ownership in ParseGrabBonus

### DIFF
--- a/src/server/CServer_Parse.cpp
+++ b/src/server/CServer_Parse.cpp
@@ -842,6 +842,12 @@ void CServerNetEngine::ParseGrabBonus(CBytestream *bs) {
 		return;
 	}
 
+	// A client may only grab bonuses for a worm it owns,
+	// like the other worm-addressed C2S handlers.
+	if( !cl->OwnsWorm(wormid) && !cl->isLocalClient() ) {
+		notes << "GameServer::ParseGrabBonus: worm " << wormid << " not owned by client." << endl;
+		return;
+	}
 
 	// Worm ID ok?
 	CWorm *w = game.wormById(wormid, false);


### PR DESCRIPTION
Require worm ownership in ParseGrabBonus

ParseGrabBonus took a worm id from the client
and changed that worm's weapon and consumed the bonus,
without checking that the client owns the worm.
Every other worm-addressed C2S handler checks cl->OwnsWorm
(ParseImReady, ParseDeathPacket, the damage handler),
so a client could grab bonuses as another player
and force-change that player's weapon.

Reject the packet unless the client owns the worm (or is the local client),
matching the sibling handlers.

Fixes #1065.
