### PR TITLE
Avoid undefined bit-shifts in BitStream

### DIFF
--- a/src/gusanos/encoding.h
+++ b/src/gusanos/encoding.h
@@ -99,7 +99,10 @@ INLINE unsigned int decodeEliasGamma(BitStream& stream)
 	
 	// prefix = number of prefixed zeroes
 	
-	return stream.getInt(prefix) | (1 << prefix);
+	// prefix comes from the (untrusted) stream and can exceed 31,
+	// which would make 1 << prefix undefined; a bit that high does not fit
+	// the unsigned-int result anyway, so drop it.
+	return stream.getInt(prefix) | (prefix < 32 ? ((uint32_t)1 << prefix) : 0u);
 }
 
 INLINE void encodeEliasDelta(BitStream& stream, unsigned int n)
@@ -120,7 +123,10 @@ INLINE unsigned int decodeEliasDelta(BitStream& stream)
 		// error - probably end reached
 		return 0;
 	
-	return stream.getInt(prefix) | (1 << prefix);
+	// prefix comes from the (untrusted) stream and can exceed 31,
+	// which would make 1 << prefix undefined; a bit that high does not fit
+	// the unsigned-int result anyway, so drop it.
+	return stream.getInt(prefix) | (prefix < 32 ? ((uint32_t)1 << prefix) : 0u);
 }
 
 struct VectorEncoding

--- a/src/util/Bitstream.cpp
+++ b/src/util/Bitstream.cpp
@@ -59,7 +59,7 @@ void BitStream::addSignedInt(int32_t n, int bits) {
 	if( n >= 0)
 		addInt(n, bits - 1);
 	else
-		addInt((1 << (bits - 1)) - n, bits - 1);
+		addInt(((uint32_t)1 << (bits - 1)) - n, bits - 1);
 }
 
 void BitStream::addFloat(float f, int bits) {
@@ -103,8 +103,14 @@ bool BitStream::getBool() {
 
 uint32_t BitStream::getInt(int bits) {
 	uint32_t ret = 0;
-	for(int i = 0; i < bits; ++i)
-		if(getBool()) ret |= 1 << i;
+	for(int i = 0; i < bits; ++i) {
+		bool b = getBool();
+		// Bits beyond 32 cannot fit the result; still consume them from the
+		// stream, but keep the shift below the width to avoid the undefined
+		// behaviour of shifting a 32-bit value by >= 32 (bits is caller- or,
+		// via elias-gamma, stream-controlled).
+		if(b && i < 32) ret |= (uint32_t)1 << i;
+	}
 	return ret;
 }
 
@@ -114,7 +120,7 @@ int32_t BitStream::getSignedInt(int bits) {
 	if( !sign /*n >= 0*/ )
 		return getInt(bits - 1);
 	else
-		return (1 << (bits - 1)) - getInt(bits - 1);
+		return ((uint32_t)1 << (bits - 1)) - getInt(bits - 1);
 }
 
 float BitStream::getFloat(int bits) {
@@ -165,7 +171,7 @@ bool BitStream::testInt()
 {
 	reset();
 	for (int i = 0; i < 32; i++)
-		addInt(1 << i, i + 1);
+		addInt((uint32_t)1 << i, i + 1);
 	for (int i = 0; i < 32; i++)
 		if (getInt(i + 1) != (uint32_t(1) << i))
 			return false;


### PR DESCRIPTION
Avoid undefined bit-shifts in BitStream

BitStream::getInt did ret |= 1 << i with 1 as int and i up to bits,
and decodeEliasGamma / decodeEliasDelta did 1 << prefix
where prefix comes from the stream.
Both shift a signed int by >= 32 (or into the sign bit at 31),
which is undefined, on attacker-controlled input.

Shift an unsigned 1 and keep the shift count below 32
(a bit that high does not fit the 32-bit result anyway):
getInt still consumes the extra bits from the stream but ignores them,
and the elias-gamma decoders drop an out-of-range top bit.
addSignedInt / getSignedInt and the testInt self-test
get the same unsigned-1 treatment.

Fixes #1083.
