### PR TITLE
Add offscreen menu-render tooling

### DIFF
--- a/include/DeprecatedGUI/CGuiLayout.h
+++ b/include/DeprecatedGUI/CGuiLayout.h
@@ -116,6 +116,9 @@ public:
 	void		FocusWidget(int id);
 	CWidget		*getWidget(int id);
     void        removeWidget(int id);
+	// Dev hook: write each widget's "id type x y w h" to a file,
+	// so an offscreen render can assert a menu's layout (see tests/headless).
+	void		DumpLayout(const std::string& path);
 	int			GetIdByName(const std::string& Name);
 	void		Error(int ErrorCode, const std::string& text);
 

--- a/include/DeprecatedGUI/Menu.h
+++ b/include/DeprecatedGUI/Menu.h
@@ -390,6 +390,10 @@ void	Menu_MainShutdown();
 void	Menu_MainFrame();
 void	Menu_MainDrawTitle(int x, int y, int id, int selected);
 
+// Open the Options menu straight on the System tab (used as a startFunction),
+// e.g. after a video-mode restart, or from OLX_START_MENU for offscreen renders.
+bool	Menu_StartWithSysOptionsMenu(void* data);
+
 
 // Local menu
 void	Menu_LocalInitialize();

--- a/src/client/AuxLib.cpp
+++ b/src/client/AuxLib.cpp
@@ -465,6 +465,20 @@ bool VideoPostProcessor::initWindow() {
 			warnings << "could not query desktop display mode (" << SDL_GetError()
 				<< "), falling back to " << m_screenWidth << "x" << screenHeight() << endl;
 		}
+
+		// Dev hook: force the screen width
+		// (normally derived from the desktop aspect ratio).
+		// Lets an offscreen render exercise a widescreen layout under the dummy video driver,
+		// which otherwise reports a 4:3 desktop.
+		// See tests/headless/render_offscreen.sh.
+		if(const char* fw = getenv("OLX_FORCE_SCREEN_WIDTH")) {
+			int w = atoi(fw);
+			if(w >= 320) {
+				m_screenWidth = w & ~1;
+				notes << "OLX_FORCE_SCREEN_WIDTH: using " << m_screenWidth
+					<< "x" << screenHeight() << endl;
+			}
+		}
 	}
 
 setvideomode:
@@ -671,6 +685,19 @@ void VideoPostProcessor::process() {
 	SDL_UpdateTexture(get()->m_videoTexture.get(), NULL, pixels, get()->screenWidth() * sizeof (uint32_t));
 
 	get()->updateSideGapTextures();
+
+	// Dev hook: dump the composed frame (the surface a screenshot saves) to a PNG for offscreen menu-render tests.
+	// Enabled by OLX_DUMP_FRAME under SDL_VIDEODRIVER=dummy.
+	// Rewrites every frame past OLX_DUMP_FRAME_AT (default 3):
+	// a settled menu sleeps on events, so the last write is the settled frame.
+	// See tests/headless/render_offscreen.sh.
+	static const char* dumpPath = getenv("OLX_DUMP_FRAME");
+	if(dumpPath) {
+		static int frame = 0;
+		static const int dumpAt = getenv("OLX_DUMP_FRAME_AT") ? atoi(getenv("OLX_DUMP_FRAME_AT")) : 3;
+		if(++frame >= dumpAt && get()->m_videoBufferSurface.get())
+			SaveSurface(get()->m_videoBufferSurface.get(), dumpPath, FMT_PNG, "");
+	}
 }
 
 // Upload the precomputed gap strips to textures when buildSideGaps produced new ones.

--- a/src/client/DeprecatedGUI/CGuiLayout.cpp
+++ b/src/client/DeprecatedGUI/CGuiLayout.cpp
@@ -15,6 +15,7 @@
 
 
 #include <assert.h>
+#include <fstream> // for DumpLayout (dev hook)
 
 
 #include "LieroX.h"
@@ -218,6 +219,24 @@ void CGuiLayout::Draw(SDL_Surface * bmpDest)
 	
 	if(tooltip.get())
 		tooltip->draw(bmpDest);
+}
+
+
+/////////////////
+// Dev hook: write each widget's "id type x y w h" (one per line) to a file,
+// so an offscreen render can assert a menu's layout.
+// See tests/headless/test_menu_layout.py.
+void CGuiLayout::DumpLayout(const std::string& path)
+{
+	std::ofstream f(path.c_str());
+	if(!f) {
+		warnings << "DumpLayout: could not open " << path << endl;
+		return;
+	}
+	for( std::list<CWidget *>::iterator w = cWidgets.begin() ; w != cWidgets.end() ; w++)
+		f << (*w)->getID() << " " << (int)(*w)->getType() << " "
+			<< (*w)->getX() << " " << (*w)->getY() << " "
+			<< (*w)->getWidth() << " " << (*w)->getHeight() << "\n";
 }
 
 

