### PR TITLE
Keep arrow keys inside a focused text box

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ IF(OLX_TESTS)
 		${OLXROOTDIR}/tests/unit/test_loopback.cpp
 		${OLXROOTDIR}/tests/unit/test_challenge_table.cpp
 		${OLXROOTDIR}/tests/unit/test_CInput.cpp
+		${OLXROOTDIR}/tests/unit/test_CGuiLayout.cpp
 		${OLXROOTDIR}/tests/unit/test_omfgscript_parser.cpp
 		${OLXROOTDIR}/tests/unit/test_linenoise.cpp
 		${ALL_SRCS} ${OLX_WIN_RESOURCES})

--- a/include/DeprecatedGUI/CGuiLayout.h
+++ b/include/DeprecatedGUI/CGuiLayout.h
@@ -120,6 +120,8 @@ public:
 	void		Error(int ErrorCode, const std::string& text);
 
 	gui_event_t	*Process();
+	// Widget an arrow key would move focus to, or NULL for no navigation.
+	CWidget		*keyboardNavigationTarget(int keysym) const;
 	void		Draw(SDL_Surface * bmpDest);
 	// Shift every widget by (dx,dy). Used to center an in-game popup layout
 	// on a wider-than-640 screen (see VideoPostProcessor::popupCenterOffsetX).

--- a/include/DeprecatedGUI/CTextbox.h
+++ b/include/DeprecatedGUI/CTextbox.h
@@ -136,6 +136,8 @@ public:
 	int		KeyDown(UnicodeChar c, int keysym, const ModifiersState& modstate);
 	int		KeyUp(UnicodeChar c, int keysym, const ModifiersState& modstate);
 
+	bool	handlesArrowKeys() const override		{ return true; }
+
 	void	Draw(SDL_Surface * bmpDest);
 
 	uintptr_t	SendMessage(int iMsg, uintptr_t Param1, uintptr_t Param2);

--- a/include/DeprecatedGUI/CWidget.h
+++ b/include/DeprecatedGUI/CWidget.h
@@ -141,6 +141,9 @@ public:
 	bool			CanLoseFocus()				{ return bCanLoseFocus; }
 	void			setLoseFocus(bool _f)			{ bCanLoseFocus = _f; }
 
+	// Widget uses the arrow keys itself (e.g. a textbox cursor); see #815.
+	virtual bool	handlesArrowKeys() const		{ return false; }
+
 	void			SetupEvents(generic_events_t *Events);	// Not used anywhere, should be removed
 	void			ProcessEvent(int Event);	// Not used anywhere, should be removed
 

--- a/src/client/DeprecatedGUI/CGuiLayout.cpp
+++ b/src/client/DeprecatedGUI/CGuiLayout.cpp
@@ -240,6 +240,45 @@ bool CGuiLayout::Build()
 }
 
 
+////////////////////
+// Widget an arrow key would move focus to, or NULL for no navigation
+CWidget *CGuiLayout::keyboardNavigationTarget(int keysym) const
+{
+	// A widget that uses the arrow keys itself (e.g. a textbox cursor) keeps them;
+	// menu navigation must not steal them (#815).
+	if (!bCanFocus || cFocused == NULL || !cFocused->CanLoseFocus() || cFocused->handlesArrowKeys())
+		return NULL;
+
+	CWidget *selected = NULL;
+	if (keysym == SDLK_UP || keysym == SDLK_LEFT) {
+		int posmin = 0;
+		int posmax = cFocused->getX() + cFocused->getY() * 0x10000 + cFocused->getKeyboardNavigationOrder() * 0x10000000;
+		for(auto widget: cWidgets) {
+			if (!widget->getEnabled() || widget == cFocused || widget->getType() == wid_Label)
+				continue;
+			int pos = widget->getX() + widget->getY() * 0x10000 + widget->getKeyboardNavigationOrder() * 0x10000000;
+			if (posmin < pos && posmax > pos) {
+				posmin = pos;
+				selected = widget;
+			}
+		}
+	} else if (keysym == SDLK_DOWN || keysym == SDLK_RIGHT) {
+		int posmin = cFocused->getX() + cFocused->getY() * 0x10000 + cFocused->getKeyboardNavigationOrder() * 0x10000000;
+		int posmax = INT_MAX;
+		for(auto widget: cWidgets) {
+			if (!widget->getEnabled() || widget == cFocused || widget->getType() == wid_Label)
+				continue;
+			int pos = widget->getX() + widget->getY() * 0x10000 + widget->getKeyboardNavigationOrder() * 0x10000000;
+			if (posmin < pos && posmax > pos) {
+				posmax = pos;
+				selected = widget;
+			}
+		}
+	}
+	return selected;
+}
+
+
 ///////////////////
 // Process all the widgets
 gui_event_t *CGuiLayout::Process()
