### PR TITLE
Fix overlapping key list in weapon selection

### DIFF
--- a/include/CInput.h
+++ b/include/CInput.h
@@ -63,6 +63,7 @@ private:
 		int		Data;
 		int		SdlIndex;
 		int		JoystickIndex; // 0-based pad index for INP_JOYSTICK
+		std::string m_name; // the config token this binding parsed from (e.g. "j1_button_south")
 		ModifiersState m_modifiers; // required modifier keys for keyboard bindings
 
 		// HINT: currently these are only used for keyboard exept nDownOnce
@@ -127,6 +128,8 @@ public:
 	int		wasUp(); // checks if there was an keyup-event; returns the count of up-events
 
 	std::string getEventName() { return m_EventName; }
+	// onlyAvailable drops bindings that can't currently fire (e.g. an absent gamepad)
+	std::string getEventName(bool onlyAvailable) const;
 
 	// event handling, called from the global input-event dispatchers
 	void	handleKeyEvent(const KeyboardEvent& ev);

--- a/src/client/CInput.cpp
+++ b/src/client/CInput.cpp
@@ -632,6 +632,7 @@ bool CInput::Binding::setup(const std::string& string)
 	Data = 0;
 	SdlIndex = 0;
 	JoystickIndex = 0;
+	m_name = string;
 	m_modifiers.clear();
 
 	// Parse optional modifier prefixes: "alt+", "ctrl+", "shift+"
@@ -981,6 +982,22 @@ bool CInput::isKeyboard() const {
 	for(std::vector<Binding>::const_iterator it = m_bindings.begin(); it != m_bindings.end(); ++it)
 		if(it->isKeyboard()) return true;
 	return false;
+}
+
+std::string CInput::getEventName(bool onlyAvailable) const {
+	if(!onlyAvailable) return m_EventName;
+	std::string res;
+	for(std::vector<Binding>::const_iterator it = m_bindings.begin(); it != m_bindings.end(); ++it) {
+		if(it->m_name.empty()) continue;
+		// A joystick binding for a pad that isn't plugged in can't fire; hide it.
+		if(it->isJoystick() && !isPadPresent(it->JoystickIndex)) continue;
+		if(!res.empty()) res += ", ";
+		res += it->m_name;
+	}
+	// Nothing usable (unbound, or bound only to an absent pad):
+	// say so explicitly rather than render a blank.
+	if(res.empty()) return "<none>";
+	return res;
 }
 
 bool CInput::usesKeyboardKey(int sym) const {

--- a/src/common/CWormHuman.cpp
+++ b/src/common/CWormHuman.cpp
@@ -919,16 +919,20 @@ void CWormHumanInputHandler::doWeaponSelectionFrame(SDL_Surface * bmpDest, CView
 	
 	// list current key settings
 	// TODO: move this out here
+	// One left-aligned column so the labels line up; a two-column layout
+	// overlapped once binding names grew wide. getEventName(true) hides bindings
+	// that can't fire (e.g. an absent gamepad). " / " is spaced so it doesn't
+	// blur into the "/" in tokens.
+	int keyx = centrex - 150;
 	y += 20;
 	tLX->cFont.DrawCentre(bmpDest, centrex, y += 15, tLX->clWeaponSelectionTitle, "~ Key settings ~");
-	tLX->cFont.Draw(bmpDest, centrex - 150, y += 15, tLX->clWeaponSelectionTitle, "up/down: " + cUp.getEventName() + "/" + cDown.getEventName());
-	tLX->cFont.Draw(bmpDest, centrex - 150, y += 15, tLX->clWeaponSelectionTitle, "left/right: " + cLeft.getEventName() + "/" + cRight.getEventName());
-	tLX->cFont.Draw(bmpDest, centrex - 150, y += 15, tLX->clWeaponSelectionTitle, "shoot: " + cShoot.getEventName());
-	y -= 45;
-	tLX->cFont.Draw(bmpDest, centrex, y += 15, tLX->clWeaponSelectionTitle, "jump/ninja: " + cJump.getEventName() + "/" + cInpRope.getEventName());
-	tLX->cFont.Draw(bmpDest, centrex, y += 15, tLX->clWeaponSelectionTitle, "select weapon: " + cSelWeapon.getEventName());
-	tLX->cFont.Draw(bmpDest, centrex, y += 15, tLX->clWeaponSelectionTitle, "strafe: " + cStrafe.getEventName());
-	tLX->cFont.Draw(bmpDest, centrex, y += 15, tLX->clWeaponSelectionTitle, "quick select weapon: " + cWeapons[0].getEventName() + " " + cWeapons[1].getEventName() + " " + cWeapons[2].getEventName() + " " + cWeapons[3].getEventName() + " " + cWeapons[4].getEventName() );
+	tLX->cFont.Draw(bmpDest, keyx, y += 15, tLX->clWeaponSelectionTitle, "up/down: " + cUp.getEventName(true) + " / " + cDown.getEventName(true));
+	tLX->cFont.Draw(bmpDest, keyx, y += 15, tLX->clWeaponSelectionTitle, "left/right: " + cLeft.getEventName(true) + " / " + cRight.getEventName(true));
+	tLX->cFont.Draw(bmpDest, keyx, y += 15, tLX->clWeaponSelectionTitle, "shoot: " + cShoot.getEventName(true));
+	tLX->cFont.Draw(bmpDest, keyx, y += 15, tLX->clWeaponSelectionTitle, "jump/ninja: " + cJump.getEventName(true) + " / " + cInpRope.getEventName(true));
+	tLX->cFont.Draw(bmpDest, keyx, y += 15, tLX->clWeaponSelectionTitle, "select weapon: " + cSelWeapon.getEventName(true));
+	tLX->cFont.Draw(bmpDest, keyx, y += 15, tLX->clWeaponSelectionTitle, "strafe: " + cStrafe.getEventName(true));
+	tLX->cFont.Draw(bmpDest, keyx, y += 15, tLX->clWeaponSelectionTitle, "quick select weapon: " + cWeapons[0].getEventName(true) + " " + cWeapons[1].getEventName(true) + " " + cWeapons[2].getEventName(true) + " " + cWeapons[3].getEventName(true) + " " + cWeapons[4].getEventName(true) );
 	
 	
 	if(!bChat_Typing) {


### PR DESCRIPTION
## Problem

The "Key settings" list in the weapon-selection screen overlapped itself.
It was drawn in two columns (at `centrex-150` and `centrex`),
which assumed short single-key names.
Gamepad support turned each binding into a comma-separated list
of keys and pad buttons,
so the left column ran past the gap and collided with the right one.

## Fix

- Draw the list as a single left-aligned column,
  so the labels line up however wide the names get.
- Add `CInput::getEventName(bool onlyAvailable)`,
  which lists only the bindings that can currently fire:
  it drops gamepad buttons for a pad that isn't connected (via `isPadPresent`),
  and returns `"<none>"` if that leaves nothing.
  The weapon-selection list uses it,
  so with no pad plugged in the lines collapse back to the plain keyboard keys
  instead of advertising controls the player can't press.
- Space the two-way separator as `" / "`
  so it doesn't blur into the `"/"` inside pad token names
  (e.g. `j1_button_south/x`).

## Testing

Built and ran; the screen now reads as a clean, aligned column
both with and without a gamepad connected.
Headless suite passes
(`test_bots_play_a_round_and_state_syncs_to_a_client` is flaky
and passes on its own re-run).