--- a/src/client/DeprecatedGUI/Menu_Options.cpp
+++ b/src/client/DeprecatedGUI/Menu_Options.cpp
@@ -14,6 +14,8 @@
 // Jason Boettcher
 
 
+#include <cstdlib> // for getenv (dev hook)
+
 #include "LieroX.h"
 #include "sound/SoundsBase.h"
 #include "Music.h"
@@ -641,6 +643,10 @@ bool Menu_OptionsInitialize()
 	cOpt_Game.SendMessage( og_BloodAmount,  SLM_SETVALUE, tLXOptions->iBloodAmount, 0);
 	//cOpt_Game.SendMessage( og_AIDifficulty, SLM_SETVALUE, tLXOptions->iAIDifficulty, 0);
 
+	// Dev hook: dump the System-tab layout for an offscreen layout test.
+	// See tests/headless/test_menu_layout.py.
+	if(const char* p = getenv("OLX_DUMP_LAYOUT"))
+		cOpt_System.DumpLayout(p);
 
 	return true;
 }

--- a/src/client/InputEvents.cpp
+++ b/src/client/InputEvents.cpp
@@ -10,6 +10,7 @@
 
 
 #include <set>
+#include <cstdlib> // for getenv/atoi (dev hooks)
 
 #include "Clipboard.h"
 #include "LieroX.h"
@@ -572,7 +573,16 @@ static void HandleMouseState() {
 		// wider screen), shift the mouse into that centered space so clicks line
 		// up with the drawn widgets.
 		Mouse.X -= VideoPostProcessor::get()->displayScreenOffsetX();
-		
+
+		// Dev hook: pin the software cursor to a fixed spot
+		// (e.g. a corner, out of the way of the widgets being captured)
+		// for deterministic offscreen renders.
+		// See tests/headless/render_offscreen.sh.
+		static const char* forceX = getenv("OLX_FORCE_MOUSE_X");
+		static const char* forceY = getenv("OLX_FORCE_MOUSE_Y");
+		if(forceX) Mouse.X = atoi(forceX);
+		if(forceY) Mouse.Y = atoi(forceY);
+
 		Mouse.deltaX = Mouse.X-oldX;
 		Mouse.deltaY = Mouse.Y-oldY;
 		Mouse.Up = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 
 
 #include <cassert>
+#include <cstdlib> // for getenv (dev hooks)
 #include <sstream> // for print_binary_string
 #include <set>
 #include <string>
@@ -359,6 +360,16 @@ startpoint:
 	}
 
 	game.init();
