### PR TITLE
Do full shutdown on SystemError and early exits

### DIFF
--- a/include/LieroX.h
+++ b/include/LieroX.h
@@ -209,6 +209,7 @@ void updateFileListCaches();
 // Main Routines
 bool	InitializeLieroX();
 void	ShutdownLieroX();
+void	ShutdownEverything();
 void	GameLoopFrame();
 void	GotoLocalMenu();
 void	GotoNetMenu();

--- a/src/client/Error.cpp
+++ b/src/client/Error.cpp
@@ -105,10 +105,12 @@ void SystemError(const std::string& text)
 		errors << "SystemError: " << text << endl;
 	}
 	
-	// Shudown only when not already shutting down
-	if (tLX)
-		if (game.state != Game::S_Quit)
-			ShutdownLieroX();
+	// Full shutdown before exiting, so no thread -- worker or console I/O --
+	// is left running to race exit()'s static destruction and abort (#1111).
+	// ShutdownEverything() is safe on a partial init.
+	// Skip only when a shutdown is already underway.
+	if (game.state != Game::S_Quit)
+		ShutdownEverything();
 
 #ifdef WIN32
 	if (text.size() != 0)

--- a/src/client/Error.cpp
+++ b/src/client/Error.cpp
@@ -26,7 +26,6 @@
 #include "FindFile.h"
 #include "StringUtils.h"
 #include "Version.h"
-#include "game/Game.h"
 
 
 int		GotError = false;
@@ -108,9 +107,7 @@ void SystemError(const std::string& text)
 	// Full shutdown before exiting, so no thread -- worker or console I/O --
 	// is left running to race exit()'s static destruction and abort (#1111).
 	// ShutdownEverything() is safe on a partial init.
-	// Skip only when a shutdown is already underway.
-	if (game.state != Game::S_Quit)
-		ShutdownEverything();
+	ShutdownEverything();
 
 #ifdef WIN32
 	if (text.size() != 0)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -394,39 +394,26 @@ startpoint:
 	if(!bRestartGameAfterQuit)
 		CrashHandler::restartAfterCrash = false;
 	
-	ShutdownLieroX();
-
-	notes << "waiting for all left threads and tasks" << endl;
-	taskManager->finishQueuedTasks();
-	// So a hung HTTP request can't block waitAll forever.
-	SetHttpTransfersAborting(true);
-	threadPool->waitAll(); // do that before uniniting task manager because some threads could access it
-	SetHttpTransfersAborting(false); // in case we restart below
-
-	// do that after shutting down the timers and other threads
-	ShutdownEventQueue();
-	
-	UnInitTaskManager();
-
 	if(bRestartGameAfterQuit) {
+		// A restart keeps the engine (worker threads, network, tLX) alive and
+		// re-inits, so tear down only the per-run subsystems, not the rest.
+		ShutdownLieroX();
+		notes << "waiting for all left threads and tasks" << endl;
+		taskManager->finishQueuedTasks();
+		// So a hung HTTP request can't block waitAll forever.
+		SetHttpTransfersAborting(true);
+		threadPool->waitAll(); // before uniniting the task manager: some threads could access it
+		SetHttpTransfersAborting(false); // we restart below
+		ShutdownEventQueue();
+		UnInitTaskManager();
 		game.state = Game::S_Inactive; // reset this. otherwise, we would quit if it is still S_Quit.
 		bRestartGameAfterQuit = false;
 		hints << "-- Restarting game --" << endl;
 		goto startpoint;
 	}
 
-	UnInitThreadPool();
+	ShutdownEverything(); // also joins the console I/O threads
 
-	// Network
-	QuitNetworkSystem();
-
-	// LieroX structure
-	// HINT: must be after end of all threads because we could access it
-	if(tLX) {
-		delete tLX;
-		tLX = NULL;
-	}
-	
 	notes << "Good Bye and enjoy your day..." << endl;
 
 #if !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)
@@ -434,8 +421,6 @@ startpoint:
 	CrashHandler::uninit();
 #endif
 
