### PR TITLE
Force the OS cursor hidden on macOS

### DIFF
--- a/include/AuxLib.h
+++ b/include/AuxLib.h
@@ -72,8 +72,8 @@ void doVppOperation(Action* act);
 void EnableSystemMouseCursor(bool enable = true);
 
 // Re-assert the wanted OS cursor visibility against the window server.
-// macOS keeps re-showing the OS cursor on window re-entry and app activation,
-// so call this regularly from the main thread.
+// Call from the main thread whenever a gate input changes:
+// the mouse enters or leaves the window, or the window gains or loses focus.
 // It is a cheap no-op on other platforms.
 void EnforceSystemMouseCursor();
 

--- a/include/AuxLib.h
+++ b/include/AuxLib.h
@@ -71,10 +71,11 @@ void doVppOperation(Action* act);
 // Use this function instead of SDL_ShowCursor()
 void EnableSystemMouseCursor(bool enable = true);
 
-// Re-assert the wanted OS cursor visibility against the window server.
-// Call from the main thread whenever a gate input changes:
-// the mouse enters or leaves the window, or the window gains or loses focus.
-// It is a cheap no-op on other platforms.
+// Apply the wanted OS cursor visibility (set via EnableSystemMouseCursor).
+// Most platforms just hide it through SDL;
+// macOS drives the hardware cursor directly,
+// so it must be re-applied from the main thread whenever a gate input changes:
+// the mouse enters or leaves the window, or the window focus flips.
 void EnforceSystemMouseCursor();
 
 class VideoPostProcessor {

--- a/include/AuxLib.h
+++ b/include/AuxLib.h
@@ -71,6 +71,12 @@ void doVppOperation(Action* act);
 // Use this function instead of SDL_ShowCursor()
 void EnableSystemMouseCursor(bool enable = true);
 
+// Re-assert the wanted OS cursor visibility against the window server.
+// macOS keeps re-showing the OS cursor on window re-entry and app activation,
+// so call this regularly from the main thread.
+// It is a cheap no-op on other platforms.
+void EnforceSystemMouseCursor();
+
 class VideoPostProcessor {
 protected:
 	SmartPointer<SDL_Window> m_window;

--- a/src/MacHelpers.m
+++ b/src/MacHelpers.m
@@ -1,8 +1,9 @@
 /*
-    Cocoa helpers used by the OLX C++ side (clipboard + user-attention
-    notifications). The legacy src/MacMain.m also defines these, but it
-    carries an SDL 1.x main() that the cmake build replaces, so this
-    file is the source of truth for the cmake build.
+    Cocoa helpers used by the OLX C++ side
+    (clipboard + user-attention notifications, OS cursor).
+    The legacy src/MacMain.m also defines the clipboard/notification ones,
+    but it carries an SDL 1.x main() that the cmake build replaces,
+    so this file is the source of truth for the cmake build.
 */
 
 #import <Cocoa/Cocoa.h>
@@ -27,4 +28,20 @@ void mac__NotifyUserOnEvent(void) {
 }
 
 void mac__ClearUserNotify(void) {
+}
+
+// Force the hardware OS cursor hidden or shown.
+// CGDisplayHideCursor keeps a global hide count that, unlike the cursor rects
+// SDL_ShowCursor relies on, is not reset when the mouse re-enters the window,
+// so the cursor stays hidden until we balance it with CGDisplayShowCursor.
+// Keep the calls balanced with our own state and call on the main thread.
+void mac__EnforceSystemCursorHidden(int hidden) {
+    static int applied = 0;  // whether we currently hold the cursor hidden
+    if (hidden && !applied) {
+        CGDisplayHideCursor(kCGDirectMainDisplay);
+        applied = 1;
+    } else if (!hidden && applied) {
+        CGDisplayShowCursor(kCGDirectMainDisplay);
+        applied = 0;
+    }
 }

--- a/src/MainLoop.cpp
+++ b/src/MainLoop.cpp
@@ -335,6 +335,11 @@ bool handleSDLEvents(bool wait) {
 			return false;
 	}
 
+	// The mouse may just have moved back over the window,
+	// where macOS re-shows the OS cursor on its own;
+	// re-assert the wanted state now, on the main thread.
+	EnforceSystemMouseCursor();
+
 	return true;
 }
 

--- a/src/MainLoop.cpp
+++ b/src/MainLoop.cpp
@@ -304,6 +304,20 @@ static bool handleSDLEvent(SDL_Event& ev) {
 		Clipboard_handleSysWmEvent(ev);
 		return true;
 	}
+	if( ev.type == SDL_WINDOWEVENT ) {
+		// The gate for the OS cursor just changed
+		// (the mouse crossed the window edge, or the window focus flipped).
+		// SDL has already updated its focus state,
+		// so re-assert here on the main thread rather than polling every frame.
+		switch(ev.window.event) {
+		case SDL_WINDOWEVENT_ENTER:
+		case SDL_WINDOWEVENT_LEAVE:
+		case SDL_WINDOWEVENT_FOCUS_GAINED:
+		case SDL_WINDOWEVENT_FOCUS_LOST:
+			EnforceSystemMouseCursor();
+			break;
+		}
+	}
 	// mainQueue could be unset at very early or late calls here
 	if(mainQueue)
 		mainQueue->push(ev);
@@ -334,11 +348,6 @@ bool handleSDLEvents(bool wait) {
 		if(!handleSDLEvent(ev))
 			return false;
 	}
-
-	// The mouse may just have moved back over the window,
-	// where macOS re-shows the OS cursor on its own;
-	// re-assert the wanted state now, on the main thread.
-	EnforceSystemMouseCursor();
 
 	return true;
 }