+
+	// Dev hook: jump straight to a submenu on startup,
+	// so an offscreen render (SDL_VIDEODRIVER=dummy) can capture a menu past the main one.
+	// See tests/headless/render_offscreen.sh.
+	if(const char* startMenu = getenv("OLX_START_MENU")) {
+		if(std::string(startMenu) == "options-system")
+			startFunction = &DeprecatedGUI::Menu_StartWithSysOptionsMenu;
+		else if(std::string(startMenu) != "main")
+			warnings << "OLX_START_MENU: unknown menu '" << startMenu << "'" << endl;
+	}
 
 	if(startFunction != NULL) {
 		if(!startFunction(startFunctionData)) {

--- a/tests/headless/render_offscreen.sh
+++ b/tests/headless/render_offscreen.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Render an OpenLieroX menu offscreen (no real display) and dump it to a PNG.
+#
+# The whole menu is drawn into a software surface before it reaches the GPU.
+# So a non-dedicated run under the dummy video driver renders the real menu offscreen,
+# which lets its layout be inspected in CI or over SSH.
+# (The dedicated headless suite, run.sh, has no video at all.)
+#
+# Usage:
+#   ./tests/headless/render_offscreen.sh <out.png> [start_menu] [width] [timeout_s]
+#
+#   out.png     where to copy the rendered frame (relative to $PWD or absolute)
+#   start_menu  which menu to open: "main" (default) or "options-system"
+#   width       force the screen width (default: let the dummy driver pick 640)
+#   timeout_s   how long to let the menu settle before capturing (default 6)
+#
+# The cursor is parked in the top-left corner so it never covers the widgets.
+set -euo pipefail
+
+OUT="${1:?usage: render_offscreen.sh <out.png> [start_menu] [width] [timeout_s]}"
+START_MENU="${2:-main}"
+WIDTH="${3:-}"
+TIMEOUT="${4:-6}"
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BIN="${OLX_BINARY:-$ROOT/build-output/bin/openlierox}"
+# The game finds its data (data/, cfg/, ...) relative to the working directory;
+# share/gamedir is the read-only data root, same as the headless harness uses.
+GAMEDIR="$ROOT/share/gamedir"
+if [ ! -x "$BIN" ]; then
+    echo ">>> openlierox not built yet; building ..."
+    "$ROOT/tests/headless/build.sh"
+fi
+
+# Isolated HOME, so the run can't touch the user's real config.
+# It also fixes where OLX writes:
+# $HOME/Library/Application Support/OpenLieroX (mac), or $HOME/.OpenLieroX (Linux).
+# Both are gitignored under $ROOT.
+RENDER_HOME="$ROOT/.render-home"
+OUT_DIR="$ROOT/.render-out"
+rm -rf "$RENDER_HOME"
+mkdir -p "$RENDER_HOME" "$OUT_DIR"
+
+# OLX writes to its first search path, the home config dir.
+# Under the isolated HOME that lands somewhere below $RENDER_HOME,
+# so the dump can't dirty the repo.
+DUMP_NAME="render_frame.png"
+
+# Absolute output path (the game runs from a different cwd, see below).
+ABS_OUT="$OUT"
+case "$OUT" in
+    /*) : ;;
+    *)  ABS_OUT="$PWD/$OUT" ;;
+esac
+
+echo ">>> rendering '$START_MENU' menu offscreen (timeout ${TIMEOUT}s) ..."
+set +e
+( cd "$GAMEDIR" && exec env \
+    HOME="$RENDER_HOME" \
+    SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy \
+    OLX_START_MENU="$START_MENU" \
+    OLX_DUMP_FRAME="$DUMP_NAME" \
+    OLX_FORCE_MOUSE_X=2 OLX_FORCE_MOUSE_Y=2 \
+    ${WIDTH:+OLX_FORCE_SCREEN_WIDTH=$WIDTH} \
+    "$BIN" ) > "$OUT_DIR/render.log" 2>&1 &
+PID=$!
+sleep "$TIMEOUT"
+kill "$PID" 2>/dev/null
+wait "$PID" 2>/dev/null
+set -e
+
+DUMP_PATH="$(find "$RENDER_HOME" -name "$DUMP_NAME" -print -quit 2>/dev/null)"
+if [ -z "$DUMP_PATH" ] || [ ! -f "$DUMP_PATH" ]; then
+    echo "ERROR: no frame was dumped (searched under $RENDER_HOME)." >&2
+    echo "       See $OUT_DIR/render.log for what the run did." >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$ABS_OUT")"
+cp "$DUMP_PATH" "$ABS_OUT"
+echo ">>> wrote $ABS_OUT"


### PR DESCRIPTION
## What

Tooling to render and inspect a real (non-dedicated) menu with no display,
so a menu's layout can be checked in CI or over SSH,
and regressions like a misplaced widget can be caught.

The whole menu is composed into a software surface before it reaches the GPU,
so the dummy SDL video driver is enough to draw it.
(The existing dedicated headless suite, `run.sh`, has no video at all,
so it can't see menu layout.)

## How

Small dev hooks, each gated on an env var and off by default:

- `OLX_START_MENU=options-system` jumps straight to a submenu on startup,
  reusing the existing `Menu_StartWithSysOptionsMenu` start-function.
- `OLX_DUMP_LAYOUT` writes each widget's `id type x y w h` (layout-local coords)
  for the Options -> System layout, so a test can assert geometry directly
  instead of diffing pixels.
- `OLX_DUMP_FRAME` dumps the composed frame to a PNG every frame past a settle count,
  so the last write is the settled menu.
- `OLX_FORCE_MOUSE_X`/`Y` pin the software cursor out of the way of the captured widgets.
- `OLX_FORCE_SCREEN_WIDTH` overrides the width the dummy driver derives from a 4:3 desktop,
  to exercise the widescreen layout.

`tests/headless/render_offscreen.sh` wires the image path together:
it runs the game under an isolated `HOME`,
waits for the menu to settle,
then copies the dumped frame to a requested path.

```
./tests/headless/render_offscreen.sh out.png options-system 1050
```

The geometry dump is consumed by `tests/headless/test_menu_layout.py` in #1103.

## Notes

No behaviour changes with the hooks unset,
so this is inert in normal play and dedicated runs.
