### PR TITLE
Count reclaimable RAM in macOS GetFreeSysMemory

### DIFF
--- a/src/common/SystemFunctions.cpp
+++ b/src/common/SystemFunctions.cpp
@@ -188,7 +188,14 @@ size_t GetFreeSysMemory() {
 	count = HOST_VM_INFO_COUNT;
 
 	host_statistics (mach_host_self(), HOST_VM_INFO,(host_info_t)&page_info, &count);
-	return page_info.free_count * pagesize;
+	// macOS keeps most RAM occupied by reclaimable caches,
+	// so free_count alone is always tiny and misleading.
+	// Count the inactive and purgeable pages too,
+	// matching the free+cache semantics of the Linux path below.
+	// (speculative pages are already part of free_count, so don't add them.)
+	return ((size_t)page_info.free_count
+			+ (size_t)page_info.inactive_count
+			+ (size_t)page_info.purgeable_count) * pagesize;
 #elif defined(__WIN64__)
 	MEMORYSTATUSEX memStatex;
 	memStatex.dwLength = sizeof (memStatex);


### PR DESCRIPTION
## Problem

At startup OLX prints a line like `Free memory: 88 MB` on a 16 GB Mac.
The macOS `GetFreeSysMemory()` returned only `free_count`,
i.e. the pages that are *truly, immediately* free.

macOS deliberately keeps almost all RAM occupied by reclaimable caches
and inactive pages, so `free_count` is always tiny and misleading.
`vm_stat` on the same machine confirms it: a few thousand free pages
next to gigabytes of reclaimable inactive pages.

This feeds the cache sizing in `Cache.cpp` and the startup notes,
so both saw far less memory than is actually available.

## Fix

Add the inactive and purgeable pages to the result,
so macOS matches the `MemFree + Buffers + Cached` semantics
the Linux path in the same function already uses.

Speculative pages are already part of `free_count`
(per the `mach/vm_statistics.h` header note),
so they are deliberately left out to avoid double counting.

## Verification

Built on macOS (arm64) and ran the dedicated binary:
the startup line now reads `Free memory: 3845 MB` instead of `88 MB`,
consistent with free + inactive + purgeable pages reported by `vm_stat`.
