### PR TITLE
Forward the forworm argument in Beta3 SendHideWorm

### DIFF
--- a/src/server/CServer_Send.cpp
+++ b/src/server/CServer_Send.cpp
@@ -303,7 +303,7 @@ void CServerNetEngineBeta3::SendText(const std::string& text, int type)
 
 void CServerNetEngineBeta3::SendHideWorm(CWorm *worm, int forworm, bool show, bool immediate)
 {
-	CServerNetEngine::SendHideWorm(worm, show, immediate);  // Just the same as for old LX
+	CServerNetEngine::SendHideWorm(worm, forworm, show, immediate);  // Just the same as for old LX
 }
 
 void CServerNetEngineBeta8::SendText(const std::string& text, int type)


### PR DESCRIPTION
Forward the forworm argument in Beta3 SendHideWorm

CServerNetEngineBeta3::SendHideWorm forwarded to the base method
but dropped the forworm argument:

	CServerNetEngine::SendHideWorm(worm, show, immediate);

so the base received forworm = show, show = immediate, immediate = false.
The base filters on forworm and picks hide-vs-spawn from show,
so per-viewer hide/show was broken for Beta3..Beta8 clients
(the mechanism behind Hide-and-Seek visibility).

Forward all four arguments.

Fixes #1069.
