### PR TITLE
Interrupt hung HTTP requests to unblock shutdown

### DIFF
--- a/include/HTTP.h
+++ b/include/HTTP.h
@@ -35,10 +35,7 @@ typedef void CURL;
 //
 void AutoSetupHTTPProxy();
 
-// Signal every in-flight CHttp transfer to abort as soon as possible,
-// or clear that signal again. Set on shutdown so a hung request
-// (a master server that accepts the connection but never answers)
-// can't block the thread-pool wait forever.
+// Make all in-flight transfers abort (or clear the flag); set on shutdown.
 void SetHttpTransfersAborting(bool aborting);
 
 //

--- a/include/HTTP.h
+++ b/include/HTTP.h
@@ -35,6 +35,12 @@ typedef void CURL;
 //
 void AutoSetupHTTPProxy();
 
+// Signal every in-flight CHttp transfer to abort as soon as possible,
+// or clear that signal again. Set on shutdown so a hung request
+// (a master server that accepts the connection but never answers)
+// can't block the thread-pool wait forever.
+void SetHttpTransfersAborting(bool aborting);
+
 //
 // Classes
 //

--- a/src/common/HTTP.cpp
+++ b/src/common/HTTP.cpp
@@ -18,6 +18,7 @@
 
 
 #include <cassert>
+#include <atomic>
 #ifdef WIN32
 	#include <windows.h>
 	#include <wininet.h>
@@ -43,6 +44,13 @@
 // Some basic defines
 #define		HTTP_TIMEOUT	10	// Filebase became laggy lately, so increased that from 5 seconds
 //#define		BUFFER_LEN		8192
+
+// Set on shutdown to make every running transfer return promptly.
+static std::atomic<bool> httpTransfersAborting(false);
+
+void SetHttpTransfersAborting(bool aborting) {
+	httpTransfersAborting = aborting;
+}
 
 
 //
@@ -153,29 +161,33 @@ void AutoSetupHTTPProxy()
 
 
 
-struct CurlThread : Action {	
-	
+struct CurlThread : Action {
+
 	CurlThread( CHttp * parent, CURL * _curl ) :
 		parent( parent ),
 		curl( _curl ),
-		curlForm( NULL )
+		curlForm( NULL ),
+		aborted( false )
 	{
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, CurlReceiveCallback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)this);
-		//curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0);
-		//curl_easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, CurlProgressCallback);
-		//curl_easy_setopt(curl, CURLOPT_PROGRESSDATA, (void *)this);	
+		// The progress callback runs about once a second even while the transfer
+		// is stalled, so it is the only place we can abort a hung request from.
+		curl_easy_setopt(curl, CURLOPT_NOPROGRESS, (long) 0);
+		curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, CurlProgressCallback);
+		curl_easy_setopt(curl, CURLOPT_XFERINFODATA, (void *)this);
 	}
-	
+
 	Result handle();
 
 	CHttp *			parent;
 	CURL *			curl;
 	curl_httppost *	curlForm;
 	Mutex			Lock;
-	
+	std::atomic<bool> aborted; // set by CancelProcessing to interrupt curl_easy_perform
+
 	static size_t CurlReceiveCallback(void *ptr, size_t size, size_t nmemb, void *data);
-	//static int CurlProgressCallback(void *clientp, double dltotal, double dlnow, double ultotal, double ulnow);
+	static int CurlProgressCallback(void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
 };
 
 CHttp::CHttp()
@@ -207,17 +219,16 @@ size_t CurlThread::CurlReceiveCallback(void *ptr, size_t size, size_t nmemb, voi
 	return realsize;
 }
 
