### PR TITLE
Change automtic PR builds to be Pre-releases

### DIFF
--- a/.github/workflows/headless-tests.yml
+++ b/.github/workflows/headless-tests.yml
@@ -2,7 +2,7 @@ name: Headless tests
 
 on:
   pull_request:
-  # Called by master-release.yaml so a release is only published when the tests pass.
+  # Called by master-build.yaml so a release is only published when the tests pass.
   workflow_call:
 
 jobs:

--- a/.github/workflows/master-build.yaml
+++ b/.github/workflows/master-build.yaml
@@ -1,9 +1,9 @@
-name: Latest master
+name: Master build
 
 # Runs whenever a PR is merged (i.e. a push lands) on a release branch.
 # It builds every platform by reusing the existing package-* pipelines,
-# then publishes a single GitHub release per build, tagged with the version
-# and flagged "Latest". Releases from previous builds are left untouched.
+# then publishes a single GitHub prerelease per build, tagged with the
+# version. Releases from previous builds are left untouched.
 on:
   push:
     branches:
@@ -54,7 +54,7 @@ jobs:
     uses: ./.github/workflows/headless-tests.yml
 
   release:
-    name: Publish latest master release
+    name: Publish master prerelease
     needs: [android, linux-bundle, linux-deb, mac, windows, wasm, headless-tests]
     runs-on: ubuntu-24.04
     steps:
@@ -84,7 +84,7 @@ jobs:
           echo "Artifacts to publish:"
           ls -la dist
 
-      - name: Publish latest master release
+      - name: Publish master prerelease
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.meta.outputs.version }}
@@ -135,15 +135,13 @@ jobs:
           echo "Publishing assets:"
           printf '  %s\n' "${ASSETS[@]}"
 
-          # One release per build, tagged with the bare version and flagged as
-          # GitHub's "Latest". The version is derived from the (always
-          # increasing) commit count, so the tag is unique to this build and a
-          # release can never already exist for it. Releases from previous
-          # builds are left untouched.
+          # One prerelease per build, tagged with the bare version. The version
+          # is derived from the (always increasing) commit count, so the tag is
+          # unique to this build and a release can never already exist for it.
+          # Releases from previous builds are left untouched.
           #
-          # --prerelease=false is explicit: a release flagged as a prerelease
-          # cannot also be marked --latest (GitHub returns "Latest release
-          # cannot be draft or prerelease.").
+          # --prerelease flags the build as a GitHub prerelease; it is
+          # deliberately not marked --latest.
           publish() {
             # Start each attempt from a clean slate:
             # if an earlier attempt created the release but failed partway
@@ -155,8 +153,7 @@ jobs:
             gh release create "$VERSION" "${ASSETS[@]}" \
               --title "OpenLieroX ${VERSION_FULL}" \
               --notes "$NOTES" \
-              --prerelease=false \
-              --latest \
+              --prerelease \
               --target "$GITHUB_SHA"
           }
 

--- a/.github/workflows/publish-to-google-play.yaml
+++ b/.github/workflows/publish-to-google-play.yaml
@@ -1,7 +1,7 @@
 name: Publish to Google Play
 
 # Publishes the signed Android App Bundle to the Play Store beta track.
-# This only runs on merges to master (invoked by master-release.yaml via
+# This only runs on merges to master (invoked by master-build.yaml via
 # workflow_call), never on pull requests, so PRs build the bundle but
 # never publish it. The bundle is produced by package-android.yml and
 # passed across as the "openlierox-aab" artifact within the same run.


### PR DESCRIPTION
App-stores such as Flathub and F-droid and possibly Debian does not let us publish if we don't differentiate pre-releases from actuall releases that have some level of manual vetting

This PR changes the automatic builds to be pre-release so that we can have vetted version tagged as "releases"

Pre-release is a concept built into Github, and a pre-release can later be promoted to be a Release

See discussion here for background:
https://github.com/openlierox/openlierox/discussions/1112