### PR TITLE
Drop redundant console I/O thread joins

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -462,7 +462,7 @@ static void ParseArguments_BeforeInit(int argc, char *argv[]) {
 // Join the stdin-CLI and tee-stdout worker threads before exit():
 // exit() runs their static std::thread destructors,
 // and a still-joinable std::thread terminates the process.
-// Registered via atexit(), and also called directly on the early-exit paths.
+// Registered via atexit(), so it covers every exit() path.
 static void quitConsoleIOThreads() {
 	quitStdinCLISupport();
 	teeStdoutQuit();
@@ -576,7 +576,6 @@ static void ParseArguments_AfterInit(int argc, char *argv[])
 			InitializeLieroX();
 			TestCChannelRobustness();
 			ShutdownLieroX();
-			quitConsoleIOThreads();
 			exit(0);
 		} else
 #endif
@@ -609,9 +608,7 @@ static void ParseArguments_AfterInit(int argc, char *argv[])
 			// so the video, event, menu, sound and game subsystems are not up yet.
 			// ShutdownLieroX() tears those down and assumes they were inited,
 			// so we cannot run it here; just quit.
-			// We do need to join the console I/O threads first, though:
-			// exit() runs their static destructors, and a joinable std::thread aborts.
-			quitConsoleIOThreads();
+			// The console I/O threads are joined by the atexit() handler.
      		exit(0);
         } else
 


### PR DESCRIPTION
Follow-up cleanup to #1108.

`quitConsoleIOThreads()` is registered via `std::atexit()` in `real_main()`
right after the console I/O threads are started,
which is before `ParseArguments_AfterInit()` runs.
So `exit(0)` on the `-nettest` and `-help` paths already joins the
stdin-CLI and tee-stdout worker threads through the atexit handler,
and the explicit `quitConsoleIOThreads()` calls there were redundant.

Remove them so the atexit handler is the single mechanism for the
early-exit paths, and update the comments to match.

No behavior change. Verified on macOS:
`test_help_exits_cleanly` and `test_systemerror_stops_console_threads`
(plus `test_shutdown_messages_not_staircased`) still pass.
