### PR TITLE
Don't list hidden dirs like .git as mods

### DIFF
--- a/src/common/CGameScript.cpp
+++ b/src/common/CGameScript.cpp
@@ -536,7 +536,11 @@ static bool checkLXSourceMod(const std::string& dir, bool abs_filename, ModInfo&
 
 static bool checkGusMod(const std::string& dir, bool abs_filename, ModInfo& info) {
 	std::string basefn = GetBaseFilename(dir);
-	
+
+	// Skip hidden dirs like .git, whose objects/ subdir would match below.
+	if(!basefn.empty() && basefn[0] == '.')
+		return false;
+
 	// TODO: absfn
 	// there is no better way to check that
 	if(IsDirectory(basefn + "/objects")) {

--- a/tests/headless/control/modlist_control.py
+++ b/tests/headless/control/modlist_control.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Control script that dumps the scanned mod list, for the mod-list test.
+
+The file-list cache is built asynchronously at startup,
+so poll ``listMods`` until the seeded positive-control mod appears
+(or give up), then emit one ``MOD:<path>`` marker per mod
+and a final ``MODLIST_DONE``.
+The test seeds directories in a search path
+and checks which of them the scan reports as mods.
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _olx_pipe import command, emit  # noqa: E402
+
+
+def main():
+    expect = os.environ.get("OLX_EXPECT_MOD", "")
+    mods = []
+    deadline = time.time() + 20
+    while time.time() < deadline:
+        mods = command("listMods")
+        if not expect or expect in mods:
+            break
+        time.sleep(0.3)
+
+    for path in mods:
+        emit("MOD:" + path)
+    emit("MODLIST_DONE")
+
+
+main()

--- a/tests/headless/test_mod_list.py
+++ b/tests/headless/test_mod_list.py
@@ -1,0 +1,67 @@
+"""Mod-list scan tests.
+
+The Mod dropdown (and the ``listMods`` command that shares its cache)
+scans every top-level directory in the search paths
+and reports each one it recognises as a mod.
+A Gusanos mod is recognised purely by an ``objects/`` subdirectory,
+which a version-control directory like ``.git`` also has
+(git's object store lives in ``.git/objects``),
+so a checkout used to show up as ``.git [Gus]``.
+Hidden dot-directories must be skipped.
+"""
+
+import os
+import sys
+
+from harness import OlxInstance, CONTROL_DIR
+
+MODLIST_CONTROL = os.path.join(CONTROL_DIR, "modlist_control.py")
+
+
+def _user_data_subdir():
+    """Search-path subdirectory under HOME that OLX scans for user content."""
+    if sys.platform == "darwin":
+        return "Library/Application Support/OpenLieroX"
+    return ".OpenLieroX"
+
+
+def _seed_mod_dir(home, name):
+    """Create ``<home>/<userdata>/<name>/objects`` so the scan sees a Gus mod."""
+    path = os.path.join(home, _user_data_subdir(), name, "objects")
+    os.makedirs(path, exist_ok=True)
+
+
+def _scanned_mods(binary, home):
+    """Run OLX headless, return the list of mod paths ``listMods`` reports."""
+    inst = OlxInstance(
+        binary, "modlist", home, MODLIST_CONTROL,
+        env={"OLX_EXPECT_MOD": "zzz_test_gus"},
+    ).start()
+    try:
+        assert inst.wait_for("MODLIST_DONE", timeout=40), (
+            "mod list scan never finished:\n" + inst.read_log())
+    finally:
+        inst.stop()
+    return [l[len("MOD:"):] for l in inst.read_log().splitlines()
+            if l.startswith("MOD:")]
+
+
+def test_git_dir_not_listed_as_mod(olx_binary, tmp_path):
+    """A ``.git`` directory in a search path is not reported as a mod.
+
+    ``zzz_test_gus`` is the positive control:
+    a plain directory with an ``objects/`` subdir, which is a real Gus mod,
+    so its presence proves the scan reached the seeded search path
+    and the ``objects/`` heuristic still works.
+    ``.git`` has the same ``objects/`` subdir but must be skipped.
+    """
+    home = str(tmp_path / "modlist")
+    _seed_mod_dir(home, "zzz_test_gus")
+    _seed_mod_dir(home, ".git")
+
+    mods = _scanned_mods(olx_binary, home)
+
+    assert "zzz_test_gus" in mods, (
+        "positive-control Gus mod was not scanned; got %r" % mods)
+    assert ".git" not in mods, (
+        ".git directory was listed as a mod; got %r" % mods)


### PR DESCRIPTION
## Problem

When running OpenLieroX from a source checkout,
the Mod dropdown (Local Play / Host) listed `.git [Gus]` as if it were a mod.

## Cause

The mod scan recognises a Gusanos mod purely by an `objects/` subdirectory
(`checkGusMod` in `src/common/CGameScript.cpp`).
A git checkout also has one: git stores its object database in `.git/objects`,
so the `.git` directory matched and was reported as a Gusanos mod.

## Fix

Skip hidden dot-directories in the Gusanos check; they are never mods.
This also covers other VCS metadata dirs such as `.svn`.

## Test

Adds a headless test (`tests/headless/test_mod_list.py`)
that seeds `.git/objects` in a search path
and checks the scan does not report it,
with a real `objects/` mod as the positive control
(so the test proves the scan reached the seeded path and the heuristic still works).
Verified it fails without the fix and passes with it.
