### PR TITLE
Fix crash on -help and -nettest early exit

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -451,6 +451,14 @@ static void ParseArguments_BeforeInit(int argc, char *argv[]) {
 }
 
 
+// Join the stdin-CLI and tee-stdout worker threads before an early exit():
+// exit() runs their static std::thread destructors,
+// and a still-joinable std::thread terminates the process.
+static void quitConsoleIOThreads() {
+	quitStdinCLISupport();
+	teeStdoutQuit();
+}
+
 static void ParseArguments_AfterInit(int argc, char *argv[])
 {
     // Parameters passed to OpenLieroX overwrite the loaded options
@@ -559,6 +567,7 @@ static void ParseArguments_AfterInit(int argc, char *argv[])
 			InitializeLieroX();
 			TestCChannelRobustness();
 			ShutdownLieroX();
+			quitConsoleIOThreads();
 			exit(0);
 		} else
 #endif
@@ -587,11 +596,13 @@ static void ParseArguments_AfterInit(int argc, char *argv[])
      		printf("   -version      Print the version and quit\n");
      		printf("   -help         Print this help and quit\n");
 
-			// Shutdown and quit
-			// ShutdownLieroX() works only correct when everything was inited because ProcessEvents() is used.
-			// Therefore we just ignore a good clean up and just quit here.
-			// This is not nice but still nicer than getting a segfault.
-			// It is not worth to fix this in a nicer way as it is fixed anyway when we use the new engine system.
+			// We are still before InitializeLieroX(),
+			// so the video, event, menu, sound and game subsystems are not up yet.
+			// ShutdownLieroX() tears those down and assumes they were inited,
+			// so we cannot run it here; just quit.
+			// We do need to join the console I/O threads first, though:
+			// exit() runs their static destructors, and a joinable std::thread aborts.
+			quitConsoleIOThreads();
      		exit(0);
         } else
 

--- a/tests/headless/test_terminal.py
+++ b/tests/headless/test_terminal.py
@@ -89,6 +89,82 @@ def _run_dedicated_on_pty(binary, home, port):
     return bytes(buf)
 
 
+def _run_args_on_pty(binary, home, args, deadline_s=60):
+    """Run the binary with the given args on a pty until it exits.
+
+    A pty makes stdin a terminal,
+    so the interactive stdin CLI (and the threaded tee-stdout path) activate,
+    which is the precondition for the early-exit crash below.
+    Returns ``(status, output)``:
+    the raw ``os.waitpid`` status and the raw terminal bytes collected.
+    """
+    env = dict(os.environ)
+    env["HOME"] = home
+    env["TERM"] = "xterm"  # so linenoise treats it as a supported terminal
+
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.chdir(GAMEDIR)
+        os.environ.clear()
+        os.environ.update(env)
+        os.execv(binary, [binary] + list(args))
+        os._exit(127)
+
+    buf = bytearray()
+    deadline = time.time() + deadline_s
+    got_eof = False
+    while time.time() < deadline:
+        r, _, _ = select.select([fd], [], [], 0.5)
+        if r:
+            try:
+                data = os.read(fd, 4096)
+            except OSError:
+                got_eof = True
+                break
+            if not data:
+                got_eof = True
+                break
+            buf += data
+
+    if not got_eof:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except OSError:
+            pass
+    _, status = os.waitpid(pid, 0)
+    return status, bytes(buf)
+
+
+def test_help_exits_cleanly(tmp_path):
+    """``-help`` prints its usage and exits cleanly, even with the stdin CLI active.
+
+    Regression test for the -help crash:
+    -help calls exit(0) directly,
+    which runs the static destructors of the stdin-CLI and tee-stdout worker threads.
+    On a real terminal those threads are up and joinable,
+    and destroying a joinable std::thread calls std::terminate() -> abort().
+    The early-exit path must join them first.
+    """
+    binary = find_binary()
+    if binary is None:
+        pytest.fail("openlierox binary not found; build it first or set OLX_BINARY",
+                    pytrace=False)
+
+    status, raw = _run_args_on_pty(binary, str(tmp_path), ["-help"])
+
+    assert b"available parameters" in raw, (
+        "-help did not print its usage banner:\n" + repr(raw[-400:])
+    )
+    assert not os.WIFSIGNALED(status), (
+        "-help crashed instead of exiting cleanly (killed by signal %d):\n"
+        % os.WTERMSIG(status) + repr(raw[-400:])
+    )
+    assert os.WEXITSTATUS(status) == 0, (
+        "-help exited with non-zero status %d:\n" % os.WEXITSTATUS(status)
+        + repr(raw[-400:])
+    )
+
+
 def test_shutdown_messages_not_staircased(tmp_path):
     """The final shutdown message prints at column 0, not staircased.
 


### PR DESCRIPTION
## Problem

`olx -help` (also `-h`, `--help`, `/?`) printed its usage and then crashed with `abort()`
instead of exiting cleanly:

```
7   openlierox   TeeStdoutInfo::~TeeStdoutInfo()  (TeeStdoutHandler.cpp:112)
9   libsystem_c  __cxa_finalize_ranges
10  libsystem_c  exit
11  openlierox   ParseArguments_AfterInit  (main.cpp:577)
```

## Cause

The `-help` handler (and, in DEBUG builds, `-nettest`) calls `exit(0)` directly.
By then `real_main` has started two worker threads:
the stdin CLI and the tee-stdout handler.
`exit()` runs the static destructors of those `std::thread` owners,
and destroying a still-joinable `std::thread` calls `std::terminate()`.

The normal shutdown path avoids this by joining both threads first
(`quitStdinCLISupport()` / `teeStdoutQuit()`);
the early-exit path skipped that.

## Fix

Join both threads via a small `quitConsoleIOThreads()` helper before the early `exit(0)`.

`ShutdownLieroX()` is not usable at this point:
it runs before `InitializeLieroX()`,
so the subsystems it tears down are not up yet.
The stale comment that suggested a full shutdown was the goal is rewritten to say so.

## Test

Adds a headless regression test that runs `-help` on a pty
(so the stdin CLI and tee threads are active, the crash precondition)
and asserts a clean exit.
Verified it fails without the fix (aborts, exit 255) and passes with it.

Fixes #1095