--- a/src/client/AuxLib.cpp
+++ b/src/client/AuxLib.cpp
@@ -21,6 +21,7 @@
 #endif
 
 
+#include <atomic>
 #include <iomanip>
 #include <time.h>
 #include <SDL.h>
@@ -82,6 +83,8 @@
 
 
 Null null;	// Used in timer class
+
+static void applySystemMouseCursor();  // apply the wanted OS cursor visibility, main thread only
 
 
 
@@ -513,11 +516,11 @@ setvideomode:
 		return false;
 	}
 	
-	// Hide the operating-system / browser cursor. OpenLieroX draws its own
-	// software cursor where one is wanted (menus), and that should be the only
-	// cursor the player ever sees — on the web too (SDL maps this to
-	// `canvas { cursor: none }`).
-	SDL_ShowCursor(SDL_DISABLE);
+	// Hide the operating-system / browser cursor.
+	// OpenLieroX draws its own software cursor where one is wanted (menus),
+	// and that should be the only cursor the player ever sees.
+	// We are on the main thread here, so apply it directly.
+	applySystemMouseCursor();
 
 #ifdef WIN32
 	// Hint: Reset the mouse state - this should avoid the mouse staying pressed
@@ -1219,28 +1222,62 @@ bool lierox_t::isAnyControlKeyDown() const {
 }
 
 
+// Whether the player should currently see the OS cursor.
+// The menus and game hide it (OpenLieroX draws its own software cursor);
+// the console and error dialogs show it.
+static std::atomic<bool> systemMouseCursorWanted(false);
+
+static void applySystemMouseCursor()
+{
+	// Should be called from the main thread, or you'll get a race condition with libX11.
+	SDL_ShowCursor(systemMouseCursorWanted ? SDL_ENABLE : SDL_DISABLE);
+}
+
+#ifdef __APPLE__
+// macOS re-shows the OS cursor on its own (window re-entry, app activation),
+// and SDL_ShowCursor(SDL_DISABLE) rides on cursor rects
+// that the window server applies unreliably,
+// so the arrow keeps flickering back over the window.
+// Enforce the wanted state at the hardware level instead,
+// gated on whether the mouse is over our window
+// so the arrow still shows over the title bar and menu bar.
+extern "C" void mac__EnforceSystemCursorHidden(int hidden);
+#endif
+
+void EnforceSystemMouseCursor()
+{
+#ifdef __APPLE__
+	if( bDedicated )
+		return;
+	// Hold the cursor hidden only while OLX is active
+	// and the mouse is over our window,
+	// so the normal arrow still shows over the title bar, the menu bar and other apps.
+	// Losing either balances the hide back out (see the helper).
+	const bool wantHidden = !systemMouseCursorWanted;
+	const bool active = SDL_GetKeyboardFocus() != NULL;
+	const bool mouseOverWindow = SDL_GetMouseFocus() != NULL;
+	mac__EnforceSystemCursorHidden(wantHidden && active && mouseOverWindow);
+#endif
+}
+
 void EnableSystemMouseCursor(bool enable)
 {
 	if( bDedicated )
 		return;
+#ifdef __EMSCRIPTEN__
+	// Web build: never show the operating-system / browser cursor.
+	// OpenLieroX's own software cursor is the only cursor the player
+	// should ever see, so ignore requests to show the OS one.
+	enable = false;
+#endif
+	systemMouseCursorWanted = enable;
 	struct EnableMouseCursor: public Action
 	{
-		bool Enable;
-		
-		EnableMouseCursor(bool b): Enable(b) {};
 		Result handle()
 		{
-#ifdef __EMSCRIPTEN__
-			// Web build: never show the operating-system / browser cursor.
-			// OpenLieroX's own software cursor is the only cursor the player
-			// should ever see, so ignore requests to show the OS one.
-			(void)Enable;
-			SDL_ShowCursor(SDL_DISABLE);
-#else
-			SDL_ShowCursor(Enable ? SDL_ENABLE : SDL_DISABLE ); // Should be called from main thread, or you'll get race condition with libX11
-#endif
+			applySystemMouseCursor();
 			return true;
 		}
 	};
-	doActionInMainThread( new EnableMouseCursor(enable) );
+	doActionInMainThread( new EnableMouseCursor() );
 };

