### PR TITLE
Join console I/O threads via atexit

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 
 
 #include <cassert>
+#include <cstdlib> // for std::atexit
 #include <sstream> // for print_binary_string
 #include <set>
 #include <string>
@@ -82,6 +83,7 @@ static bool enableStdinCLI = true;
 
 static void ParseArguments_BeforeInit(int argc, char *argv[]);
 static void ParseArguments_AfterInit(int argc, char *argv[]);
+static void quitConsoleIOThreads();
 
 static std::list<std::string> startupCommands;
 
@@ -219,7 +221,13 @@ int real_main(int argc, char *argv[])
 	if(enableStdinCLI)
 		stdinCLIinitRes = initStdinCLISupport();
 	teeStdoutInit();
-	
+
+	// The two console I/O threads own static std::threads.
+	// Any exit() that skips the normal shutdown (e.g. SystemError())
+	// would otherwise destroy them still-joinable, which calls std::terminate().
+	// atexit runs before those static destructors, so join them here.
+	std::atexit(quitConsoleIOThreads);
+
 	mainThreadId = getCurrentThreadId();
 	assert(mainThreadId != (ThreadId)-1);
 	setCurThreadName("Main Thread");
@@ -451,9 +459,10 @@ static void ParseArguments_BeforeInit(int argc, char *argv[]) {
 }
 
 
-// Join the stdin-CLI and tee-stdout worker threads before an early exit():
+// Join the stdin-CLI and tee-stdout worker threads before exit():
 // exit() runs their static std::thread destructors,
 // and a still-joinable std::thread terminates the process.
+// Registered via atexit(), and also called directly on the early-exit paths.
 static void quitConsoleIOThreads() {
 	quitStdinCLISupport();
 	teeStdoutQuit();

--- a/tests/headless/test_terminal.py
+++ b/tests/headless/test_terminal.py
@@ -89,18 +89,21 @@ def _run_dedicated_on_pty(binary, home, port):
     return bytes(buf)
 
 
-def _run_args_on_pty(binary, home, args, deadline_s=60):
+def _run_args_on_pty(binary, home, args, deadline_s=60, env=None):
     """Run the binary with the given args on a pty until it exits.
 
     A pty makes stdin a terminal,
     so the interactive stdin CLI (and the threaded tee-stdout path) activate,
     which is the precondition for the early-exit crash below.
+    ``env`` adds or overrides environment variables for the child.
     Returns ``(status, output)``:
     the raw ``os.waitpid`` status and the raw terminal bytes collected.
     """
+    extra_env = env or {}
     env = dict(os.environ)
     env["HOME"] = home
     env["TERM"] = "xterm"  # so linenoise treats it as a supported terminal
+    env.update(extra_env)
 
     pid, fd = pty.fork()
     if pid == 0:
@@ -162,6 +165,40 @@ def test_help_exits_cleanly(tmp_path):
     assert os.WEXITSTATUS(status) == 0, (
         "-help exited with non-zero status %d:\n" % os.WEXITSTATUS(status)
         + repr(raw[-400:])
+    )
+
+
+def test_systemerror_exits_cleanly(tmp_path):
+    """A fatal SystemError() exits cleanly, even with the stdin CLI active.
+
+    SystemError() runs ShutdownLieroX() and then exit(-1),
+    and ShutdownLieroX() does not stop the console I/O threads.
+    On a real terminal the stdin-CLI and tee-stdout worker threads are up,
+    so exit() used to destroy their still-joinable std::threads,
+    which calls std::terminate() -> abort().
+    An invalid SDL_VIDEODRIVER makes video init fail deterministically,
+    which is the earliest reliable SystemError() we can trigger from outside.
+    The crash handler is disabled so the abort surfaces as a real signal:
+    otherwise it catches the SIGABRT, dumps a callstack and exits 255,
+    which would hide the crash from this test.
+    """
+    binary = find_binary()
+    if binary is None:
+        pytest.fail("openlierox binary not found; build it first or set OLX_BINARY",
+                    pytrace=False)
+
+    status, raw = _run_args_on_pty(
+        binary, str(tmp_path), ["-disablecrashhandler"],
+        env={"SDL_VIDEODRIVER": "olx-nonexistent-driver"})
+
+    assert not os.WIFSIGNALED(status), (
+        "SystemError aborted instead of exiting cleanly (killed by signal %d):\n"
+        % os.WTERMSIG(status) + repr(raw[-400:])
+    )
+    # SystemError() ends with exit(-1), i.e. status 255.
+    assert os.WEXITSTATUS(status) == 255, (
+        "expected exit(-1) from SystemError, got status %d:\n"
+        % os.WEXITSTATUS(status) + repr(raw[-400:])
     )
 
 

--- a/tests/headless/test_terminal.py
+++ b/tests/headless/test_terminal.py
@@ -168,37 +168,47 @@ def test_help_exits_cleanly(tmp_path):
     )
 
 