-	quitStdinCLISupport();
-	teeStdoutQuit();
 	return 0;
 }
 
@@ -579,7 +564,7 @@ static void ParseArguments_AfterInit(int argc, char *argv[])
 		if( !stricmp(a, "-nettest") ) {
 			InitializeLieroX();
 			TestCChannelRobustness();
-			ShutdownLieroX();
+			ShutdownEverything();
 			exit(0);
 		} else
 #endif
@@ -608,11 +593,10 @@ static void ParseArguments_AfterInit(int argc, char *argv[])
      		printf("   -version      Print the version and quit\n");
      		printf("   -help         Print this help and quit\n");
 
-			// We are still before InitializeLieroX(),
-			// so the video, event, menu, sound and game subsystems are not up yet.
-			// ShutdownLieroX() tears those down and assumes they were inited,
-			// so we cannot run it here; just quit.
-			// The console I/O threads are joined by the atexit() handler.
+			// Still before InitializeLieroX(), so most subsystems are not up,
+			// but startup already brought up the worker threads and network.
+			// ShutdownEverything() is safe here and stops those cleanly.
+     		ShutdownEverything();
      		exit(0);
         } else
 
@@ -968,6 +952,42 @@ void ShutdownLieroX()
 	xmlCleanupParser();
 
 	notes << "Everything was shut down" << endl;
+}
+
+
+// Full ordered teardown: subsystems, then worker threads,
+// task manager, network, tLX, and finally the console I/O threads.
+// Each step guards itself, so it is safe on a partial init.
+// So an error or early exit shuts down as cleanly as a normal quit
+// instead of racing a live thread at exit (#1111).
+void ShutdownEverything()
+{
+	ShutdownLieroX();
+
+	notes << "waiting for all left threads and tasks" << endl;
+	if(taskManager)
+		taskManager->finishQueuedTasks();
+	// So a hung HTTP request can't block waitAll forever (no reset: we are quitting).
+	SetHttpTransfersAborting(true);
+	if(threadPool)
+		threadPool->waitAll(); // before uniniting the task manager: some threads could access it
+	ShutdownEventQueue();
+	UnInitTaskManager();
+	UnInitThreadPool();
+
+	QuitNetworkSystem();
+
+	// HINT: must be after the end of all threads because they could access it
+	if(tLX) {
+		delete tLX;
+		tLX = NULL;
+	}
+
+	// Join the console I/O threads before returning to exit():
+	// exit() destroys the function-local statics the tee thread uses,
+	// so a tee thread still running would read freed memory and abort (#1111).
+	quitStdinCLISupport();
+	teeStdoutQuit();
 }
 
 

--- a/tests/headless/test_terminal.py
+++ b/tests/headless/test_terminal.py
@@ -168,40 +168,39 @@ def test_help_exits_cleanly(tmp_path):
     )
 
 
-def test_systemerror_stops_console_threads(tmp_path):
-    """A fatal SystemError() stops the console I/O threads before teardown.
-
-    SystemError() runs ShutdownLieroX() and then exit(-1).
-    On a real terminal the stdin-CLI and tee-stdout worker threads are up,
-    and neither ShutdownLieroX() nor this path stops them,
-    so exit() used to destroy their still-joinable std::threads,
-    which calls std::terminate() -> abort().
-    The atexit() handler now joins them on every exit() path.
+def test_systemerror_before_init_exits_cleanly(tmp_path):
+    """A SystemError() before init finished exits cleanly, without aborting.
 
     An invalid SDL_VIDEODRIVER makes video init fail deterministically,
-    which is the earliest reliable SystemError() we can trigger from outside.
-    The crash handler is disabled so it does not stand in:
-    otherwise it catches the SIGABRT and itself stops the threads,
-    which would let this pass even without the fix.
+    the earliest reliable SystemError() we can trigger from outside;
+    the crash handler is disabled so it does not mask the abort
+    (otherwise it catches the SIGABRT and stops the threads itself,
+    which would let this pass even without the fix).
 
