### PR TITLE
Make the download worker stop flag atomic

### DIFF
--- a/include/FileDownload.h
+++ b/include/FileDownload.h
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <atomic>
 #include <stdio.h>  // for FILE
 #include "ThreadPool.h"
 #include <SDL_mutex.h>
@@ -152,7 +153,7 @@ private:
 	size_t						 iActiveDownloads;
 
 	friend Result ManagerMain(void *param);
-	volatile bool				bBreakThread;
+	std::atomic<bool>			bBreakThread;
 
 public:
 	void						ProcessDownloads();


### PR DESCRIPTION
Make the download worker stop flag atomic

CHttpDownloadManager::bBreakThread was volatile bool.
volatile is not a synchronization primitive in C++:
the destructor writes the flag while the worker thread reads it in its loop,
which ThreadSanitizer reports as a data race.
Make it std::atomic<bool>.
The lifetime was already correct (the destructor waits for the worker),
so this only makes the stop signal well-defined.

Fixes #1087.
