### PR TITLE
Clamp completion cursor to the new buffer length

### DIFF
--- a/src/client/StdinCLISupport.cpp
+++ b/src/client/StdinCLISupport.cpp
@@ -1,5 +1,6 @@
 #include <thread>
 #include <system_error>
+#include <algorithm> // std::min
 #include "StdinCLISupport.h"
 #include "ThreadPool.h"
 #include "Mutex.h"
@@ -114,7 +115,9 @@ bool linenoiseCompletionCallbackFunc(const std::string& buf, LinenoiseCompletion
 	if(!fail) {
 		Mutex::ScopedLock lock(stdoutMutex);
 		linenoiseEnv.buf = newState.text;
-		linenoiseEnv.pos = newState.pos;
+		// a completion can return a buffer shorter than the old cursor,
+		// so keep the pos <= buf.size() invariant, else the next edit throws
+		linenoiseEnv.pos = std::min(newState.pos, linenoiseEnv.buf.size());
 		linenoiseEnv.refreshLine();
 		return true;
 	}


### PR DESCRIPTION
Fixes #1097.

A tab-completion can return a buffer
shorter than the old cursor position.
`linenoiseCompletionCallbackFunc` adopted the completion's `text` and `pos` as-is,
so `pos` was left past the end of the shorter buffer,
and the next edit in `getNextInput()` (`buf.substr(pos)` / `buf.erase(pos)`)
threw `std::out_of_range` and terminated the stdin thread.

The fix clamps `pos` to `buf.size()` when adopting the completion result,
keeping the `pos <= buf.size()` invariant at the point it was broken.
No catch-all around the thread body, as the issue asked.

### Verification

Builds, and the headless terminal regression test
(`tests/headless/test_terminal.py`) passes.

No new automated test.
The broken path runs through the file-static `linenoiseCompletionCallbackFunc`,
reachable only through the full interactive stdin CLI
and the `AutoComplete` machinery on a real tty,
so there is no clean unit or headless repro.
(`getNextInput()` also resets `buf`/`pos` on entry,
so the bad state only exists mid-loop right after a completion.)
The change is a one-line clamp on a clear invariant.
