### PR TITLE
Trigger web-demo update after publishing release

### DIFF
--- a/.github/workflows/master-release.yaml
+++ b/.github/workflows/master-release.yaml
@@ -176,3 +176,28 @@ jobs:
             sleep "$delay"
             attempt=$((attempt + 1))
           done
+
+  # Once the release (with the -wasm.zip asset) is published, tell the website
+  # repo to refresh its playable web demo. That repo's update-wasm.yml listens
+  # for a repository_dispatch of type "update-wasm"; it pulls the just-published
+  # release, drops the new binaries into web-demo/, and its push redeploys the
+  # GitHub Pages site. This must run after "release" (not from package-wasm.yml)
+  # because the website fetches the published release, not the raw build artifact.
+  notify-website:
+    name: Trigger web-demo update
+    needs: [release]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Dispatch update-wasm to the website repo
+        env:
+          # GITHUB_TOKEN can't reach another repo, so this needs a token with
+          # write access to openlierox/openlierox.github.io (a fine-grained PAT
+          # with Contents: write, or a classic token with the "repo" scope),
+          # stored as the WEBSITE_DISPATCH_TOKEN secret in this repo.
+          GH_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/openlierox/openlierox.github.io/dispatches \
+            -f event_type=update-wasm


### PR DESCRIPTION
## What

After the latest-master release is published, notify the website repo
(`openlierox/openlierox.github.io`) to refresh its playable WebAssembly demo.

A new `notify-website` job (`needs: [release]`) sends a `repository_dispatch`
of type `update-wasm` to the site repo. That repo's `update-wasm.yml` already
listens for exactly that event: it downloads the just-published release's
`*-wasm.zip`, drops the new binaries into `web-demo/`, and redeploys the
GitHub Pages site.

## Why here, and not in package-wasm.yml

The website consumes the **published GitHub release** asset, not the raw build
artifact, so the trigger has to run after the `release` job. It also can't live
in `package-wasm.yml`, which runs on pull requests too — we don't want PR builds
poking the live site.

## Required secret

Cross-repo dispatch can't use the default `GITHUB_TOKEN`. This job reads a
`WEBSITE_DISPATCH_TOKEN` secret: a token with `Contents: write` on
`openlierox/openlierox.github.io` (a fine-grained PAT scoped to that one repo,
or a classic token with the `repo` scope). The secret is already configured in
this repo. If it is ever missing, `notify-website` fails but the release itself
still succeeds, and the website's daily cron still catches up.
