### PR TITLE
Harden shutdown on partial init and crash exit

### DIFF
--- a/src/MainLoop.cpp
+++ b/src/MainLoop.cpp
@@ -387,8 +387,7 @@ void SetCrashHandlerReturnPoint(const char* name) {
 		hints << "returned from sigsetjmp in " << name << endl;
 		if(!tLXOptions) {
 			notes << "we already have tLXOptions uninitialised, exiting now" << endl;
-			// Stop the console I/O threads before exit() destroys the statics
-			// they use, else the tee thread hits a use-after-free (#1111).
+			// Join the console I/O threads before exit() frees the tee thread's statics (#1111).
 			quitStdinCLISupport();
 			teeStdoutQuit();
 			exit(10);

--- a/src/MainLoop.cpp
+++ b/src/MainLoop.cpp
@@ -18,6 +18,8 @@
 #include "IRC.h"
 #include "CrashHandler.h"
 #include "Clipboard.h"
+#include "TeeStdoutHandler.h"
+#include "client/StdinCLISupport.h"
 
 
 
@@ -385,6 +387,10 @@ void SetCrashHandlerReturnPoint(const char* name) {
 		hints << "returned from sigsetjmp in " << name << endl;
 		if(!tLXOptions) {
 			notes << "we already have tLXOptions uninitialised, exiting now" << endl;
+			// Stop the console I/O threads before exit() destroys the statics
+			// they use, else the tee thread hits a use-after-free (#1111).
+			quitStdinCLISupport();
+			teeStdoutQuit();
 			exit(10);
 			return;
 		}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -223,12 +223,8 @@ int real_main(int argc, char *argv[])
 		stdinCLIinitRes = initStdinCLISupport();
 	teeStdoutInit();
 
-	// Last-resort join for the two console I/O threads (they own static std::threads),
-	// covering any exit() path that doesn't stop them first.
-	// Not sufficient on its own: the tee thread uses function-local statics that
-	// exit() may destroy before this atexit runs (see #1111),
-	// so the real shutdown paths join the threads explicitly (ShutdownEverything);
-	// this only backstops paths that reach exit() with the threads still up.
+	// Backstop join for the console I/O threads; the shutdown paths join them
+	// explicitly first, since exit() can free the tee thread's statics (#1111).
 	std::atexit(quitConsoleIOThreads);
 
 	mainThreadId = getCurrentThreadId();
@@ -957,12 +953,9 @@ void ShutdownLieroX()
 }
 
 
-// Full ordered teardown: subsystems, then worker threads,
-// task manager, network, tLX, and finally the console I/O threads.
-// Reached from error and early-exit paths on partially-initialized state,
-// so each step skips or no-ops when its subsystem was never brought up.
-// Joining the console threads here, before returning to exit(),
-// keeps them from racing exit()'s static destruction (#1111).
+// Full ordered teardown for error/early-exit paths on partial init:
+// subsystems, worker threads, task manager, network, tLX, then the console
+// I/O threads -- joined here so they don't race exit()'s teardown (#1111).
 void ShutdownEverything()
 {
 	ShutdownLieroX();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -223,10 +223,12 @@ int real_main(int argc, char *argv[])
 		stdinCLIinitRes = initStdinCLISupport();
 	teeStdoutInit();
 
-	// The two console I/O threads own static std::threads.
-	// Any exit() that skips the normal shutdown (e.g. SystemError())
-	// would otherwise destroy them still-joinable, which calls std::terminate().
-	// atexit runs before those static destructors, so join them here.
+	// Last-resort join for the two console I/O threads (they own static std::threads),
+	// covering any exit() path that doesn't stop them first.
+	// Not sufficient on its own: the tee thread uses function-local statics that
+	// exit() may destroy before this atexit runs (see #1111),
+	// so the real shutdown paths join the threads explicitly (ShutdownEverything);
+	// this only backstops paths that reach exit() with the threads still up.
 	std::atexit(quitConsoleIOThreads);
 
 	mainThreadId = getCurrentThreadId();
@@ -850,7 +852,7 @@ void ShutdownLieroX()
 
 	// Options
 	// Save already here in case some other method crashes
-	if(!bDedicated) // only save if not in dedicated mode
+	if(!bDedicated && tLXOptions) // only save if not dedicated and options are loaded
 		tLXOptions->SaveToDisc();
 		
 	DeprecatedGUI::CChatWidget::GlobalDestroy();	
@@ -930,7 +932,7 @@ void ShutdownLieroX()
 
 	// HINT: save the options again because some could get changed in CServer/CClient destructors and shutdown functions
 	// TODO: like what changes? why are there options saved both in CServer/CClient structure and in options?
-	if(!bDedicated) // only save if not in dedicated mode
+	if(!bDedicated && tLXOptions) // only save if not dedicated and options are loaded
 		tLXOptions->SaveToDisc();
 
 	ShutdownOptions();
@@ -957,9 +959,10 @@ void ShutdownLieroX()
 
 // Full ordered teardown: subsystems, then worker threads,
 // task manager, network, tLX, and finally the console I/O threads.
-// Each step guards itself, so it is safe on a partial init.
-// So an error or early exit shuts down as cleanly as a normal quit
-// instead of racing a live thread at exit (#1111).
+// Reached from error and early-exit paths on partially-initialized state,
+// so each step skips or no-ops when its subsystem was never brought up.
+// Joining the console threads here, before returning to exit(),
+// keeps them from racing exit()'s static destruction (#1111).
 void ShutdownEverything()
 {
 	ShutdownLieroX();


### PR DESCRIPTION
Follow-up to #1111 / #1120, cleaning up the remaining `exit()` paths
that could still race the console I/O threads, plus two hardening fixes.

## What

- **Guard `tLXOptions->SaveToDisc()`** (both calls in `ShutdownLieroX()`).
  `ShutdownEverything()` can be reached before options are loaded
  (an error very early in startup), where `tLXOptions` is still `NULL`;
  the save would dereference it.

- **Join the console I/O threads before the crash-recovery `exit(10)`**
  in `SetCrashHandlerReturnPoint()` (`MainLoop.cpp`).
  Otherwise the tee-stdout thread can outlive `exit()`'s static destruction
  and read its freed function-local statics --
  the same use-after-free that #1111 fixed on the `SystemError()` path.

- **Correct two stale comments**:
  the `atexit(quitConsoleIOThreads)` join is only a backstop, not sufficient
  on its own (LIFO static destruction can free the tee thread's statics before
  it runs -- the #1111 root cause), and `ShutdownEverything()` is *reached* on
  partial init rather than being provably safe on every possible state.

## Exit-path audit

After this, every `exit()` that could have live console threads stops them first:

| Path | How the threads are stopped |
| --- | --- |
| `SystemError()` | `ShutdownEverything()` |
| `-help`, `-nettest` | `ShutdownEverything()` |
| crash-recovery `exit(10)` | explicit join (this PR) |
| `-version` | n/a -- runs before the threads are started |
| any other `exit()` | `atexit` backstop |

## Testing

Builds clean; the headless terminal + smoke suite passes.
The two hardening paths (a pre-options `ShutdownEverything()`, and the
crash-recovery `exit(10)`) are defensive and not straightforward to trigger
deterministically from the headless harness, so they have no dedicated test;
the primary `SystemError()`-before-init path remains covered by
`test_systemerror_before_init_exits_cleanly`.
