### PR TITLE
Avoid per-checkstep worm-iterator allocation

### DIFF
--- a/src/common/PhysicsLX56_Projectiles.cpp
+++ b/src/common/PhysicsLX56_Projectiles.cpp
@@ -39,6 +39,7 @@
 #include "WeaponDesc.h"
 #include "sound/SoundsBase.h"
 #include "game/Game.h"
+#include "util/macros.h"
 
 #ifdef __MINGW32_VERSION
 // TODO: ugly hack, fix it - mingw stdlib seems to be broken
@@ -66,9 +67,13 @@ INLINE int CProjectile::ProjWormColl(CVec pos)
 	bool preventSelfShooting =
 		(this->getIgnoreWormCollBeforeTime() > this->fLastSimulationTime); // if the simulation is too early, ignore this worm col
 
-	for_each_iterator(CWorm*, w_, game.aliveWorms()) {
-		CWorm* w = w_->get();
-		
+	// Iterate the worm map directly rather than game.aliveWorms(),
+	// which heap-allocates a filter iterator on every call
+	// (this runs per checkstep of every projectile).
+	foreach(w_, game.wormMap()) {
+		CWorm* w = w_->second;
+		if(!w->getAlive()) continue;
+
 		if(preventSelfShooting && w == ownerWorm)
 			continue;
 
@@ -664,21 +669,25 @@ static VectorD2<float> objectAngleDiff(CGameObject* w, CGameObject* prj) {
 
 static CWorm* nearestWorm(CVec pos) {
 	CWorm* best = NULL;
-	for_each_iterator(CWorm*, w, game.aliveWorms()) {
-		if(best == NULL) { best = w->get(); continue; }
-		if((best->getPos() - pos).GetLength2() > (w->get()->getPos() - pos).GetLength2())
-			best = w->get();
+	foreach(it, game.wormMap()) {
+		CWorm* w = it->second;
+		if(!w->getAlive()) continue;
+		if(best == NULL) { best = w; continue; }
+		if((best->getPos() - pos).GetLength2() > (w->getPos() - pos).GetLength2())
+			best = w;
 	}
 	return best;
 }
 
 static CWorm* nearestOtherWorm(CVec pos, int worm) {
 	CWorm* best = NULL;
-	for_each_iterator(CWorm*, w, game.aliveWorms()) {
-		if(w->get()->getID() == worm) continue;
-		if(best == NULL) { best = w->get(); continue; }
-		if((best->getPos() - pos).GetLength2() > (w->get()->getPos() - pos).GetLength2())
-			best = w->get();
+	foreach(it, game.wormMap()) {
+		CWorm* w = it->second;
+		if(!w->getAlive()) continue;
+		if(w->getID() == worm) continue;
+		if(best == NULL) { best = w; continue; }
+		if((best->getPos() - pos).GetLength2() > (w->getPos() - pos).GetLength2())
+			best = w;
 	}
 	return best;
 }
@@ -686,12 +695,14 @@ static CWorm* nearestOtherWorm(CVec pos, int worm) {
 static CWorm* nearestEnemyWorm(CVec pos, int worm) {
 	const int team = game.ifWorm<int>(worm, &CWorm::getTeam, -1);
 	CWorm* best = NULL;
-	for_each_iterator(CWorm*, w, game.aliveWorms()) {
-		if(w->get()->getID() == worm) continue;
-		if(cClient->isTeamGame() && team == w->get()->getTeam()) continue;
-		if(best == NULL) { best = w->get(); continue; }
-		if((best->getPos() - pos).GetLength2() > (w->get()->getPos() - pos).GetLength2())
-			best = w->get();
+	foreach(it, game.wormMap()) {
+		CWorm* w = it->second;
+		if(!w->getAlive()) continue;
+		if(w->getID() == worm) continue;
+		if(cClient->isTeamGame() && team == w->getTeam()) continue;
+		if(best == NULL) { best = w; continue; }
+		if((best->getPos() - pos).GetLength2() > (w->getPos() - pos).GetLength2())
+			best = w;
 	}
 	return best;
 }
@@ -700,12 +711,14 @@ static CWorm* nearestTeamMate(CVec pos, int worm) {
 	if(!cClient->isTeamGame()) return NULL;
 	const int team = game.ifWorm<int>(worm, &CWorm::getTeam, -1);
 	CWorm* best = NULL;
-	for_each_iterator(CWorm*, w, game.aliveWorms()) {
-		if(w->get()->getID() == worm) continue;
-		if(team != w->get()->getTeam()) continue;
-		if(best == NULL) { best = w->get(); continue; }
-		if((best->getPos() - pos).GetLength2() > (w->get()->getPos() - pos).GetLength2())
-			best = w->get();
+	foreach(it, game.wormMap()) {
+		CWorm* w = it->second;
+		if(!w->getAlive()) continue;
+		if(w->getID() == worm) continue;
+		if(team != w->getTeam()) continue;
+		if(best == NULL) { best = w; continue; }
+		if((best->getPos() - pos).GetLength2() > (w->getPos() - pos).GetLength2())
+			best = w;
 	}
 	return best;
 }

--- a/src/game/Game.h
+++ b/src/game/Game.h
@@ -150,6 +150,7 @@ public:
 	Iterator<CWorm*>::Ref localWorms();
 	Iterator<CWorm*>::Ref aliveWorms();
 	Iterator<CWorm*>::Ref wormsOfClient(const CServerConnection* cl);
+	const std::map<int,CWorm*>& wormMap() const { return m_worms; }
 	CWorm* wormById(int wormId, bool assertExisting = true);
 	CWorm* firstLocalHumanWorm();
 	CWorm* findWormByName(const std::string& name);


### PR DESCRIPTION
Avoid per-checkstep worm-iterator allocation

ProjWormColl iterated worms via game.aliveWorms(),
which heap-allocates a filter-iterator chain
and dispatches through a virtual iterator and a boost::function predicate,
on every call.
It runs once per 2-pixel checkstep of every projectile's path,
so at thousands of projectiles times 84 Hz
it was on the order of half a million allocations per second.

Add a read-only Game::wormMap() accessor
and iterate the worm map directly, with the getAlive() filter inline.
Same worms in the same order,
no allocation and no virtual or boost::function dispatch.
The four guided-projectile nearestWorm helpers had the same pattern; fixed too.

Behaviour is unchanged: the iteration order and filter are identical.
Verified with the headless gameplay test --
bots still fight, deal damage and sync to a client.