@@ -359,37 +398,9 @@ gui_event_t *CGuiLayout::Process()
 			if (kbev.down && (kbev.sym == SDLK_UP || kbev.sym == SDLK_LEFT || kbev.sym == SDLK_DOWN || kbev.sym == SDLK_RIGHT)) {
 
 				bKeyboardNavigation = true;
-				CWidget * selected = NULL;
+				CWidget * selected = keyboardNavigationTarget(kbev.sym);
 
-				if (!bCanFocus || cFocused == NULL || !cFocused->CanLoseFocus()) {
-					// Do nothing
-				} else if (kbev.sym == SDLK_UP || kbev.sym == SDLK_LEFT) {
-					int posmin = 0;
-					int posmax = cFocused->getX() + cFocused->getY() * 0x10000 + cFocused->getKeyboardNavigationOrder() * 0x10000000;
-					for(auto widget: cWidgets) {
-						if (!widget->getEnabled() || widget == cFocused || widget->getType() == wid_Label)
-							continue;
-						int pos = widget->getX() + widget->getY() * 0x10000 + widget->getKeyboardNavigationOrder() * 0x10000000;
-						if (posmin < pos && posmax > pos) {
-							posmin = pos;
-							selected = widget;
-						}
-					}
-				} else if (kbev.sym == SDLK_DOWN || kbev.sym == SDLK_RIGHT) {
-					int posmin = cFocused->getX() + cFocused->getY() * 0x10000 + cFocused->getKeyboardNavigationOrder() * 0x10000000;
-					int posmax = INT_MAX;
-					for(auto widget: cWidgets) {
-						if (!widget->getEnabled() || widget == cFocused || widget->getType() == wid_Label)
-							continue;
-						int pos = widget->getX() + widget->getY() * 0x10000 + widget->getKeyboardNavigationOrder() * 0x10000000;
-						if (posmin < pos && posmax > pos) {
-							posmax = pos;
-							selected = widget;
-						}
-					}
-				}
-
-				if (cFocused && selected && cFocused != selected) {
+				if (selected && cFocused != selected) {
 					cFocused->setFocused(false);
 					cFocused = selected;
 					widgetSelectedWithKeyboard = true;

--- a/tests/unit/test_CGuiLayout.cpp
+++ b/tests/unit/test_CGuiLayout.cpp
@@ -1,0 +1,79 @@
+/*
+ *  Unit tests for CGuiLayout keyboard navigation (CGuiLayout.h).
+ *
+ *  Regression test for #815
+ *  ("Using arrow keys to move text cursor messes up mouse"):
+ *  while a text box is focused the arrow keys move its text cursor,
+ *  so menu arrow-key navigation must not also fire
+ *  and warp the mouse to another widget.
+ */
+
+#include "unittest.h"
+#include "DeprecatedGUI/CGuiLayout.h"
+#include "DeprecatedGUI/CWidget.h"
+#include "DeprecatedGUI/CTextbox.h"
+
+#include <SDL.h>
+
+using namespace DeprecatedGUI;
+
+namespace {
+
+// A minimal navigable widget, so the layout test needs no fonts or graphics.
+// handlesArrowKeys() is settable to model both a plain button (false)
+// and a text-editing widget that owns the arrow keys (true).
+class TestWidget : public CWidget {
+public:
+	TestWidget(WidgetType_t type, bool ownsArrows)
+		: bOwnsArrows(ownsArrows) { iType = type; }
+
+	bool	handlesArrowKeys() const override { return bOwnsArrows; }
+
+	void	Create() override {}
+	void	Destroy() override {}
+	int		MouseOver(mouse_t*) override { return -1; }
+	int		MouseUp(mouse_t*, int) override { return -1; }
+	int		MouseDown(mouse_t*, int) override { return -1; }
+	int		MouseWheelUp(mouse_t*) override { return -1; }
+	int		MouseWheelDown(mouse_t*) override { return -1; }
+	int		KeyDown(UnicodeChar, int, const ModifiersState&) override { return -1; }
+	int		KeyUp(UnicodeChar, int, const ModifiersState&) override { return -1; }
+	void	Draw(SDL_Surface*) override {}
+	uintptr_t	SendMessage(int, uintptr_t, uintptr_t) override { return 0; }
+	uintptr_t	SendMessage(int, const std::string&, uintptr_t) override { return 0; }
+	uintptr_t	SendMessage(int, std::string*, uintptr_t) override { return 0; }
+
+private:
+	bool	bOwnsArrows;
+};
+
+}
+
+void test_GuiLayoutArrowKeysStayInTextbox() {
+	// A text box reports it uses the arrow keys itself; a plain button does not.
+	CTextbox textbox;
+	CHECK(textbox.handlesArrowKeys());
+	TestWidget plainButton(wid_Button, false);
+	CHECK(!plainButton.handlesArrowKeys());
+
+	// A layout with a text field on the left and a button on its right.
+	CGuiLayout layout;
+	TestWidget* field = new TestWidget(wid_Textbox, true);
+	TestWidget* button = new TestWidget(wid_Button, false);
+	layout.Add(field, 1, 10, 10, 50, 20);
+	layout.Add(button, 2, 100, 10, 50, 20);
+
+	// From the button, Left arrow navigates to the field: navigation works.
+	layout.FocusWidget(2);
+	CHECK(layout.getFocusedWidget() == button);
+	CHECK(layout.keyboardNavigationTarget(SDLK_LEFT) == field);
+
+	// From the field, the arrow keys belong to the text cursor,
+	// so navigation must not happen and the mouse must not be warped (#815).
+	layout.FocusWidget(1);
+	CHECK(layout.getFocusedWidget() == field);
+	CHECK(layout.keyboardNavigationTarget(SDLK_LEFT) == NULL);
+	CHECK(layout.keyboardNavigationTarget(SDLK_RIGHT) == NULL);
+
+	layout.Shutdown();
+}

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -28,6 +28,7 @@ void test_ChallengeSurvivesStaleConnect();
 void test_ChallengeReissueIsIdempotent();
 void test_ChallengeConsumeRepeated();
 void test_KeyboardDownOnceFiresOncePerPress();
+void test_GuiLayoutArrowKeysStayInTextbox();
 void test_OmfgScriptDeepExpression();
 void test_OmfgScriptDeepPropertyBlocks();
 void test_OmfgScriptShallowOk();
@@ -48,6 +49,7 @@ int main() {
 	test_ChallengeReissueIsIdempotent();
 	test_ChallengeConsumeRepeated();
 	test_KeyboardDownOnceFiresOncePerPress();
+	test_GuiLayoutArrowKeysStayInTextbox();
 	test_OmfgScriptDeepExpression();
 	test_OmfgScriptDeepPropertyBlocks();
 	test_OmfgScriptShallowOk();


### PR DESCRIPTION
Fixes #815.

## Problem

Menu arrow-key navigation (added for 0.58) moves widget focus
and warps the mouse pointer to the newly focused widget on every arrow press.
Nothing stopped it from firing while a text box was focused,
so pressing Left/Right to move the text cursor
also jumped menu focus and jerked the mouse around.
This is the regression the reporter saw between 0.58 rc3 and 0.58.

The `if (ev >= 0) return` guard that was meant to suppress this is unreliable:
`ev` only holds the last queued event's result,
and `CTextbox::KeyUp` always returns `TXT_NONE`,
so a key-up in the same frame lets navigation run anyway.
Up/Down are never consumed by the text box at all.

## Fix

A focused widget that uses the arrow keys itself now keeps them.

- `CWidget::handlesArrowKeys()` (virtual, `false` by default; `true` for `CTextbox`).
- The navigation search moves out of `CGuiLayout::Process()`
  into `CGuiLayout::keyboardNavigationTarget()`,
  which returns no target when the focused widget reports it handles arrows.
  That is both the fix and a seam that can be unit-tested
  without driving the whole menu loop.

Tab and mouse clicks still move focus out of a text box, as before.

## Test

`tests/unit/test_CGuiLayout.cpp` (in the `olx_tests` suite):
from a focused button an arrow still navigates,
but from a focused text box `keyboardNavigationTarget()` returns none,
so no focus change and no mouse warp.
Removing just the new guard makes the Right-arrow case fail,
confirming the test reproduces #815.
