### PR TITLE
Fix screenshot-format combobox alignment

### DIFF
--- a/src/client/DeprecatedGUI/Menu_Options.cpp
+++ b/src/client/DeprecatedGUI/Menu_Options.cpp
@@ -525,7 +525,7 @@ bool Menu_OptionsInitialize()
 
 	// Put the combo box after the other widgets to get around the problem with widget layering
 	cOpt_System.Add( new CCombobox(), os_NetworkSpeed, 170, starty + 155 - 3, 130,17);
-	cOpt_System.Add( new CCombobox(), os_ScreenshotFormat, 365, starty + 250 - 2, 70,17);
+	cOpt_System.Add( new CCombobox(), os_ScreenshotFormat, 365, starty + 225, 70,17);
 	cOpt_System.Add( new CCombobox(), os_ColourDepth, 275, starty + 20, 145, 17);
 
 	// Set the values


### PR DESCRIPTION
## Problem

In Options -> System, the "Screenshot format" combobox sat a few pixels too low,
dropped down onto the "Check for updates" row instead of sitting next to its label.

The label uses the running layout cursor `y`,
which at that row works out to `starty + 225`,
but the combobox was placed with a hardcoded `starty + 250 - 2` (== `starty + 248`),
about 23px lower.

## Fix

Position the combobox at `starty + 225` so its top lines up with its label,
matching how the neighbouring Colour-depth combobox tracks its own label.

## Verification

Rendered the Options -> System menu offscreen before and after the change
(see the offscreen-render tooling PR):

- Before: the "Png" combobox is on the "Check for updates" row.
- After: it aligns with the "Screenshot format" label.
