### PR TITLE
Drain tee-stdout pipe before closing its read end

### DIFF
--- a/src/common/TeeStdoutHandler.cpp
+++ b/src/common/TeeStdoutHandler.cpp
@@ -262,11 +262,10 @@ void teeStdoutQuit(bool wait) {
 		close(STDOUT_FILENO);
 		close(STDERR_FILENO);
 		close(teeStdoutInfo.pipeend);
-		// Closing the write ends above already makes the tee thread's read()
-		// return EOF; it then drains the buffered output (the message above
-		// included) and exits. Closing the read end (pipestart) here would race
-		// that drain and could discard those final messages, so we close it only
-		// after the join below.
+		// Close the read end only after the join below:
+		// closing the write ends already makes the tee thread's read() hit EOF,
+		// so it drains the buffered output and exits;
+		// closing it early would race that drain and lose those bytes.
 		if(wait) {
 			if(teeStdoutInfo.proc) waitpid(teeStdoutInfo.proc, NULL, 0);
 			// A real join: unlike SDL_WaitThread it returns only once the

--- a/src/common/TeeStdoutHandler.cpp
+++ b/src/common/TeeStdoutHandler.cpp
@@ -261,14 +261,18 @@ void teeStdoutQuit(bool wait) {
 			notes << "wait for teeStdout handler quit" << endl;
 		close(STDOUT_FILENO);
 		close(STDERR_FILENO);
-		if(teeStdoutInfo.pipestart >= 0) close(teeStdoutInfo.pipestart);
 		close(teeStdoutInfo.pipeend);
-		// The forked process / thread should quit itself now.
+		// Closing the write ends above already makes the tee thread's read()
+		// return EOF; it then drains the buffered output (the message above
+		// included) and exits. Closing the read end (pipestart) here would race
+		// that drain and could discard those final messages, so we close it only
+		// after the join below.
 		if(wait) {
 			if(teeStdoutInfo.proc) waitpid(teeStdoutInfo.proc, NULL, 0);
 			// A real join: unlike SDL_WaitThread it returns only once the
 			// thread has fully finished, so freeing below cannot race it.
 			if(teeStdoutInfo.thread.joinable()) teeStdoutInfo.thread.join();
+			if(teeStdoutInfo.pipestart >= 0) close(teeStdoutInfo.pipestart);
 		}
 		// On the crash path we must not block; detach so the destructor of the
 		// static teeStdoutInfo cannot call std::terminate() on a joinable thread.


### PR DESCRIPTION
## Problem

On the multithreaded tee-stdout path (stdin CLI active),
`teeStdoutQuit()` could lose the final output written just before shutdown.
The tee thread reads stdout/stderr from a pipe
and writes it on to the real terminal and the log file.
On quit, the function wrote a last message into the pipe
and then closed the pipe's read end (`pipestart`)
while the tee thread was still reading from it.

Closing the write ends is the real EOF signal:
the thread drains whatever is buffered and exits.
Closing the read end early races that drain,
and on a loss the kernel discards the buffered bytes,
so the last messages never reach the terminal or the log.

It is a scheduler race, so it usually works locally
but fails intermittently under load,
surfacing as a flaky `test_systemerror_stops_console_threads`
(example CI failure: run 29091628125).

## Fix

Close the read end only after the thread is joined,
once it has drained.
On the crash path the detached thread ends on the write-end EOF anyway,
so closing the read end there was unnecessary too.

## Testing

Full headless suite green locally on macOS (15 passed),
including the previously flaky `test_terminal.py` cases.

Fixes #1117