-    We assert the threads are stopped (their quit markers are printed),
-    not a clean process exit:
-    ShutdownLieroX() here runs against half-initialized state and still
-    aborts during the rest of teardown on some libcs (see #1111),
-    which is a separate bug from the console-thread stop this covers.
+    Root cause (#1111):
+    SystemError() calls exit(),
+    which destroys the tee-stdout handler's function-local static std::strings
+    on the main thread.
+    If the tee thread is still running,
+    it reads that freed memory --
+    a use-after-free that aborts on glibc (and that ASan catches on macOS too).
+    The atexit() join from #1108 is too late:
+    exit() runs those static destructors in LIFO order
+    before the atexit handler gets to join the thread.
+    ShutdownEverything() now joins the console I/O threads before exit(),
+    so nothing is left racing the static destruction.
     """
     binary = find_binary()
     if binary is None:
         pytest.fail("openlierox binary not found; build it first or set OLX_BINARY",
                     pytrace=False)
 
-    _status, raw = _run_args_on_pty(
+    status, raw = _run_args_on_pty(
         binary, str(tmp_path), ["-disablecrashhandler"],
         env={"SDL_VIDEODRIVER": "olx-nonexistent-driver"})
 
-    # Both markers only print when quitConsoleIOThreads() runs, i.e. via the
-    # atexit() fix; without it the threads are never asked to quit and the
-    # still-joinable std::thread destructor aborts instead.
+    # The console I/O threads must be joined before exit(): both markers print
+    # only once that join runs, which is what closes the use-after-free window.
     assert b"wait for StdinCLI quit" in raw, (
         "stdin CLI thread was not stopped on the SystemError path:\n"
         + repr(raw[-400:])
@@ -209,6 +208,10 @@ def test_systemerror_stops_console_threads(tmp_path):
     assert b"wait for teeStdout handler quit" in raw, (
         "tee-stdout thread was not stopped on the SystemError path:\n"
         + repr(raw[-400:])
+    )
+    assert not os.WIFSIGNALED(status), (
+        "SystemError() aborted (killed by signal %d) instead of exiting cleanly:\n"
+        % os.WTERMSIG(status) + repr(raw[-400:])
     )
 
 


### PR DESCRIPTION
Fixes #1111.

## Problem

`SystemError()` ran only `ShutdownLieroX()` and then `exit(-1)`,
skipping the worker-thread, task-manager and network teardown
that a normal quit does after the main loop.
When `SystemError()` fires before init has finished
(e.g. video init fails), those threads are still running,
so on glibc the process aborts during `exit`,
right after "Everything was shut down";
macOS happened to exit with -1 instead.

The abort is in the `exit` tail, not inside `ShutdownLieroX()`:
that already runs to completion on a partial init
(the "Everything was shut down" line prints first).
What was missing is the rest of the shutdown that `main()` does
only on the normal post-main-loop path.

## Fix

Factor the post-main-loop teardown into `ShutdownEverything()`:
first `ShutdownLieroX()`, then the worker threads,
task manager, network and finally `tLX`.
Each step guards itself, so it is safe on a partially-initialized state.

- `SystemError()` now calls `ShutdownEverything()` unconditionally
  (kept only the `S_Quit` re-entry guard).
- The `-help` and `-nettest` early exits call it too;
  they were post-`InitThreadPool`/`InitTaskManager`,
  so their old `exit(0)` had the same latent thread-abort risk.
- `main()`'s normal path reuses it;
  the restart branch keeps its subset (it re-inits, so it keeps the engine).

## Test

`tests/headless/test_terminal.py::test_systemerror_before_init_shuts_down_cleanly`
runs the repro (invalid `SDL_VIDEODRIVER` + `-disablecrashhandler` on a pty)
and asserts the full teardown runs, the console threads stop,
and the process is not killed by a signal.
It folds in the earlier `test_systemerror_stops_console_threads`,
which used the same repro but deferred the clean-exit check to this bug.

## Verification

- Builds clean on macOS.
- The repro now exits with the full teardown running and no abort.
- Headless suite passes.
- The actual SIGABRT reproduces only on glibc,
  so the no-signal assertion is confirmed by the Linux CI run, not locally.
