### PR TITLE
Fix single-shot large negative speed encoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ IF(OLX_TESTS)
 		${OLXROOTDIR}/tests/unit/test_CInput.cpp
 		${OLXROOTDIR}/tests/unit/test_omfgscript_parser.cpp
 		${OLXROOTDIR}/tests/unit/test_linenoise.cpp
+		${OLXROOTDIR}/tests/unit/test_CShootList.cpp
 		${ALL_SRCS} ${OLX_WIN_RESOURCES})
 	SET_TARGET_PROPERTIES(olx_tests PROPERTIES
 		RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"

--- a/include/CShootList.h
+++ b/include/CShootList.h
@@ -129,6 +129,7 @@ public:
 	AbsTime		getStartTime()			{ return m_fStartTime; }
 	AbsTime		getLastWrite()			{ return m_fLastWrite; }
 
+	friend void test_CShootListSpeedRoundtrip();  // unit test: writeSingle/readSingle
 };
 
 

--- a/src/common/CShootList.cpp
+++ b/src/common/CShootList.cpp
@@ -178,17 +178,20 @@ void CShootList::writeSingle( CBytestream *bs, const Version& receiverVer, int i
 	else
 		bs->writeByte( psShot->nAngle );
 
+	// Same structure as writeMulti() and readSingle():
+	// a large negative speed sets both flags, so the branches must be
+	// independent ifs, not an else-if that hides the large-and-negative case.
+	int speed = psShot->nSpeed;
 	if( flags & SMF_LARGESPEED )
-		bs->writeByte( psShot->nSpeed-255 );
-	else if( flags & SMF_NEGSPEED ) {
+		speed = psShot->nSpeed-255;
+	if( flags & SMF_NEGSPEED ) {
 		if(flags & SMF_LARGESPEED)
-			bs->writeByte( (-psShot->nSpeed)-255 );
+			speed = (-psShot->nSpeed)-255;
 		else
-			bs->writeByte( -psShot->nSpeed );
+			speed = -psShot->nSpeed;
 	}
-	else
-		bs->writeByte( psShot->nSpeed );
-	
+	bs->writeByte( speed );
+
 	if(receiverVer >= OLXBetaVersion(0,58,1)) {
 		bs->ResetBitPos();
 		bs->writeBit(psShot->release);

--- a/src/common/CShootList.cpp
+++ b/src/common/CShootList.cpp
@@ -178,18 +178,14 @@ void CShootList::writeSingle( CBytestream *bs, const Version& receiverVer, int i
 	else
 		bs->writeByte( psShot->nAngle );
 
-	// Same structure as writeMulti() and readSingle():
-	// a large negative speed sets both flags, so the branches must be
-	// independent ifs, not an else-if that hides the large-and-negative case.
+	// Speed byte: negate for SMF_NEGSPEED,
+	// then drop the 255 offset for SMF_LARGESPEED.
+	// readSingle() inverts this (add 255, then negate).
 	int speed = psShot->nSpeed;
+	if( flags & SMF_NEGSPEED )
+		speed = -speed;
 	if( flags & SMF_LARGESPEED )
-		speed = psShot->nSpeed-255;
-	if( flags & SMF_NEGSPEED ) {
-		if(flags & SMF_LARGESPEED)
-			speed = (-psShot->nSpeed)-255;
-		else
-			speed = -psShot->nSpeed;
-	}
+		speed -= 255;
 	bs->writeByte( speed );
 
 	if(receiverVer >= OLXBetaVersion(0,58,1)) {
@@ -286,15 +282,10 @@ void CShootList::writeMulti( CBytestream *bs, const Version& receiverVer, int in
 		bs->writeByte( psShot->nAngle );
 
 	int speed = psShot->nSpeed;
-
+	if( flags & SMF_NEGSPEED )
+		speed = -speed;
 	if( flags & SMF_LARGESPEED )
-		speed = psShot->nSpeed-255;
-	if( flags & SMF_NEGSPEED ) {
-		if(flags & SMF_LARGESPEED)
-			speed = (-psShot->nSpeed)-255;
-		else
-			speed = -psShot->nSpeed;
-	}
+		speed -= 255;
 
 	bs->writeByte( speed );
 	
@@ -462,19 +453,15 @@ void CShootList::readSingle( CBytestream *bs, const Version& senderVer, int max_
 
 	psShot->nAngle = bs->readByte();
 	int speed = bs->readByte();
-	psShot->nSpeed = speed;
 
 	if( flags & SMF_LARGEANGLE )
 		psShot->nAngle += 255;
 
 	if( flags & SMF_LARGESPEED )
-		psShot->nSpeed = speed+255;
-	if( flags & SMF_NEGSPEED ) {
-		if( flags & SMF_LARGESPEED )
-			psShot->nSpeed = -(speed+255);
-		else
-			psShot->nSpeed = -speed;
-	}
+		speed += 255;
+	if( flags & SMF_NEGSPEED )
+		speed = -speed;
+	psShot->nSpeed = speed;
 
 
 	// Convert the pos
@@ -521,19 +508,15 @@ void CShootList::readMulti( CBytestream *bs, const Version& senderVer, int max_w
 
 	psShot->nAngle = bs->readByte();
 	int speed = bs->readByte();
-	psShot->nSpeed = speed;
 
 	if( flags & SMF_LARGEANGLE )
 		psShot->nAngle += 255;
 
 	if( flags & SMF_LARGESPEED )
-		psShot->nSpeed = speed+255;
-	if( flags & SMF_NEGSPEED ) {
-		if( flags & SMF_LARGESPEED )
-			psShot->nSpeed = -(speed+255);
-		else
-			psShot->nSpeed = -speed;
-	}
+		speed += 255;
+	if( flags & SMF_NEGSPEED )
+		speed = -speed;
+	psShot->nSpeed = speed;
 
 	// Convert the pos
 	psShot->cPos = CVec( (float)x, (float)y );

--- a/tests/unit/test_CShootList.cpp
+++ b/tests/unit/test_CShootList.cpp
@@ -12,14 +12,13 @@
 #include "CShootList.h"
 
 // Regression for #1115:
-// a single shot with a large negative relative speed (nSpeed < -255)
-// sets both SMF_LARGESPEED and SMF_NEGSPEED.
-// writeSingle() used an else-if that hid the large-and-negative branch,
-// so it sent nSpeed-255 while readSingle() expects (-nSpeed)-255,
-// and the shot decoded with the wrong speed.
-// writeSingle() and readSingle() must round-trip every speed.
+// a single shot with a large negative speed (nSpeed < -255)
+// sets both SMF_LARGESPEED and SMF_NEGSPEED,
+// which writeSingle() once mis-encoded.
+// Every speed must round-trip writeSingle() -> readSingle().
 void test_CShootListSpeedRoundtrip() {
-	const Version ver = OLXBetaVersion(0,57,0);  // before the release bit; keeps the packet simple
+	// before the release bit; keeps the packet simple
+	const Version ver = OLXBetaVersion(0,57,0);
 	const int max_weapon_id = 10;
 
 	const int speeds[] = { 0, 50, 255, 400, -100, -255, -300, -510 };

--- a/tests/unit/test_CShootList.cpp
+++ b/tests/unit/test_CShootList.cpp
@@ -1,0 +1,55 @@
+/*
+ *  Unit test for CShootList shot encoding.
+ */
+
+#include "unittest.h"
+
+// CShootList.h is not self-contained; pull in its types first, as the .cpp does.
+#include "olx-types.h"
+#include "CVec.h"
+#include "Version.h"
+#include "CBytestream.h"
+#include "CShootList.h"
+
+// Regression for #1115:
+// a single shot with a large negative relative speed (nSpeed < -255)
+// sets both SMF_LARGESPEED and SMF_NEGSPEED.
+// writeSingle() used an else-if that hid the large-and-negative branch,
+// so it sent nSpeed-255 while readSingle() expects (-nSpeed)-255,
+// and the shot decoded with the wrong speed.
+// writeSingle() and readSingle() must round-trip every speed.
+void test_CShootListSpeedRoundtrip() {
+	const Version ver = OLXBetaVersion(0,57,0);  // before the release bit; keeps the packet simple
+	const int max_weapon_id = 10;
+
+	const int speeds[] = { 0, 50, 255, 400, -100, -255, -300, -510 };
+	for(size_t i = 0; i < sizeof(speeds)/sizeof(speeds[0]); ++i) {
+		CShootList src;
+		CHECK(src.Initialize());
+		shoot_t& s = src.m_psShoot[0];
+		s.fTime = TimeDiff();
+		s.nWeapon = 5;
+		s.cPos = CVec(10, 20);
+		s.cWormVel = CVec(0, 0);
+		s.nAngle = 90;
+		s.nRandom = 42;
+		s.nSpeed = speeds[i];
+		s.nWormID = 3;
+		s.release = false;
+		src.m_nNumShootings = 1;
+
+		CBytestream bs;
+		src.writeSingle(&bs, ver, 0);
+
+		bs.ResetPosToBegin();
+		bs.readByte();  // skip the S2C_SINGLESHOOT id
+
+		CShootList dst;
+		CHECK(dst.Initialize());
+		dst.readSingle(&bs, ver, max_weapon_id);
+
+		CHECK(dst.m_psShoot[0].nSpeed == speeds[i]);
+		CHECK(dst.m_psShoot[0].nAngle == 90);
+		CHECK(dst.m_psShoot[0].nWormID == 3);
+	}
+}

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -34,6 +34,7 @@ void test_OmfgScriptShallowOk();
 void test_OmfgScriptHugeIntegerLiteral();
 void test_OmfgScriptHugeNumberFirstToken();
 void test_LinenoiseRefreshLineZeroCols();
+void test_CShootListSpeedRoundtrip();
 
 int main() {
 	printf("Running OLX unit tests...\n");
@@ -54,6 +55,7 @@ int main() {
 	test_OmfgScriptHugeIntegerLiteral();
 	test_OmfgScriptHugeNumberFirstToken();
 	test_LinenoiseRefreshLineZeroCols();
+	test_CShootListSpeedRoundtrip();
 
 	if(g_olxTestFailures) {
 		printf("FAILED: %d check(s)\n", g_olxTestFailures);


### PR DESCRIPTION
Fixes #1115.

A single shot with a large negative relative speed (`nSpeed < -255`)
sets both `SMF_LARGESPEED` and `SMF_NEGSPEED`.
`writeSingle()` chained the speed byte with `else if`,
so the large-and-negative case never reached its own branch:
it sent `nSpeed-255` while `readSingle()` reconstructs `-(byte+255)`,
so `nSpeed = -300` decoded as `-468` and the shot desynced.

The fix gives `writeSingle()` the same two independent `if`s
that `writeMulti()` and the decoder already use,
so every speed round-trips.

### Verification

New unit test `test_CShootListSpeedRoundtrip`
drives `writeSingle()` -> `readSingle()` across a range of speeds
(normal, large positive, small and large negative)
and checks each round-trips.
`writeSingle` and the shot buffer are private,
so the test reaches them through a single `friend` declaration.

Confirmed the test fails without the fix
(exactly the two large-negative cases) and passes with it;
full `olx_tests` suite green and `openlierox` builds.
