### PR TITLE
Fix screenshot-format combobox alignment

### DIFF
--- a/src/client/DeprecatedGUI/Menu_Options.cpp
+++ b/src/client/DeprecatedGUI/Menu_Options.cpp
@@ -525,7 +525,7 @@ bool Menu_OptionsInitialize()
 
 	// Put the combo box after the other widgets to get around the problem with widget layering
 	cOpt_System.Add( new CCombobox(), os_NetworkSpeed, 170, starty + 155 - 3, 130,17);
-	cOpt_System.Add( new CCombobox(), os_ScreenshotFormat, 365, starty + 250 - 2, 70,17);
+	cOpt_System.Add( new CCombobox(), os_ScreenshotFormat, 365, starty + 225, 70,17);
 	cOpt_System.Add( new CCombobox(), os_ColourDepth, 275, starty + 20, 145, 17);
 
 	// Set the values


### PR DESCRIPTION
Fixes #1102.

## Problem

In Options -> System, the "Screenshot format" combobox sat a few pixels too low,
dropped onto the "Check for updates" row instead of lining up with its label.

The label uses the running layout cursor, which at that row is `starty + 225`,
but the combobox was hardcoded at `starty + 250 - 2` (`starty + 248`), ~23px lower.

## Fix

Place the combobox at `starty + 225` so its top matches its label's row.

Verified by rendering Options -> System before and after:
the "Png" combobox moves up from the "Check for updates" row onto its own label's row.
