### PR TITLE
Warn on unknown options and add -version

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -442,6 +442,11 @@ static void ParseArguments_BeforeInit(int argc, char *argv[]) {
 			hints.minCoutVerb = 2;
 			warnings.minCoutVerb = 1;
 		}
+		// -version prints the version and quits, before any init
+		else if( stricmp(a, "-version") == 0 || stricmp(a, "--version") == 0 ) {
+			printf("%s\n", GetFullGameName());
+			exit(0);
+		}
 	}
 }
 
@@ -530,7 +535,7 @@ static void ParseArguments_AfterInit(int argc, char *argv[])
 
 		if( stricmp(a, "-aftercrash") == 0) {
 			afterCrash = true;
-		}
+		} else
 
 #ifdef WIN32
 		// -console
@@ -547,6 +552,17 @@ static void ParseArguments_AfterInit(int argc, char *argv[])
 		} else
 #endif
 
+#ifdef DEBUG
+		// -nettest
+		// Test CChannel reliability, then quit
+		if( !stricmp(a, "-nettest") ) {
+			InitializeLieroX();
+			TestCChannelRobustness();
+			ShutdownLieroX();
+			exit(0);
+		} else
+#endif
+
 		// -help
 		// Displays help and quits
         if( !stricmp(a, "-h") || !stricmp(a, "-help") || !stricmp(a, "--help") || !stricmp(a, "/?")) {
@@ -556,6 +572,7 @@ static void ParseArguments_AfterInit(int argc, char *argv[])
      		printf("   -opengl       OpenLieroX will use OpenGL for drawing\n");
      		printf("   -noopengl     Explicitly disable using OpenGL\n");
      		printf("   -dedicated    Dedicated mode\n");
+     		printf("   -script scr   Run a dedicated server with the given script\n");
      		printf("   -nojoystick   Disable Joystick support\n");
      		printf("   -nosound      Disable sound\n");
      		printf("   -window       Run in window mode\n");
@@ -566,8 +583,9 @@ static void ParseArguments_AfterInit(int argc, char *argv[])
 			#ifdef DEBUG
      		printf("   -nettest      Test CChannel reliability\n");
 			#endif
-     		printf("   -skin         Turns on new skinned GUI - it's unfinished yet\n");
-     		printf("   -noskin       Turns off new skinned GUI\n");
+     		printf("   -silent       Reduce the console verbosity\n");
+     		printf("   -version      Print the version and quit\n");
+     		printf("   -help         Print this help and quit\n");
 
 			// Shutdown and quit
 			// ShutdownLieroX() works only correct when everything was inited because ProcessEvents() is used.
@@ -575,16 +593,14 @@ static void ParseArguments_AfterInit(int argc, char *argv[])
 			// This is not nice but still nicer than getting a segfault.
 			// It is not worth to fix this in a nicer way as it is fixed anyway when we use the new engine system.
      		exit(0);
-        }
-		#ifdef DEBUG
-		if( !stricmp(a, "-nettest") )
-		{
-			InitializeLieroX();
-			TestCChannelRobustness();
-			ShutdownLieroX();
-     		exit(0);
-		}
-		#endif
+        } else
+
+		// handled in ParseArguments_BeforeInit; recognized here so they don't warn
+		if( !stricmp(a, "-disablestdincli") || !stricmp(a, "-disablecrashhandler") || !stricmp(a, "-silent") ) {
+			// nothing to do
+		} else
+
+			warnings << "unknown option: " << a << endl;
     }
 }
 


### PR DESCRIPTION
## What

Make command-line option handling report mistakes instead of hiding them,
and add a `-version` flag.

- **Warn on unknown options.**
  Until now any unrecognized option fell through the parse loop silently,
  so a typo like `-dedcated` just started a normal client with no feedback.
  A final `else` now warns on anything unknown.
  As part of this the loose `-aftercrash`, `-console` and `-nettest` cases
  are folded into the same `if/else` chain so it is a single well-formed chain,
  and the first-pass flags (`-disablestdincli`, `-disablecrashhandler`, `-silent`)
  are recognized in the second pass so they do not warn.

- **Add `-version` / `--version`.**
  Handled before init, so it just prints the version and quits
  without spinning up the game.

- **Fix the `-help` list to match reality.**
  Drop `-skin` / `-noskin`, which were advertised but never implemented,
  and add the missing `-script`, `-silent` and `-version`.

Kept as warn-and-continue rather than a hard error,
so a launcher passing a stray flag is not broken.

## Testing

- `./build-output/bin/openlierox -version` prints `OpenLieroX/<version>` and exits, no init.
- `-bogus` prints `unknown option: -bogus`; `-silent` stays quiet.
- `-help` lists the real options, no `-skin`/`-noskin`.
- Headless suite green: `12 passed`.
