### PR TITLE
Make the socket event-handler stop flag atomic

### DIFF
--- a/src/common/Networking.cpp
+++ b/src/common/Networking.cpp
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <atomic>
 
 #include <curl/curl.h>
 
@@ -560,7 +561,7 @@ static void nlPrepareClose(NLsocket socket) {
 struct NetworkSocket::EventHandler {
 	struct SharedData {
 		Mutex mutex;
-		bool quitSignal;
+		std::atomic<bool> quitSignal;
 		NetworkSocket* sock;
 		NLint nlGroup;
 		


### PR DESCRIPTION
Make the socket event-handler stop flag atomic

NetworkSocket::EventHandler::SharedData::quitSignal was a plain bool:
the worker threads read it without the mutex in their poll loop
while quit() writes it under the mutex,
which ThreadSanitizer reports as a data race.
Make it std::atomic<bool>.
SharedData is reference-counted so the workers keep it alive;
this only makes the stop signal well-defined.

Fixes #1088.
