### PR TITLE
Stop double-counting free space in the AI path-width test

### DIFF
--- a/src/common/CWormBot.cpp
+++ b/src/common/CWormBot.cpp
@@ -475,7 +475,7 @@ public:
 					if(trace) left++;
 				}
 				pt = start - dir; trace = true;
-				for(right = 0; trace && right < (wormsize-left); right++, pt -= dir) {
+				for(right = 0; trace && right < (wormsize-left); pt -= dir) {
 					trace = simpleTraceLine(pt, dist, PX_ROCK);
 					if(trace) right++;
 				}


### PR DESCRIPTION
Stop double-counting free space in the AI path-width test

check_checkpoint::operator() incremented the right-side counter twice
per free line: once in the loop header (right++) and once in the body.
The symmetric left loop increments only in the body,
so right over-counted by 2x
and the space test (left + right >= wormsize) passed
with only about half the free width actually verified.

Bots then added path nodes through gaps narrower than a worm,
routing worms into openings they cannot fit through.

Drop the right++ from the loop header,
so right counts like left.

Fixes #1071.
