### PR TITLE
Fix linenoise refreshLine hang on zero columns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ IF(OLX_TESTS)
 		${OLXROOTDIR}/tests/unit/test_challenge_table.cpp
 		${OLXROOTDIR}/tests/unit/test_CInput.cpp
 		${OLXROOTDIR}/tests/unit/test_omfgscript_parser.cpp
+		${OLXROOTDIR}/tests/unit/test_linenoise.cpp
 		${ALL_SRCS} ${OLX_WIN_RESOURCES})
 	SET_TARGET_PROPERTIES(olx_tests PROPERTIES
 		RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"

--- a/libs/linenoise/linenoise.cpp
+++ b/libs/linenoise/linenoise.cpp
@@ -191,7 +191,10 @@ static void linenoiseAtExit(void) {
 static int getColumns() {
     struct winsize ws;
 
-	if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == -1) return 80;
+	// A pty with no window size set reports ws_col == 0.
+	// refreshLine() below divides the line against cols and would spin forever
+	// on a zero (or absurdly small) width, so fall back to a sane default.
+	if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == -1 || ws.ws_col == 0) return 80;
     return ws.ws_col;
 }
 
@@ -201,12 +204,14 @@ void LinenoiseEnv::refreshLine() {
 
     char seq[64];
     
-	while(prompt.size() + pos >= cols) {
+	// pos and len are unsigned; guard against underflow so a small cols
+	// cannot turn these into endless loops.
+	while(pos > 0 && prompt.size() + pos >= cols) {
 		cbuf++;
         len--;
         pos--;
     }
-	while(prompt.size() + len > cols) {
+	while(len > 0 && prompt.size() + len > cols) {
         len--;
     }
 

--- a/tests/unit/test_linenoise.cpp
+++ b/tests/unit/test_linenoise.cpp
@@ -1,0 +1,31 @@
+/*
+ *  Unit test for the linenoise line editor.
+ */
+
+#include "unittest.h"
+
+#ifdef HAVE_LINENOISE
+#include "linenoise.h"
+
+// refreshLine() used to spin forever when the terminal reported 0 columns
+// (a pty with no window size set):
+// prompt.size() + pos >= 0 is always true for the unsigned pos,
+// so pos and len underflowed instead of the loop ending,
+// and a dedicated server with the stdin CLI could hang at startup.
+// It must now terminate for any cols value.
+void test_LinenoiseRefreshLineZeroCols() {
+	LinenoiseEnv env;
+	env.fd = -1;               // send its writes nowhere
+	env.cols = 0;              // a pty with no window size
+	env.prompt = "OLX> ";
+	env.buf = "abcdefghij";
+	env.pos = env.buf.size();
+	env.refreshLine();         // before the fix: an infinite loop
+	CHECK(true);               // reaching here means it terminated
+}
+
+#else
+
+void test_LinenoiseRefreshLineZeroCols() { CHECK(true); }
+
+#endif

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -33,6 +33,7 @@ void test_OmfgScriptDeepPropertyBlocks();
 void test_OmfgScriptShallowOk();
 void test_OmfgScriptHugeIntegerLiteral();
 void test_OmfgScriptHugeNumberFirstToken();
+void test_LinenoiseRefreshLineZeroCols();
 
 int main() {
 	printf("Running OLX unit tests...\n");
@@ -52,6 +53,7 @@ int main() {
 	test_OmfgScriptShallowOk();
 	test_OmfgScriptHugeIntegerLiteral();
 	test_OmfgScriptHugeNumberFirstToken();
+	test_LinenoiseRefreshLineZeroCols();
 
 	if(g_olxTestFailures) {
 		printf("FAILED: %d check(s)\n", g_olxTestFailures);


### PR DESCRIPTION
Fix linenoise refreshLine hang on zero columns

A dedicated server with the interactive stdin CLI occasionally hung at startup
(about 1 in 20 starts).
refreshLine trims the line against cols with unsigned pos/len:

	while(prompt.size() + pos >= cols) { cbuf++; len--; pos--; }

cols comes from getColumns(), which returns ws.ws_col,
and a pty with no window size set reports ws_col == 0.
With cols == 0 the condition is always true and pos/len underflow,
so the loop never ends.
It is intermittent because refreshLine runs on the main thread only when
a startup log message is printed while the stdin thread owns the line editor,
and only when getColumns happened to return 0.
Confirmed by lldb: the main thread was stuck in refreshLine holding the stdout mutex,
the stdin thread waiting on it.

getColumns now returns 80 when ws_col is 0
(a 0-column terminal is nonsensical),
and the loops are guarded against underflow,
so refreshLine terminates for any cols value.

Added a unit test that calls refreshLine with cols = 0:
it hangs without the fix and returns with it.

Fixes #1080.