-def test_systemerror_exits_cleanly(tmp_path):
-    """A fatal SystemError() exits cleanly, even with the stdin CLI active.
+def test_systemerror_stops_console_threads(tmp_path):
+    """A fatal SystemError() stops the console I/O threads before teardown.
 
-    SystemError() runs ShutdownLieroX() and then exit(-1),
-    and ShutdownLieroX() does not stop the console I/O threads.
+    SystemError() runs ShutdownLieroX() and then exit(-1).
     On a real terminal the stdin-CLI and tee-stdout worker threads are up,
+    and neither ShutdownLieroX() nor this path stops them,
     so exit() used to destroy their still-joinable std::threads,
     which calls std::terminate() -> abort().
+    The atexit() handler now joins them on every exit() path.
+
     An invalid SDL_VIDEODRIVER makes video init fail deterministically,
     which is the earliest reliable SystemError() we can trigger from outside.
-    The crash handler is disabled so the abort surfaces as a real signal:
-    otherwise it catches the SIGABRT, dumps a callstack and exits 255,
-    which would hide the crash from this test.
+    The crash handler is disabled so it does not stand in:
+    otherwise it catches the SIGABRT and itself stops the threads,
+    which would let this pass even without the fix.
+
+    We assert the threads are stopped (their quit markers are printed),
+    not a clean process exit:
+    ShutdownLieroX() here runs against half-initialized state and still
+    aborts during the rest of teardown on some libcs (see #1111),
+    which is a separate bug from the console-thread stop this covers.
     """
     binary = find_binary()
     if binary is None:
         pytest.fail("openlierox binary not found; build it first or set OLX_BINARY",
                     pytrace=False)
 
-    status, raw = _run_args_on_pty(
+    _status, raw = _run_args_on_pty(
         binary, str(tmp_path), ["-disablecrashhandler"],
         env={"SDL_VIDEODRIVER": "olx-nonexistent-driver"})
 
-    assert not os.WIFSIGNALED(status), (
-        "SystemError aborted instead of exiting cleanly (killed by signal %d):\n"
-        % os.WTERMSIG(status) + repr(raw[-400:])
+    # Both markers only print when quitConsoleIOThreads() runs, i.e. via the
+    # atexit() fix; without it the threads are never asked to quit and the
+    # still-joinable std::thread destructor aborts instead.
+    assert b"wait for StdinCLI quit" in raw, (
+        "stdin CLI thread was not stopped on the SystemError path:\n"
+        + repr(raw[-400:])
     )
-    # SystemError() ends with exit(-1), i.e. status 255.
-    assert os.WEXITSTATUS(status) == 255, (
-        "expected exit(-1) from SystemError, got status %d:\n"
-        % os.WEXITSTATUS(status) + repr(raw[-400:])
+    assert b"wait for teeStdout handler quit" in raw, (
+        "tee-stdout thread was not stopped on the SystemError path:\n"
+        + repr(raw[-400:])
     )
 
 


### PR DESCRIPTION
Fixes #1096.

#1098 stopped the console I/O threads before the `-help` and `-nettest`
early exits, but `SystemError()` was left out:
it runs `ShutdownLieroX()` (which does not stop those threads)
and then `exit(-1)`.
`exit()` destroys the file-static `std::thread` owners,
and a still-joinable `std::thread` destructor calls `std::terminate()`,
so a fatal runtime error aborted (SIGABRT) instead of exiting with -1.

Rather than chase every `exit()` site,
register `quitConsoleIOThreads()` with `std::atexit()` once the threads are started.
An atexit handler registered during `real_main()`
runs before the file-static destructors,
so it joins the threads first, on every `exit()` path at once.
The helper is already idempotent,
so the explicit calls on the normal and early-exit paths stay harmless.

### Verification

Builds, and the full headless suite passes (`tests/headless/`, 15 tests).

Added a headless regression test that forces a `SystemError()`
by pointing SDL at a non-existent video driver on a pty
(so the stdin-CLI and tee-stdout threads are active),
with the crash handler disabled so it does not stop the threads itself.
It asserts the threads are stopped
(their quit markers print only when the atexit handler runs),
and fails on the pre-fix binary.

It deliberately does not assert a clean process exit:
on this path `ShutdownLieroX()` runs against half-initialized state
and still aborts during the rest of teardown on glibc,
which is a separate pre-existing bug, filed as #1111.
The console-thread stop this PR is about is what the test covers.
