### PR TITLE
Wrap projectile old Y by map height, not width

### DIFF
--- a/src/common/PhysicsLX56_Projectiles.cpp
+++ b/src/common/PhysicsLX56_Projectiles.cpp
@@ -147,7 +147,7 @@ INLINE ProjCollisionType FinalWormCollisionCheck(CProjectile* proj, const CVec& 
 					FMOD(proj->vPos.write().x, (float)map->GetWidth());
 					FMOD(proj->vPos.write().y, (float)map->GetHeight());
 					FMOD(proj->vOldPos.x, (float)map->GetWidth());
-					FMOD(proj->vOldPos.y, (float)map->GetWidth());		
+					FMOD(proj->vOldPos.y, (float)map->GetHeight());
 				}
 				
 				return ProjCollisionType::Worm(ret);


### PR DESCRIPTION
Wrap projectile old Y by map height, not width

On an infinite map, FinalWormCollisionCheck wrapped the projectile's
old Y position modulo the map width instead of its height:

	FMOD(proj->vOldPos.y, (float)map->GetWidth());

The parallel block just below wraps it by GetHeight(),
so this was a copy-paste of the .x line.
On a non-square infinite map it corrupts the checkstep-distance comparison
and the collision resolution when a projectile hits a worm.

Fixes #1067.
