### PR TITLE
Pass weapon by const ref in Explosion/InjureWorm

### DIFF
--- a/include/CClient.h
+++ b/include/CClient.h
@@ -426,8 +426,8 @@ public:
 
 	void		SpawnProjectile(CVec pos, CVec vel, int rot, int owner, proj_t *_proj, int _random, AbsTime time, AbsTime ignoreWormCollBeforeTime);
     void        disableProjectile(CProjectile *prj);
-	void		Explosion(AbsTime time, CVec pos, float damage, int shake, int owner, std::string weapon = "");
-	void		InjureWorm(CWorm *w, float damage, int owner, std::string weapon = "");
+	void		Explosion(AbsTime time, CVec pos, float damage, int shake, int owner, const std::string& weapon = "");
+	void		InjureWorm(CWorm *w, float damage, int owner, const std::string& weapon = "");
 	void		LaserSight(CWorm *w, float Angle, bool highlightCrosshair = true);
 
 	void		processChatter();

--- a/src/client/CClient_Game.cpp
+++ b/src/client/CClient_Game.cpp
@@ -224,7 +224,7 @@ simulateStart:
 
 ///////////////////
 // Explosion
-void CClient::Explosion(AbsTime time, CVec pos, float damage, int shake, int owner, std::string weapon)
+void CClient::Explosion(AbsTime time, CVec pos, float damage, int shake, int owner, const std::string& weapon)
 {	
 	bool    gotDirt = false;
 	Color	DirtEntityColour;
@@ -332,7 +332,7 @@ void CClient::Explosion(AbsTime time, CVec pos, float damage, int shake, int own
 
 ///////////////////
 // Injure a worm
-void CClient::InjureWorm(CWorm *w, float damage, int owner, std::string weapon)
+void CClient::InjureWorm(CWorm *w, float damage, int owner, const std::string& weapon)
 {
 	if (!w->getAlive())  // Injuring a dead worm makes no sense
 		return;


### PR DESCRIPTION
Pass weapon by const ref in Explosion/InjureWorm

Explosion and InjureWorm took the weapon name by value.
Explosion copies it on entry,
then calls InjureWorm for each worm in the blast,
copying it again per injured worm.
Explosions fire per exploding projectile,
so rapid or explosive weapons caused many std::string heap copies per frame.

Take the weapon name by const reference in both.