-/*
-int	CurlThread::CurlProgressCallback(void *clientp, double dltotal, double dlnow, double ultotal, double ulnow) {
+int	CurlThread::CurlProgressCallback(void *clientp, curl_off_t, curl_off_t, curl_off_t, curl_off_t) {
 	CurlThread* self = (CurlThread *)clientp;
-	
-	Mutex::ScopedLock l(self->Lock);
-	if( !self->parent ) // Aborting
-		return 0;
-	
-	return 1;
+	// A non-zero return aborts curl_easy_perform with CURLE_ABORTED_BY_CALLBACK.
+	// aborted is set when the request was cancelled,
+	// httpTransfersAborting on shutdown.
+	// Both are atomic, so no lock is needed here.
+	if( self->aborted || httpTransfersAborting )
+		return 1;
+	return 0;
 }
-*/
 
 CURL * CHttp::InitializeTransfer(const std::string& url, const std::string& proxy)
 {
@@ -342,6 +353,9 @@ void CHttp::CancelProcessing() // Non-blocking
 	if(curlThread != NULL)
 	{
 		Mutex::ScopedLock l(curlThread->Lock);
+		// Interrupt a still-running transfer via the progress callback,
+		// so the worker thread returns instead of blocking in curl_easy_perform.
+		curlThread->aborted = true;
 		curlThread->parent = NULL;
 		curlThread = NULL;
 	}

--- a/src/common/HTTP.cpp
+++ b/src/common/HTTP.cpp
@@ -45,6 +45,12 @@
 #define		HTTP_TIMEOUT	10	// Filebase became laggy lately, so increased that from 5 seconds
 //#define		BUFFER_LEN		8192
 
+// Abort a transfer that stays below this speed (bytes/sec) for this long (sec).
+// Unlike CURLOPT_TIMEOUT this never aborts a healthy but slow large transfer,
+// it only fires when the connection has effectively stalled.
+#define		HTTP_LOW_SPEED_LIMIT	30
+#define		HTTP_LOW_SPEED_TIME		30
+
 // Set on shutdown to make every running transfer return promptly.
 static std::atomic<bool> httpTransfersAborting(false);
 
@@ -247,6 +253,8 @@ CURL * CHttp::InitializeTransfer(const std::string& url, const std::string& prox
 	curl_easy_setopt( curl, CURLOPT_USERAGENT, Useragent.c_str() );
 	curl_easy_setopt( curl, CURLOPT_NOSIGNAL, (long) 1 );
 	curl_easy_setopt( curl, CURLOPT_CONNECTTIMEOUT, (long) HTTP_TIMEOUT );
+	curl_easy_setopt( curl, CURLOPT_LOW_SPEED_LIMIT, (long) HTTP_LOW_SPEED_LIMIT );
+	curl_easy_setopt( curl, CURLOPT_LOW_SPEED_TIME, (long) HTTP_LOW_SPEED_TIME );
 	curl_easy_setopt( curl, CURLOPT_FOLLOWLOCATION, (long) 1 ); // Allow server to use 3XX Redirect codes
 	curl_easy_setopt( curl, CURLOPT_MAXREDIRS, (long) 25 ); // Some reasonable limit
 #ifdef CURLSSLOPT_NATIVE_CA

--- a/src/common/HTTP.cpp
+++ b/src/common/HTTP.cpp
@@ -45,13 +45,11 @@
 #define		HTTP_TIMEOUT	10	// Filebase became laggy lately, so increased that from 5 seconds
 //#define		BUFFER_LEN		8192
 
-// Abort a transfer that stays below this speed (bytes/sec) for this long (sec).
-// Unlike CURLOPT_TIMEOUT this never aborts a healthy but slow large transfer,
-// it only fires when the connection has effectively stalled.
+// Abort a transfer stalled below this speed (bytes/sec) for this long (sec).
 #define		HTTP_LOW_SPEED_LIMIT	30
 #define		HTTP_LOW_SPEED_TIME		30
 
-// Set on shutdown to make every running transfer return promptly.
+// Set on shutdown to abort running transfers.
 static std::atomic<bool> httpTransfersAborting(false);
 
 void SetHttpTransfersAborting(bool aborting) {
@@ -177,8 +175,7 @@ struct CurlThread : Action {
 	{
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, CurlReceiveCallback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)this);
-		// The progress callback runs about once a second even while the transfer
-		// is stalled, so it is the only place we can abort a hung request from.
+		// Lets us abort a stalled transfer; curl calls it ~1x/sec.
 		curl_easy_setopt(curl, CURLOPT_NOPROGRESS, (long) 0);
 		curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, CurlProgressCallback);
 		curl_easy_setopt(curl, CURLOPT_XFERINFODATA, (void *)this);
@@ -190,7 +187,7 @@ struct CurlThread : Action {
 	CURL *			curl;
 	curl_httppost *	curlForm;
 	Mutex			Lock;
-	std::atomic<bool> aborted; // set by CancelProcessing to interrupt curl_easy_perform
+	std::atomic<bool> aborted; // set by CancelProcessing
 
 	static size_t CurlReceiveCallback(void *ptr, size_t size, size_t nmemb, void *data);
 	static int CurlProgressCallback(void *clientp, curl_off_t dltotal, curl_off_t dlnow, curl_off_t ultotal, curl_off_t ulnow);
@@ -227,10 +224,7 @@ size_t CurlThread::CurlReceiveCallback(void *ptr, size_t size, size_t nmemb, voi
 
 int	CurlThread::CurlProgressCallback(void *clientp, curl_off_t, curl_off_t, curl_off_t, curl_off_t) {
 	CurlThread* self = (CurlThread *)clientp;
-	// A non-zero return aborts curl_easy_perform with CURLE_ABORTED_BY_CALLBACK.
-	// aborted is set when the request was cancelled,
-	// httpTransfersAborting on shutdown.
-	// Both are atomic, so no lock is needed here.
+	// Non-zero aborts the transfer (CURLE_ABORTED_BY_CALLBACK).
 	if( self->aborted || httpTransfersAborting )
 		return 1;
 	return 0;
@@ -361,9 +355,7 @@ void CHttp::CancelProcessing() // Non-blocking
 	if(curlThread != NULL)
 	{
 		Mutex::ScopedLock l(curlThread->Lock);
-		// Interrupt a still-running transfer via the progress callback,
-		// so the worker thread returns instead of blocking in curl_easy_perform.
-		curlThread->aborted = true;
+		curlThread->aborted = true; // abort a running transfer, not just detach
 		curlThread->parent = NULL;
 		curlThread = NULL;
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,7 @@
 #include "Music.h"
 #include "Debug.h"
 #include "TaskManager.h"
+#include "HTTP.h"
 #include "CGameMode.h"
 #include "ConversationLogger.h"
 #include "OLXCommand.h"
@@ -397,7 +398,11 @@ startpoint:
 
 	notes << "waiting for all left threads and tasks" << endl;
 	taskManager->finishQueuedTasks();
+	// A hung HTTP request (e.g. an unresponsive master server) would otherwise
+	// block waitAll forever; tell any in-flight transfer to abort now.
+	SetHttpTransfersAborting(true);
 	threadPool->waitAll(); // do that before uniniting task manager because some threads could access it
+	SetHttpTransfersAborting(false); // in case we restart the game below
 
 	// do that after shutting down the timers and other threads
 	ShutdownEventQueue();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -398,11 +398,10 @@ startpoint:
 
 	notes << "waiting for all left threads and tasks" << endl;
 	taskManager->finishQueuedTasks();
-	// A hung HTTP request (e.g. an unresponsive master server) would otherwise
-	// block waitAll forever; tell any in-flight transfer to abort now.
+	// So a hung HTTP request can't block waitAll forever.
 	SetHttpTransfersAborting(true);
 	threadPool->waitAll(); // do that before uniniting task manager because some threads could access it
-	SetHttpTransfersAborting(false); // in case we restart the game below
+	SetHttpTransfersAborting(false); // in case we restart below
 
 	// do that after shutting down the timers and other threads
 	ShutdownEventQueue();

--- a/tests/headless/control/shutdown_control.py
+++ b/tests/headless/control/shutdown_control.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Dedicated-server control script for the shutdown-hang test (issue #800).
+
+Hosts a lobby with master-server registration enabled,
+but routes all HTTP through a proxy that points at a black hole:
+a socket that accepts the connection and then never answers.
+That is the condition under which a registration request used to hang
+inside curl and block OLX's shutdown forever.
+
+After the request has had time to go out and stall,
+it issues ``quit`` and lets the harness measure
+how long the process then takes to exit.
+
+Environment:
+  OLX_PORT           UDP port to host on (default 23400)
+  OLX_HTTP_PROXY     proxy address all HTTP is routed through (the black hole)
+  OLX_REGISTER_WAIT  seconds to wait after hosting before quitting (default 3)
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _olx_pipe import command, emit  # noqa: E402
+
+
+def main():
+    port = os.environ.get("OLX_PORT", "23400")
+    proxy = os.environ.get("OLX_HTTP_PROXY", "")
+    command("setvar GameOptions.Network.RegisterServer 1")
+    command("setvar GameOptions.Network.UseIpToCountry 0")
+    command('setvar GameOptions.Network.HttpProxy "%s"' % proxy)
+    command("setvar GameOptions.GameInfo.AllowEmptyGames 1")
+
+    command("startlobby " + port)
+    emit("SERVER_LOBBY")
+
+    # Give the registration request time to be sent to (and stall at) the proxy.
+    time.sleep(float(os.environ.get("OLX_REGISTER_WAIT", "3")))
+
+    emit("SERVER_QUIT")
+    command("quit")  # OLX shuts down and closes the pipe (command then exits)
+
+
+main()

--- a/tests/headless/test_shutdown.py
+++ b/tests/headless/test_shutdown.py
@@ -1,0 +1,109 @@
+"""Headless shutdown test: a dedicated server must not hang on quit (issue #800).
+
+A dedicated server registers with the master servers over HTTP.
+When a master server accepts the connection but never answers,
+the registration request stalls inside curl.
+On master this blocked OLX's shutdown wait forever
+("ThreadPool: waiting for N task(s) ... CHttp ... is still working").
+
+The test routes all of the server's HTTP through a proxy
+that points at a black hole (a socket that accepts and never replies),
+so a registration request is guaranteed to be in flight and stalled,
+then quits the server and checks that it still exits promptly.
+"""
+
+import os
+import socket
+import subprocess
+import threading
+import time
+
+from harness import CONTROL_DIR, OlxInstance
+
+SHUTDOWN_CONTROL = os.path.join(CONTROL_DIR, "shutdown_control.py")
+
+
+class BlackHoleProxy:
+    """A TCP listener that accepts connections and then never answers.
+
+    Used as OLX's HTTP proxy so every outgoing request connects
+    (past the connect timeout) but then stalls waiting for a reply,
+    which is exactly the state that used to wedge shutdown.
+    """
+
+    def __init__(self):
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen(16)
+        self.port = self._sock.getsockname()[1]
+        self.connections = 0
+        self._held = []
+        self._stop = False
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self):
+        self._sock.settimeout(0.5)
+        while not self._stop:
+            try:
+                conn, _ = self._sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            # Hold the connection open and stay silent.
+            self.connections += 1
+            self._held.append(conn)
+
+    def stop(self):
+        self._stop = True
+        for conn in self._held:
+            conn.close()
+        self._sock.close()
+
+
+def test_dedicated_server_shutdown_not_blocked_by_registration(olx_binary, tmp_path):
+    """Quitting a registering dedicated server exits promptly (issue #800).
+
+    Reproduces the hang: with a stalled registration request in flight,
+    master blocks in the thread-pool wait indefinitely, so this fails
+    (the process never exits) until the request is interruptible.
+    """
+    proxy = BlackHoleProxy()
+    server = OlxInstance(
+        olx_binary, "server", str(tmp_path / "server"), SHUTDOWN_CONTROL,
+        env={
+            "OLX_PORT": "23400",
+            "OLX_HTTP_PROXY": "127.0.0.1:%d" % proxy.port,
+            "OLX_REGISTER_WAIT": "3",
+        },
+    ).start()
+    try:
+        assert server.wait_for("SERVER_QUIT", timeout=40), (
+            "server never reached the quit point:\n" + server.read_log()
+        )
+
+        # The registration request really went out to the (stalled) proxy,
+        # so the shutdown-blocking condition genuinely existed.
+        assert proxy.connections >= 1, (
+            "no HTTP request reached the proxy; the hang was not exercised"
+        )
+
+        # After quit, OLX must exit despite the hung request still in flight.
+        start = time.time()
+        try:
+            server.proc.wait(timeout=20)
+        except subprocess.TimeoutExpired:
+            assert False, (
+                "OLX hung on shutdown (>20s) with a stalled registration "
+                "request in flight:\n" + server.read_log()
+            )
+        shutdown_time = time.time() - start
+        assert shutdown_time < 15, (
+            "shutdown took %.1fs; the stalled registration request was not "
+            "interrupted promptly" % shutdown_time
+        )
+    finally:
+        server.stop()
+        proxy.stop()


### PR DESCRIPTION
Fixes #800.

## Problem

A dedicated server that has been online a while often hangs on shutdown,
printing `ThreadPool: waiting for N task(s) ...`
with `CHttp: .../svr_register.php ... is still working`.
It is waiting on master-server registration requests
that never finish.

## Root cause

`CHttp` runs each request on a thread pool worker that blocks in `curl_easy_perform`.
`CancelProcessing()` only detached the parent pointer;
it never stopped the running transfer,
and the receive callback (the existing abort path) only runs when data arrives,
so a connected-but-stalled request could block indefinitely.
On shutdown the thread-pool wait then blocks forever.
It also means every re-registration interval leaked another stuck worker
(the pile-up of identical threads in the report).

## Fix

- Enable curl's progress callback (`CURLOPT_XFERINFOFUNCTION`),
  which fires about once a second even while a transfer is stalled,
  and abort the transfer from it when the request was cancelled
  or the process is shutting down.
- `CancelProcessing()` now sets that abort flag,
  so cancelling a request genuinely stops it
  (this alone fixes the thread pile-up).
- `main()` signals all in-flight transfers to abort
  right before the thread-pool wait on exit,
  so no owner needs to remember to cancel.

The abort path uses atomics and takes no lock,
avoiding the existing inverse lock order between `handle()` and `CancelProcessing()`.

A second, independent commit adds `CURLOPT_LOW_SPEED_LIMIT`/`TIME`
as defense in depth (abort a transfer stalled below 30 B/s for 30 s).
This is deliberately not `CURLOPT_TIMEOUT`,
which would also abort a healthy but slow large download.

## Testing

New headless test `tests/headless/test_shutdown.py`
routes the server's HTTP through a black-hole proxy
(accepts the connection, never answers),
confirms a registration request actually reached it,
then quits and asserts the process still exits promptly.
Without the fix it reproduces the exact hang from the issue and times out.
Full headless suite passes (16/16).
