### PR TITLE
Fix new[] leaks on map-loader error paths

### DIFF
--- a/src/common/MapLoader_LieroX.cpp
+++ b/src/common/MapLoader_LieroX.cpp
@@ -20,6 +20,7 @@
 #include "PixelFunctors.h"
 #include "Cache.h"
 #include <zlib.h>
+#include <vector>
 #ifndef DEDICATED_ONLY
 #include <gd.h>
 #endif
@@ -73,24 +74,17 @@ class ML_LieroX : public MapLoad {
 		EndianSwap(destsize);
 		
 		// Allocate the memory
-		uint8_t *pSource = new uint8_t[size];
-		uint8_t *pDest = new uint8_t[destsize];
-		
-		if(!pSource || !pDest) {
-			errors << "CMap::LoadImageFormat: not enough memory" << endl;
-			return false;
-		}
-		
-		if(fread(pSource, sizeof(uint8_t), size, fp) < size) {
+		std::vector<uint8_t> pSource(size);
+		std::vector<uint8_t> pDest(destsize);
+
+		if(fread(pSource.data(), sizeof(uint8_t), size, fp) < size) {
 			errors << "CMap::LoadImageFormat: cannot read data" << endl;
 			return false;
 		}
-		
+
 		ulong lng_dsize = destsize;
-		if( uncompress( pDest, &lng_dsize, pSource, size ) != Z_OK ) {
+		if( uncompress( pDest.data(), &lng_dsize, pSource.data(), size ) != Z_OK ) {
 			errors("Failed decompression\n");
-			delete[] pSource;
-			delete[] pDest;
 			return false;
 		}
 		destsize = (uint32_t) lng_dsize; // can only get smaller
@@ -101,12 +95,8 @@ class ML_LieroX : public MapLoad {
 		if( destsize < Uint64(head.width) * Uint64(head.height) * 7 )
 		{
 			errors("CMap::LoadImageFormat(): image too small for Width*Height");
-			delete[] pSource;
-			delete[] pDest;
 			return false;
 		}
-		
-		delete[] pSource;  // not needed anymore
 		
 		//
 		// Translate the data
@@ -173,9 +163,6 @@ class ML_LieroX : public MapLoad {
 		//SDL_SaveBMP(pxf, "mat.bmp");
 		//SDL_SaveBMP(m->bmpImage.get(), GetWriteFullFileName("debug-front.bmp",true).c_str());
 		//SDL_SaveBMP(m->bmpBackImage.get(), GetWriteFullFileName("debug-back.bmp",true).c_str());
-		
-		// Delete the data
-		delete[] pDest;
 		
 		// Try to load additional data (like hi-res images)
 		LoadAdditionalLevelData(m);

--- a/src/common/MapLoader_OrigLiero.cpp
+++ b/src/common/MapLoader_OrigLiero.cpp
@@ -17,6 +17,7 @@
 #include "Color.h"
 #include "FileUtils.h"
 #include "PixelFunctors.h"
+#include <vector>
 
 class ML_OrigLiero : public MapLoad {
 public:
@@ -63,40 +64,26 @@ public:
 		// Image type of map
 		m->Type = MPT_IMAGE;
 		
-		uchar *palette = new uchar[768];
-		if( palette == NULL) {
-			errors << "CMap::LoadOriginal: ERROR: not enough memory for palette" << endl;
-			return false;
-		}
-		
+		std::vector<uchar> palette(768);
+
 		// Load the palette
 		if(!Powerlevel) {
 			FILE *fpal = OpenGameFile("data/lieropal.act","rb");
 			if(!fpal) {
 				return false;
 			}
-			
-			if(fread(palette,sizeof(uchar),768,fpal) < 768) {
+
+			if(fread(&palette[0],sizeof(uchar),768,fpal) < 768) {
+				fclose(fpal);
 				return false;
 			}
 			fclose(fpal);
 		}
-		
+
 		// Load the image map
-	imageMapCreate:
-		uchar *bytearr = new uchar[Width*Height];
-		if(bytearr == NULL) {
-			errors << "CMap::LoadOriginal: ERROR: not enough memory for bytearr" << endl;
-			if(cCache.GetEntryCount() > 0) {
-				hints << "current cache size is " << cCache.GetCacheSize() << ", we are clearing it now" << endl;
-				cCache.Clear();
-				goto imageMapCreate;
-			}
-			delete[] palette;
-			return false;
-		}
-		
-		if(fread(bytearr,sizeof(uchar),Width*Height,fp) < Width*Height) {
+		std::vector<uchar> bytearr(Width*Height);
+
+		if(fread(&bytearr[0],sizeof(uchar),Width*Height,fp) < Width*Height) {
 			errors << "CMap::LoadOriginal: cannot read file" << endl;
 			return false;
 		}
@@ -107,13 +94,11 @@ public:
 			// Load id
 			fread_fixedwidthstr<10>(id,fp);
 			if(!stringcaseequal(id,"POWERLEVEL")) {
-				delete[] palette;
-				delete[] bytearr;
 				return false;
 			}
-			
+
 			// Load the palette
-			if(fread(palette,sizeof(uchar),768,fp) < 768) {
+			if(fread(&palette[0],sizeof(uchar),768,fp) < 768) {
 				return false;
 			}
 			
@@ -164,9 +149,6 @@ public:
 		m->unlockFlags();
 		UnlockSurface(m->bmpDrawImage);
 		UnlockSurface(m->bmpBackImageHiRes);
-		
-		delete[] palette;
-		delete[] bytearr;
 		
 		m->lxflagsToGusflags();
 		return true;


### PR DESCRIPTION
Fix new[] leaks on map-loader error paths

MapLoader_OrigLiero and the LieroX LoadImageFormat allocated buffers
with new[] and leaked them on several error returns:
- OrigLiero leaked palette (and the fpal FILE handle) and bytearr
  when a read or the POWERLEVEL check failed.
- LoadImageFormat leaked pSource and pDest on the read-fail path,
  and pDest again if the surface lock (LOCK_OR_FAIL) bailed.
They also had dead NULL checks after new
(new throws, so it never returns NULL),
and OrigLiero had an unreachable cache-clear-and-retry hanging off that check.

Use std::vector for these buffers,
so every early return frees them automatically,
and drop the dead NULL checks (and close fpal on the read-fail path).
The LieroX sizes come from the file and can be 0,
so those buffers are addressed with data() rather than &v[0].

Verified with the headless physics and smoke tests:
a real LieroX map still loads and the worm physics is unchanged.