--- a/src/client/AuxLib.cpp
+++ b/src/client/AuxLib.cpp
@@ -84,8 +84,6 @@
 
 Null null;	// Used in timer class
 
-static void applySystemMouseCursor();  // apply the wanted OS cursor visibility, main thread only
-
 
 
 // TODO: is this the best format? why? comment that.
@@ -520,7 +518,6 @@ setvideomode:
 	// OpenLieroX draws its own software cursor where one is wanted (menus),
 	// and that should be the only cursor the player ever sees.
 	// We are on the main thread here, so apply it directly.
-	applySystemMouseCursor();
 	EnforceSystemMouseCursor();
 
 #ifdef WIN32
@@ -1228,36 +1225,30 @@ bool lierox_t::isAnyControlKeyDown() const {
 // the console and error dialogs show it.
 static std::atomic<bool> systemMouseCursorWanted(false);
 
-static void applySystemMouseCursor()
-{
-	// Should be called from the main thread, or you'll get a race condition with libX11.
-	SDL_ShowCursor(systemMouseCursorWanted ? SDL_ENABLE : SDL_DISABLE);
-}
-
 #ifdef __APPLE__
-// macOS re-shows the OS cursor on its own (window re-entry, app activation),
-// and SDL_ShowCursor(SDL_DISABLE) rides on cursor rects
-// that the window server applies unreliably,
-// so the arrow keeps flickering back over the window.
-// Enforce the wanted state at the hardware level instead,
-// gated on whether the mouse is over our window
-// so the arrow still shows over the title bar and menu bar.
 extern "C" void mac__EnforceSystemCursorHidden(int hidden);
 #endif
 
 void EnforceSystemMouseCursor()
 {
+	// Should be called from the main thread, or you'll get a race condition with libX11.
 #ifdef __APPLE__
-	if( bDedicated )
-		return;
-	// Hold the cursor hidden only while OLX is active
-	// and the mouse is over our window,
+	// On macOS, SDL_ShowCursor(SDL_DISABLE) rides on AppKit cursor rects
+	// that the window server applies unreliably on window re-entry,
+	// so the arrow keeps flickering back over the window.
+	// Drive the hardware cursor directly instead of through SDL,
+	// gated on OLX being active with the mouse over its window,
 	// so the normal arrow still shows over the title bar, the menu bar and other apps.
 	// Losing either balances the hide back out (see the helper).
+	if( bDedicated )
+		return;
 	const bool wantHidden = !systemMouseCursorWanted;
 	const bool active = SDL_GetKeyboardFocus() != NULL;
 	const bool mouseOverWindow = SDL_GetMouseFocus() != NULL;
 	mac__EnforceSystemCursorHidden(wantHidden && active && mouseOverWindow);
+#else
+	// Every other window manager hides the cursor reliably through SDL.
+	SDL_ShowCursor(systemMouseCursorWanted ? SDL_ENABLE : SDL_DISABLE);
 #endif
 }
 
@@ -1276,7 +1267,6 @@ void EnableSystemMouseCursor(bool enable)
 	{
 		Result handle()
 		{
-			applySystemMouseCursor();
 			EnforceSystemMouseCursor();
 			return true;
 		}

--- a/src/client/AuxLib.cpp
+++ b/src/client/AuxLib.cpp
@@ -521,6 +521,7 @@ setvideomode:
 	// and that should be the only cursor the player ever sees.
 	// We are on the main thread here, so apply it directly.
 	applySystemMouseCursor();
+	EnforceSystemMouseCursor();
 
 #ifdef WIN32
 	// Hint: Reset the mouse state - this should avoid the mouse staying pressed
@@ -1276,6 +1277,7 @@ void EnableSystemMouseCursor(bool enable)
 		Result handle()
 		{
 			applySystemMouseCursor();
+			EnforceSystemMouseCursor();
 			return true;
 		}
 	};


### PR DESCRIPTION
The menus and game hide the OS cursor with `SDL_ShowCursor(SDL_DISABLE)`,
but on macOS (SDL3 via sdl2-compat) that rides on AppKit cursor rects,
which the window server applies unreliably:
the arrow flickers back roughly every other time
the mouse moves back over the window.

## Fix

Hide the cursor through `CGDisplayHideCursor` instead.
Its global hide count is independent of the cursor rects,
so the cursor stays hidden across window re-entry
until we balance it with `CGDisplayShowCursor`.
The wanted state is re-asserted from the main event loop,
gated on OLX being active with the mouse over its window,
so the normal arrow still shows over the title bar, the menu bar and other apps.

## Notes

- macOS-only; other platforms keep the existing `SDL_ShowCursor` path unchanged.
- The self-balancing helper only calls the CoreGraphics API on real transitions,
  so it is cheap to call every event-loop pass.
- `CGCursorIsVisible` was deliberately avoided as an oracle:
  it is deprecated and returns "visible" even after a successful hide,
  which would risk leaving the cursor stuck hidden.

Fixes #1092.
