### PR TITLE
Tighten the no-force-push rule in the guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,5 +18,4 @@ Rules that are easy to miss when working as an AI agent:
   and a change is verified by running it, not only by reading the diff.
 - Once a commit is pushed, don't force-push, amend, or squash it;
   a new change -- even a small follow-up on an open PR -- is a new commit.
-  Rewrite history only to undo a mistake you already pushed,
-  to rebase onto master, or when explicitly asked.
+  Rewrite history only to rebase onto master, or when explicitly asked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,5 +16,7 @@ Rules that are easy to miss when working as an AI agent:
   not at a fixed column.
 - Code must build and pass the headless tests (`./tests/headless/run.sh`) before you push,
   and a change is verified by running it, not only by reading the diff.
-- Don't force-push a published commit;
-  a new change is a new commit.
+- Once a commit is pushed, don't force-push, amend, or squash it;
+  a new change -- even a small follow-up on an open PR -- is a new commit.
+  Rewrite history only to undo a mistake you already pushed,
+  to rebase onto master, or when explicitly asked.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,8 @@
 - Keep commits small and focused; it makes review and later bisecting easy.
 - Once a commit is pushed, don't force-push or rewrite it;
   a new change -- even a small follow-up on an open PR -- is a new commit.
-- Force-push or rewrite history only to undo a history mistake you already pushed,
-  to rebase onto master, or when explicitly asked; don't squash commits together.
+- Force-push or rewrite history only to rebase onto master,
+  or when explicitly asked; don't squash commits together.
 - No `Co-authored-by:` lines crediting an LLM or AI agent.
 
 ## C++ style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,10 @@
 - Subject: imperative mood, <= 50 chars, capitalized, no trailing period.
 - Then a blank line and a body wrapped at ~72, explaining what and why.
 - Keep commits small and focused; it makes review and later bisecting easy.
-- Don't force-push a published commit; a new change is a new commit.
-  Only rewrite/force-push your own not-yet-merged commits (or when asked to).
+- Once a commit is pushed, don't force-push or rewrite it;
+  a new change -- even a small follow-up on an open PR -- is a new commit.
+- Force-push or rewrite history only to undo a history mistake you already pushed,
+  to rebase onto master, or when explicitly asked; don't squash commits together.
 - No `Co-authored-by:` lines crediting an LLM or AI agent.
 
 ## C++ style


### PR DESCRIPTION
The commit guidance previously said
"Only rewrite/force-push your own not-yet-merged commits (or when asked to),"
which reads as a standing license
to amend an open PR's commit and force-push.

This replaces that with the intended policy,
in both CONTRIBUTING.md and the agent-facing CLAUDE.md:

- Once a commit is pushed,
  don't force-push, amend, or squash it;
  a new change is a new commit,
  even a small follow-up on an open PR.
- Force-push or history rewrite is only for
  undoing a pushed mistake,
  rebasing onto master,
  or when explicitly asked;
  never squash commits together.
