### PR TITLE
Fix wasm sample-level staging for CastleStrike

### DIFF
--- a/build/wasm/WASM-PORT.md
+++ b/build/wasm/WASM-PORT.md
@@ -297,7 +297,7 @@ stages a curated subset under `output/preload/gamedir/`:
 cfg/ data/ scripts/ gui_skins/ themes/ skins/ games/
 Classic/ Gusanos/  [MW 1.0/ promode/ if present]
 GeoIP.dat  startup.lua
-levels/{747, Base Fight, BetaBoxDE, Castle Strike, Dirt Level}.lxl
+levels/{747, Base Fight, BetaBoxDE, CastleStrike, Dirt Level}.lxl
 *.gamesettings
 ```
 

--- a/build/wasm/build-wasm.sh
+++ b/build/wasm/build-wasm.sh
@@ -132,7 +132,7 @@ if [ "$SKIP_DATA" -eq 0 ]; then
     # levels (and the empty `levels/` dir) for the introduction
     # game's level lookup to succeed.
     mkdir -p "$SD/levels"
-    for lvl in "747.lxl" "Base Fight.lxl" "BetaBoxDE.lxl" "Castle Strike.lxl" \
+    for lvl in "747.lxl" "Base Fight.lxl" "BetaBoxDE.lxl" "CastleStrike.lxl" \
                "Dirt Level.lxl"; do
         if [ -f "$GD/levels/$lvl" ]; then
             cp -f "$GD/levels/$lvl" "$SD/levels/$lvl"


### PR DESCRIPTION
## Problem

The wasm build stages a curated subset of `share/gamedir`,
including a handful of sample levels
(so custom selection is not empty
and the Introduction game's `levels/../games/...` path resolution works).

The staged list spelled one entry `"Castle Strike.lxl"` with a space,
but the actual file is `levels/CastleStrike.lxl` (no space),
so the `[ -f ]` guard never matched and Castle Strike was silently skipped.

## Change

Use the real filename in `build-wasm.sh`
(and the matching doc line in `WASM-PORT.md`),
so `CastleStrike.lxl` is actually staged into the web build.

## Verification

`share/gamedir/levels/CastleStrike.lxl` exists;
`levels/Castle Strike.lxl` (with a space) does not,
confirming the old entry never matched and the corrected one does.
The change is a staging-list filename correction,
so no engine or emcc build behaviour changes beyond that file now being copied.
