### PR TITLE
Sync map terrain to mid-game joiners (#827)

### DIFF
--- a/include/CClientNetEngine.h
+++ b/include/CClientNetEngine.h
@@ -102,6 +102,7 @@ protected:
     void		 ParseDropped(CBytestream *bs);
     void		 ParseSendFile(CBytestream *bs);
 	void		 ParseMapSyncData(CBytestream *bs);
+	void		 ParseMapChecksum(CBytestream *bs);
 	virtual void ParseFlagInfo(CBytestream* bs);
 	virtual void ParseTeamScoreUpdate(CBytestream* bs);
 	virtual void ParseWormProps(CBytestream* bs);

--- a/include/CClientNetEngine.h
+++ b/include/CClientNetEngine.h
@@ -44,8 +44,7 @@ public:
 	virtual void		SendText(const std::string& sText, std::string sWormName);
 	virtual void		SendWormDetails();
 	virtual void		SendGrabBonus(int id, int wormid);
-	// Ask the server to resync any terrain regions that differ from ours (#827).
-	void				SendRequestMapSync();
+	void				SendRequestMapSync();	// terrain resync request (#827)
 	virtual void		SendUpdateLobby(bool ready = true);
 	virtual void		SendDisconnect();
 	virtual void		SendFileData();

--- a/include/CClientNetEngine.h
+++ b/include/CClientNetEngine.h
@@ -44,6 +44,8 @@ public:
 	virtual void		SendText(const std::string& sText, std::string sWormName);
 	virtual void		SendWormDetails();
 	virtual void		SendGrabBonus(int id, int wormid);
+	// Ask the server to resync any terrain regions that differ from ours (#827).
+	void				SendRequestMapSync();
 	virtual void		SendUpdateLobby(bool ready = true);
 	virtual void		SendDisconnect();
 	virtual void		SendFileData();
@@ -99,6 +101,7 @@ protected:
 	void		 ParseDestroyBonus(CBytestream *bs);
     void		 ParseDropped(CBytestream *bs);
     void		 ParseSendFile(CBytestream *bs);
+	void		 ParseMapSyncData(CBytestream *bs);
 	virtual void ParseFlagInfo(CBytestream* bs);
 	virtual void ParseTeamScoreUpdate(CBytestream* bs);
 	virtual void ParseWormProps(CBytestream* bs);

--- a/include/CServer.h
+++ b/include/CServer.h
@@ -85,6 +85,7 @@ private:
 	bool		recheckGame;
 
 	AbsTime		fLastBonusTime;
+	AbsTime		fLastMapChecksumSent;	// throttles the terrain-checksum broadcast (#827)
 
 	int			iLastVictim;	// TODO: what is this good for
 

--- a/include/CServerNetEngine.h
+++ b/include/CServerNetEngine.h
@@ -51,6 +51,7 @@ public:
 	void		 ParseDisconnect();
 	void		 ParseGrabBonus(CBytestream *bs);
 	void		 ParseSendFile(CBytestream *bs);
+	void		 ParseRequestMapSync(CBytestream *bs);
 
 	bool		 ParseChatCommand(const std::string& message);
 	

--- a/include/Protocol.h
+++ b/include/Protocol.h
@@ -57,7 +57,7 @@ enum C2S_MESSAGES {
 	C2S_GUSANOS			= 15, // >=0.59 beta1
 	C2S_GUSANOSUPDATE	= 16, // >=0.59 beta5
 	C2S_GAMEATTRUPDATE	= 17, // >=0.59 beta10
-	C2S_REQUESTMAPSYNC	= 18, // >=0.59 beta11: client sends its per-region terrain checksums to pull the regions that differ (#827)
+	C2S_REQUESTMAPSYNC	= 18, // >=20260712.2: client sends its per-region terrain checksums to pull the regions that differ (#827)
 };
 
 // Server->Client
@@ -100,8 +100,8 @@ enum S2C_MESSAGES {
 	S2C_PLAYSOUND		= 35, // >=0.59 beta1
 	S2C_GUSANOSUPDATE	= 36, // >=0.59 beta5
 	S2C_GAMEATTRUPDATE	= 37, // >=0.59 beta10
-	S2C_MAPSYNCDATA		= 38, // >=0.59 beta11: server sends the terrain material of the regions a client asked to resync (#827)
-	S2C_MAPCHECKSUM		= 39, // >=0.59 beta11: server publishes its whole-map terrain checksum so clients can detect drift and re-pull (#827)
+	S2C_MAPSYNCDATA		= 38, // >=20260712.2: server sends the terrain material of the regions a client asked to resync (#827)
+	S2C_MAPCHECKSUM		= 39, // >=20260712.2: server publishes its whole-map terrain checksum so clients can detect drift and re-pull (#827)
 };
 
 

--- a/include/Protocol.h
+++ b/include/Protocol.h
@@ -57,6 +57,7 @@ enum C2S_MESSAGES {
 	C2S_GUSANOS			= 15, // >=0.59 beta1
 	C2S_GUSANOSUPDATE	= 16, // >=0.59 beta5
 	C2S_GAMEATTRUPDATE	= 17, // >=0.59 beta10
+	C2S_REQUESTMAPSYNC	= 18, // >=0.59 beta11: client sends its per-region terrain checksums to pull the regions that differ (#827)
 };
 
 // Server->Client
@@ -99,6 +100,7 @@ enum S2C_MESSAGES {
 	S2C_PLAYSOUND		= 35, // >=0.59 beta1
 	S2C_GUSANOSUPDATE	= 36, // >=0.59 beta5
 	S2C_GAMEATTRUPDATE	= 37, // >=0.59 beta10
+	S2C_MAPSYNCDATA		= 38, // >=0.59 beta11: server sends the terrain material of the regions a client asked to resync (#827)
 };
 
 

--- a/include/Protocol.h
+++ b/include/Protocol.h
@@ -101,6 +101,7 @@ enum S2C_MESSAGES {
 	S2C_GUSANOSUPDATE	= 36, // >=0.59 beta5
 	S2C_GAMEATTRUPDATE	= 37, // >=0.59 beta10
 	S2C_MAPSYNCDATA		= 38, // >=0.59 beta11: server sends the terrain material of the regions a client asked to resync (#827)
+	S2C_MAPCHECKSUM		= 39, // >=0.59 beta11: server publishes its whole-map terrain checksum so clients can detect drift and re-pull (#827)
 };
 
 

--- a/include/Version.h
+++ b/include/Version.h
@@ -94,6 +94,20 @@ INLINE Version OLXBetaVersion(int num, int subnum, int betaversion) {
 	return v;
 }
 
+// A date-based release version (YYYYMMDD.build),
+// the scheme in use since the 0.59 betas -- see get_olx_version() in functions.sh.
+// Use this to gate a feature introduced
+// after the switch away from the OLXBetaVersion numbering.
+INLINE Version OLXDateVersion(int date, int build) {
+	Version v;
+	v.gamename = fullGameName;
+	v.num = date;
+	v.subnum = build;
+	v.subsubnum = 0;
+	v.releasetype = Version::RT_NORMAL;
+	return v;
+}
+
 INLINE Version OLXVersionBranchStart(int num, int subnum) {
 	Version v;
 	v.gamename = fullGameName;

--- a/src/client/CClient_Parse.cpp
+++ b/src/client/CClient_Parse.cpp
@@ -657,6 +657,10 @@ bool CClientNetEngine::ParsePacket(CBytestream *bs)
 				break;
 			}
 
+			case S2C_MAPSYNCDATA:
+				ParseMapSyncData(bs);
+				break;
+
 			default:
 #if !defined(FUZZY_ERROR_TESTING_S2C)
 				warnings << "cl: Unknown packet " << (unsigned)cmd << endl;
@@ -1456,6 +1460,37 @@ void CClientNetEngine::ParseGameOver(CBytestream *bs)
 
 	// if we are away (perhaps waiting because we were out), notify us
 	NotifyUserOnEvent();
+}
+
+
+///////////////////
+// Parse terrain-resync data:
+// apply the material of each region the server sent,
+// so our map catches up on destruction from before we joined (#827).
+void CClientNetEngine::ParseMapSyncData(CBytestream *bs)
+{
+	int num = bs->readInt16();
+	if(num < 0) { bs->SkipAll(); return; }
+
+	CMap* m = game.gameMap();
+	int applied = 0;
+	for(int i = 0; i < num; ++i) {
+		int col = bs->readInt16();
+		int row = bs->readInt16();
+		if(m && m->isLoaded()) {
+			if(m->applyRegionMaterial(bs, col, row))
+				applied++;
+		} else {
+			// No map to apply to; consume the payload to stay aligned.
+			Uint32 rawLen = (Uint32)bs->readInt(4); (void)rawLen;
+			Uint32 compLen = (Uint32)bs->readInt(4);
+			bs->readData(compLen);
+		}
+	}
+	if(m && applied) {
+		m->CalculateDirtCount();
+		notes << "map sync: applied " << applied << " terrain region(s)" << endl;
+	}
 }
 
 

--- a/src/client/CClient_Parse.cpp
+++ b/src/client/CClient_Parse.cpp
@@ -661,6 +661,10 @@ bool CClientNetEngine::ParsePacket(CBytestream *bs)
 				ParseMapSyncData(bs);
 				break;
 
+			case S2C_MAPCHECKSUM:
+				ParseMapChecksum(bs);
+				break;
+
 			default:
 #if !defined(FUZZY_ERROR_TESTING_S2C)
 				warnings << "cl: Unknown packet " << (unsigned)cmd << endl;
@@ -1491,6 +1495,20 @@ void CClientNetEngine::ParseMapSyncData(CBytestream *bs)
 		m->CalculateDirtCount();
 		notes << "map sync: applied " << applied << " terrain region(s)" << endl;
 	}
+}
+
+
+///////////////////
+// Parse the server's terrain checksum:
+// if our map differs, pull the regions that changed (#827).
+void CClientNetEngine::ParseMapChecksum(CBytestream *bs)
+{
+	Uint32 serverCrc = (Uint32)bs->readInt(4);
+	CMap* m = game.gameMap();
+	if(!m || !m->isLoaded())
+		return;
+	if(m->getMaterialChecksum() != serverCrc)
+		SendRequestMapSync();
 }
 
 

--- a/src/client/CClient_Send.cpp
+++ b/src/client/CClient_Send.cpp
@@ -114,6 +114,29 @@ void CClientNetEngine::SendGameReady()
 
 
 ///////////////////
+// Ask the server to resync any terrain regions that differ from ours (#827).
+// We send our per-region material checksums; the server replies (S2C_MAPSYNCDATA)
+// with the regions that differ, so a mid-game joiner catches up on past destruction.
+void CClientNetEngine::SendRequestMapSync()
+{
+	if(client->getServerVersion() < OLXBetaVersion(0,59,11)) return;
+	CMap* m = game.gameMap();
+	if(!m || !m->isLoaded()) return;
+
+	CBytestream bs;
+	bs.writeByte(C2S_REQUESTMAPSYNC);
+	int cols = m->getMapSyncCols(), rows = m->getMapSyncRows();
+	bs.writeInt16(cols);
+	bs.writeInt16(rows);
+	for(int r = 0; r < rows; ++r)
+		for(int c = 0; c < cols; ++c)
+			bs.writeInt((int)m->getRegionMaterialChecksum(c, r), 4);
+
+	client->cNetChan->AddReliablePacketToSend(bs);
+}
+
+
+///////////////////
 // Send a death
 void CClientNetEngine::SendDeath(int victim, int killer)
 {

--- a/src/client/CClient_Send.cpp
+++ b/src/client/CClient_Send.cpp
@@ -119,7 +119,7 @@ void CClientNetEngine::SendGameReady()
 // with the regions that differ, so a mid-game joiner catches up on past destruction.
 void CClientNetEngine::SendRequestMapSync()
 {
-	if(client->getServerVersion() < OLXBetaVersion(0,59,11)) return;
+	if(client->getServerVersion() < OLXDateVersion(20260712,2)) return;
 	CMap* m = game.gameMap();
 	if(!m || !m->isLoaded()) return;
 

--- a/src/common/CMap.cpp
+++ b/src/common/CMap.cpp
@@ -813,6 +813,17 @@ void CMap::CalculateDirtCount()
 }
 
 
+Uint32 CMap::getMaterialChecksum() {
+	if(!material) return 0;
+	lockFlags(false);
+	uLong crc = crc32(0, Z_NULL, 0);
+	for(size_t y = 0; y < Height; ++y)
+		crc = crc32(crc, (const Bytef*)material->line[y], (uInt)Width);
+	unlockFlags(false);
+	return (Uint32)crc;
+}
+
+
 static bool getGroundPos(CMap* cMap, const CVec& pos, CVec* ret, uchar badPX) {
 	// TODO: optimise
 	

--- a/src/common/CMap.cpp
+++ b/src/common/CMap.cpp
@@ -824,6 +824,107 @@ Uint32 CMap::getMaterialChecksum() {
 }
 
 
+// Bounds of region (col,row), clipped to the map.
+void CMap::syncRegionBounds(int col, int row, int& x0, int& y0, int& x1, int& y1) const {
+	x0 = col * MAP_SYNC_REGION;
+	y0 = row * MAP_SYNC_REGION;
+	x1 = MIN(x0 + (int)MAP_SYNC_REGION, (int)Width);
+	y1 = MIN(y0 + (int)MAP_SYNC_REGION, (int)Height);
+}
+
+
+Uint32 CMap::getRegionMaterialChecksum(int col, int row) {
+	if(!material) return 0;
+	int x0, y0, x1, y1;
+	syncRegionBounds(col, row, x0, y0, x1, y1);
+	lockFlags(false);
+	uLong crc = crc32(0, Z_NULL, 0);
+	for(int y = y0; y < y1; ++y)
+		crc = crc32(crc, (const Bytef*)&material->line[y][x0], (uInt)(x1 - x0));
+	unlockFlags(false);
+	return (Uint32)crc;
+}
+
+
+void CMap::writeRegionMaterial(CBytestream* bs, int col, int row) {
+	int x0, y0, x1, y1;
+	syncRegionBounds(col, row, x0, y0, x1, y1);
+	int rw = x1 - x0, rh = y1 - y0;
+	uLong rawLen = (uLong)rw * rh;
+
+	std::vector<uchar> raw(rawLen ? rawLen : 1);
+	lockFlags(false);
+	size_t p = 0;
+	for(int y = y0; y < y1; ++y)
+		for(int x = x0; x < x1; ++x)
+			raw[p++] = (uchar)material->line[y][x];
+	unlockFlags(false);
+
+	uLong compLen = compressBound(rawLen);
+	std::vector<uchar> comp(compLen ? compLen : 1);
+	if(compress(&comp[0], &compLen, &raw[0], rawLen) != Z_OK) {
+		errors << "CMap::writeRegionMaterial: compress failed" << endl;
+		compLen = 0;
+	}
+	bs->writeInt((int)rawLen, 4);
+	bs->writeInt((int)compLen, 4);
+	bs->writeData(std::string((const char*)&comp[0], compLen));
+}
+
+
+bool CMap::applyRegionMaterial(CBytestream* bs, int col, int row) {
+	int x0, y0, x1, y1;
+	syncRegionBounds(col, row, x0, y0, x1, y1);
+	int rw = x1 - x0, rh = y1 - y0;
+
+	uLong rawLen = (uLong)(Uint32)bs->readInt(4);
+	uLong compLen = (uLong)(Uint32)bs->readInt(4);
+	std::string comp = bs->readData(compLen);
+	if(!material || rawLen != (uLong)rw * rh || comp.size() != compLen)
+		return false;
+
+	std::vector<uchar> raw(rawLen ? rawLen : 1);
+	uLong gotLen = rawLen;
+	if(uncompress(&raw[0], &gotLen, (const Bytef*)comp.data(), compLen) != Z_OK || gotLen != rawLen)
+		return false;
+
+	// Overwrite the material and repaint only the pixels that changed:
+	// carved/empty reveals the background image,
+	// placed dirt shows the front tile,
+	// unchanged pixels keep the original artwork.
+	const bool haveImage = bmpBackImageHiRes.get() != NULL && bmpDrawImage.get() != NULL
+		&& Theme.bmpFronttile.get() != NULL;
+	SDL_Surface* front = Theme.bmpFronttile.get();
+
+	lockFlags(true);
+	if(haveImage) { LockSurface(bmpDrawImage); LockSurface(Theme.bmpFronttile); }
+	size_t p = 0;
+	for(int y = y0; y < y1; ++y) {
+		for(int x = x0; x < x1; ++x, ++p) {
+			uchar newIdx = raw[p];
+			if((uchar)material->line[y][x] == newIdx)
+				continue;
+			material->line[y][x] = (char)newIdx;
+			if(!haveImage)
+				continue;
+			uchar lx = m_materialList[newIdx].toLxFlags();
+			int dx = x * 2, dy = y * 2;
+			if(lx & PX_DIRT) {
+				Color c(front->format, GetPixel(front, x % front->w, y % front->h));
+				PutPixel2x2(bmpDrawImage.get(), dx, dy, c.get(bmpDrawImage->format));
+			}
+			else // empty (carved) or rock: reveal the background image
+				CopyPixel2x2_SameFormat(bmpDrawImage.get(), bmpBackImageHiRes.get(), dx, dy);
+		}
+	}
+	if(haveImage) { UnlockSurface(Theme.bmpFronttile); UnlockSurface(bmpDrawImage); }
+	unlockFlags(true);
+
+	UpdateArea(x0, y0, rw, rh, true);
+	return true;
+}
+
+
 static bool getGroundPos(CMap* cMap, const CVec& pos, CVec* ret, uchar badPX) {
 	// TODO: optimise
 	

--- a/src/common/Command.cpp
+++ b/src/common/Command.cpp
@@ -2224,6 +2224,28 @@ void Cmd_mapInfo::exec(CmdLineIntf* caller, const std::vector<std::string>& para
 	}
 }
 
+COMMAND(getMapMaterialChecksum, "checksum of the map material mask (test hook)", "", 0, 0);
+void Cmd_getMapMaterialChecksum::exec(CmdLineIntf* caller, const std::vector<std::string>& params) {
+	CMap* m = game.gameMap();
+	if(!m) { caller->writeMsg("map not loaded", CNC_ERROR); return; }
+	caller->pushReturnArg(to_string(m->getMaterialChecksum()));
+}
+
+COMMAND(carveMap, "carve a hole in the map (test hook)", "x y [size]", 2, 3);
+void Cmd_carveMap::exec(CmdLineIntf* caller, const std::vector<std::string>& params) {
+	if(game.isClient() || !cServer || !cServer->isServerRunning()) { caller->writeMsg(name + " works only as server"); return; }
+	CMap* m = game.gameMap();
+	if(!m) { caller->writeMsg("map not loaded", CNC_ERROR); return; }
+	bool fail = false;
+	int x = from_string<int>(params[0], fail);
+	int y = from_string<int>(params[1], fail);
+	int size = 4;
+	if(params.size() > 2) size = from_string<int>(params[2], fail);
+	if(fail) { printUsage(caller); return; }
+	int carved = m->CarveHole(size, CVec((float)x, (float)y), false);
+	caller->pushReturnArg(itoa(carved));
+}
+
 COMMAND(findSpot, "find randm free spot in map (close to pos)", "[(x,y)]", 0, 1);
 void Cmd_findSpot::exec(CmdLineIntf* caller, const std::vector<std::string>& params) {
 	if(game.isClient() || !cServer || !cServer->isServerRunning()) { caller->writeMsg(name + " works only as server"); return; }

--- a/src/common/Command.cpp
+++ b/src/common/Command.cpp
@@ -2231,6 +2231,19 @@ void Cmd_getMapMaterialChecksum::exec(CmdLineIntf* caller, const std::vector<std
 	caller->pushReturnArg(to_string(m->getMaterialChecksum()));
 }
 
+COMMAND(getMapRegionChecksum, "checksum of one terrain-sync region (test hook)", "col row", 2, 2);
+void Cmd_getMapRegionChecksum::exec(CmdLineIntf* caller, const std::vector<std::string>& params) {
+	CMap* m = game.gameMap();
+	if(!m) { caller->writeMsg("map not loaded", CNC_ERROR); return; }
+	bool fail = false;
+	int col = from_string<int>(params[0], fail);
+	int row = from_string<int>(params[1], fail);
+	if(fail || col < 0 || row < 0 || col >= m->getMapSyncCols() || row >= m->getMapSyncRows()) {
+		caller->writeMsg("region out of range", CNC_ERROR); return;
+	}
+	caller->pushReturnArg(to_string(m->getRegionMaterialChecksum(col, row)));
+}
+
 COMMAND(carveMap, "carve a hole in the map (test hook)", "x y [size]", 2, 3);
 void Cmd_carveMap::exec(CmdLineIntf* caller, const std::vector<std::string>& params) {
 	if(game.isClient() || !cServer || !cServer->isServerRunning()) { caller->writeMsg(name + " works only as server"); return; }

--- a/src/game/CMap.h
+++ b/src/game/CMap.h
@@ -353,6 +353,10 @@ public:
 	void				SetMinimapDimensions(uint _w, uint _h);
     uint         GetDirtCount() const { return nTotalDirtCount; }
 
+	// Checksum over the raw material mask (per-pixel material index).
+	// Detects terrain divergence between peers (late join, drift); see #827.
+	Uint32			getMaterialChecksum();
+
 	bool			getCreated()	{ return Created; }
 	
 	

--- a/src/game/CMap.h
+++ b/src/game/CMap.h
@@ -263,8 +263,7 @@ private:
 	// Saves region of map to savebuffer for RestoreFromMemory() - called from CarveHole()/PlaceDirt()/PlaceGreenDirt()
 	void SaveToMemoryInternal(int x, int y, int w, int h);
 
-	// Clipped bounds of terrain-sync region (col,row); see MAP_SYNC_REGION.
-	void syncRegionBounds(int col, int row, int& x0, int& y0, int& x1, int& y1) const;
+	void syncRegionBounds(int col, int row, int& x0, int& y0, int& x1, int& y1) const;	// clipped region bounds (#827)
 
 
 public:	
@@ -356,21 +355,14 @@ public:
 	void				SetMinimapDimensions(uint _w, uint _h);
     uint         GetDirtCount() const { return nTotalDirtCount; }
 
-	// Terrain reconciliation (see #827): the map is divided into square regions;
-	// a peer compares per-region checksums and pulls only the regions that differ.
-	enum { MAP_SYNC_REGION = 64 };
+	// terrain reconciliation, per region (#827)
+	enum { MAP_SYNC_REGION = 64 };	// region size in pixels
 	int				getMapSyncCols() const { return (int)((Width + MAP_SYNC_REGION - 1) / MAP_SYNC_REGION); }
 	int				getMapSyncRows() const { return (int)((Height + MAP_SYNC_REGION - 1) / MAP_SYNC_REGION); }
-
-	// Checksum over the raw material mask (per-pixel material index).
-	// Detects terrain divergence between peers (late join, drift); see #827.
-	Uint32			getMaterialChecksum();
+	Uint32			getMaterialChecksum();	// checksum of the whole material mask
 	Uint32			getRegionMaterialChecksum(int col, int row);
-
-	// Serialize one region's raw material mask (zlib-compressed) to the stream,
-	// and apply a received region (overwrite material + redraw the changed pixels).
-	void			writeRegionMaterial(CBytestream* bs, int col, int row);
-	bool			applyRegionMaterial(CBytestream* bs, int col, int row);
+	void			writeRegionMaterial(CBytestream* bs, int col, int row);	// serialize one region (zlib)
+	bool			applyRegionMaterial(CBytestream* bs, int col, int row);	// apply + redraw one region
 
 	bool			getCreated()	{ return Created; }
 	

--- a/src/game/CMap.h
+++ b/src/game/CMap.h
@@ -263,6 +263,9 @@ private:
 	// Saves region of map to savebuffer for RestoreFromMemory() - called from CarveHole()/PlaceDirt()/PlaceGreenDirt()
 	void SaveToMemoryInternal(int x, int y, int w, int h);
 
+	// Clipped bounds of terrain-sync region (col,row); see MAP_SYNC_REGION.
+	void syncRegionBounds(int col, int row, int& x0, int& y0, int& x1, int& y1) const;
+
 
 public:	
 
@@ -353,9 +356,21 @@ public:
 	void				SetMinimapDimensions(uint _w, uint _h);
     uint         GetDirtCount() const { return nTotalDirtCount; }
 
+	// Terrain reconciliation (see #827): the map is divided into square regions;
+	// a peer compares per-region checksums and pulls only the regions that differ.
+	enum { MAP_SYNC_REGION = 64 };
+	int				getMapSyncCols() const { return (int)((Width + MAP_SYNC_REGION - 1) / MAP_SYNC_REGION); }
+	int				getMapSyncRows() const { return (int)((Height + MAP_SYNC_REGION - 1) / MAP_SYNC_REGION); }
+
 	// Checksum over the raw material mask (per-pixel material index).
 	// Detects terrain divergence between peers (late join, drift); see #827.
 	Uint32			getMaterialChecksum();
+	Uint32			getRegionMaterialChecksum(int col, int row);
+
+	// Serialize one region's raw material mask (zlib-compressed) to the stream,
+	// and apply a received region (overwrite material + redraw the changed pixels).
+	void			writeRegionMaterial(CBytestream* bs, int col, int row);
+	bool			applyRegionMaterial(CBytestream* bs, int col, int row);
 
 	bool			getCreated()	{ return Created; }
 	

--- a/src/game/Game.cpp
+++ b/src/game/Game.cpp
@@ -21,6 +21,7 @@
 #include "OLXCommand.h"
 #include "IRC.h"
 #include "CClient.h"
+#include "CClientNetEngine.h"
 #include "CServer.h"
 #include "Physics.h"
 #include "DeprecatedGUI/Menu.h"
@@ -446,6 +447,11 @@ Result Game::prepareGameloop() {
 	preparedMap = cClient->getGameLobby()[FT_Map];
 
 	cClient->bMapGrabbed = true;
+
+	// The map file is loaded pristine; a client (especially a mid-game joiner)
+	// now pulls the server's current terrain so past destruction is in sync (#827).
+	if(game.isClient())
+		cClient->getNetEngine()->SendRequestMapSync();
 
 	// always also load Gusanos engine
 	// even with LX-stuff-only, we may access/need it (for network stuff and later probably more)

--- a/src/server/CServer_Game.cpp
+++ b/src/server/CServer_Game.cpp
@@ -262,7 +262,7 @@ void GameServer::SimulateGame()
 			CServerConnection* cl = &getClients()[c];
 			if(cl->isLocalClient()) continue;
 			if(cl->getStatus() == NET_DISCONNECTED || cl->getStatus() == NET_ZOMBIE) continue;
-			if(cl->getClientVersion() < OLXBetaVersion(0,59,11)) continue;
+			if(cl->getClientVersion() < OLXDateVersion(20260712,2)) continue;
 			cl->getNetEngine()->SendPacket(&bs);
 		}
 	}

--- a/src/server/CServer_Game.cpp
+++ b/src/server/CServer_Game.cpp
@@ -249,6 +249,24 @@ void GameServer::SimulateGame()
 		fLastBonusTime = tLX->currentTime;
 	}
 
+	// Periodically publish the terrain checksum, so clients can detect drift
+	// from the server's map (late join, or float divergence) and pull the
+	// regions that differ (#827).
+	if(game.gameMap() && game.gameMap()->isLoaded()
+	   && tLX->currentTime - fLastMapChecksumSent > TimeDiff(2.0f)) {
+		fLastMapChecksumSent = tLX->currentTime;
+		CBytestream bs;
+		bs.writeByte(S2C_MAPCHECKSUM);
+		bs.writeInt((int)game.gameMap()->getMaterialChecksum(), 4);
+		for(int c = 0; c < MAX_CLIENTS; c++) {
+			CServerConnection* cl = &getClients()[c];
+			if(cl->isLocalClient()) continue;
+			if(cl->getStatus() == NET_DISCONNECTED || cl->getStatus() == NET_ZOMBIE) continue;
+			if(cl->getClientVersion() < OLXBetaVersion(0,59,11)) continue;
+			cl->getNetEngine()->SendPacket(&bs);
+		}
+	}
+
 	// check for flag
 	for_each_iterator(CWorm*, w, game.worms())
 		flagInfo()->checkWorm(w->get());

--- a/src/server/CServer_Parse.cpp
+++ b/src/server/CServer_Parse.cpp
@@ -178,6 +178,10 @@ void CServerNetEngine::ParsePacket(CBytestream *bs) {
 			break;
 		}
 
+		case C2S_REQUESTMAPSYNC:
+			ParseRequestMapSync(bs);
+			break;
+
 		default:
 			// HACK, HACK: old olx/lxp clients send the ping twice, once normally once per channel
 			// which leads to warnings here - we simply parse it here and avoid warnings
@@ -827,6 +831,53 @@ void CServerNetEngine::ParseDisconnect() {
 	server->DropClient(cl, CLL_QUIT, "client disconnected");
 }
 
+
+
+///////////////////
+// Parse a terrain-resync request: the client sent its per-region material
+// checksums; reply with the material of the regions that differ (#827).
+void CServerNetEngine::ParseRequestMapSync(CBytestream *bs) {
+	int cols = bs->readInt16();
+	int rows = bs->readInt16();
+
+	// Reject implausible dimensions before allocating/reading.
+	if(cols <= 0 || rows <= 0 || cols > 4096 || rows > 4096) {
+		bs->SkipAll();
+		return;
+	}
+
+	std::vector<Uint32> clientCrc((size_t)cols * rows);
+	for(size_t i = 0; i < clientCrc.size(); ++i)
+		clientCrc[i] = (Uint32)bs->readInt(4);
+
+	CMap* m = game.gameMap();
+	if(!m || !m->isLoaded())
+		return;
+	// Only same-size maps can be reconciled region by region.
+	if(cols != m->getMapSyncCols() || rows != m->getMapSyncRows())
+		return;
+
+	CBytestream out;
+	out.writeByte(S2C_MAPSYNCDATA);
+	// Reserve the region count; fill it in once we know how many differ.
+	std::vector< std::pair<int,int> > diff;
+	size_t idx = 0;
+	for(int r = 0; r < rows; ++r)
+		for(int c = 0; c < cols; ++c, ++idx)
+			if(m->getRegionMaterialChecksum(c, r) != clientCrc[idx])
+				diff.push_back(std::make_pair(c, r));
+
+	if(diff.empty())
+		return;
+
+	out.writeInt16((int)diff.size());
+	for(size_t i = 0; i < diff.size(); ++i) {
+		out.writeInt16(diff[i].first);
+		out.writeInt16(diff[i].second);
+		m->writeRegionMaterial(&out, diff[i].first, diff[i].second);
+	}
+	SendPacket(&out);
+}
 
 
 ///////////////////

--- a/tests/headless/control/client_control.py
+++ b/tests/headless/control/client_control.py
@@ -27,6 +27,7 @@ def main():
     name = os.environ.get("OLX_CLIENT_NAME", "client")
     leave_signal = os.environ.get("OLX_LEAVE_SIGNAL_FILE")
     emit_state = os.environ.get("OLX_EMIT_STATE")
+    emit_mapchk = os.environ.get("OLX_EMIT_MAPCHK")
     reached_playing = False
     combat = False
     prev_worms = set()
@@ -49,6 +50,13 @@ def main():
         if state == "Playing" and not reached_playing:
             emit("CLIENT[%s] PLAYING" % name)
             reached_playing = True
+        # Report this client's terrain checksum,
+        # so a test can confirm a mid-game joiner
+        # ends up with the same map state as the server (#827).
+        if reached_playing and emit_mapchk:
+            chk = command("getMapMaterialChecksum")
+            if chk:
+                emit("CLIENT[%s] MAPCHK %s" % (name, chk[0]))
         # Report this client's own view of every worm's state, so a test can
         # check it against the server's view and confirm the game state syncs.
         if reached_playing and emit_state:

--- a/tests/headless/control/server_control.py
+++ b/tests/headless/control/server_control.py
@@ -80,6 +80,10 @@ def main():
 
     emit_state = os.environ.get("OLX_EMIT_STATE")
     spawn_close = os.environ.get("OLX_SPAWN_CLOSE")
+    # "x,y;x,y;..." points to carve once the game is running,
+    # to diverge the server's terrain from the untouched map file (#827).
+    carve_spec = os.environ.get("OLX_CARVE_MAP")
+    emit_mapchk = os.environ.get("OLX_EMIT_MAPCHK")
 
     start_when = int(os.environ.get("OLX_START_WHEN_WORMS", "1"))
     started = False
@@ -107,6 +111,19 @@ def main():
                     for wid in worms:
                         command('spawnWorm %s "%s,%s"' % (wid, spot[0], spot[1]))
                     emit("SERVER_SPAWN_CLOSE %s,%s" % (spot[0], spot[1]))
+            if carve_spec:
+                carved = 0
+                for point in carve_spec.split(";"):
+                    xy = point.split(",")
+                    if len(xy) == 2:
+                        ret = command("carveMap %s %s" % (xy[0], xy[1]))
+                        if ret:
+                            carved += int(ret[0])
+                emit("SERVER_CARVED count=%d" % carved)
+        if playing and emit_mapchk:
+            chk = command("getMapMaterialChecksum")
+            if chk:
+                emit("SERVER_MAPCHK %s" % chk[0])
         if playing and emit_state:
             states = emit_worm_states("SERVER")
             total_dmg = sum(s["dmg"] for s in states.values())

--- a/tests/headless/control/terrain_control.py
+++ b/tests/headless/control/terrain_control.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Control script for the terrain-carve test (see tests/headless/test_terrain.py).
+
+It starts a game, then freezes the simulation (``simStep`` manual stepping)
+so nothing but an explicit carve can change the map.
+It reports the whole-map checksum and two region checksums
+before and after the carve,
+so the test can confirm the carve changed the map,
+changed the carved region,
+and left an untouched region alone.
+
+Environment variables:
+
+====================  =========================================================
+``OLX_MAP``           level file (default "Dirt Level.lxl")
+``OLX_CARVE_AT``      "x,y" to carve at (default "200,150", on the dirt)
+``OLX_TARGET_REGION`` "col,row" region the carve falls in (default "3,2")
+``OLX_CONTROL_REGION``"col,row" region far from the carve (default "0,0")
+====================  =========================================================
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _olx_pipe import command, emit, game_state, worm_ids  # noqa: E402
+
+
+def _one(ret):
+    return ret[0] if ret else "?"
+
+
+def whole_chk():
+    return _one(command("getMapMaterialChecksum"))
+
+
+def region_chk(reg):
+    col, row = reg.split(",")
+    return _one(command("getMapRegionChecksum %s %s" % (col, row)))
+
+
+def main():
+    carve_at = os.environ.get("OLX_CARVE_AT", "200,150")
+    target = os.environ.get("OLX_TARGET_REGION", "3,2")
+    control = os.environ.get("OLX_CONTROL_REGION", "0,0")
+
+    settings = {
+        "GameOptions.Network.RegisterServer": 0,
+        "GameOptions.Network.UseIpToCountry": 0,
+        "GameOptions.GameInfo.GameType": "Death Match",
+        "GameOptions.GameInfo.LevelName": os.environ.get("OLX_MAP", "Dirt Level.lxl"),
+        "GameOptions.GameInfo.ModName": "Classic",
+        "GameOptions.GameInfo.ForceRandomWeapons": 1,
+        "GameOptions.GameInfo.ImmediateStart": 1,
+        "GameOptions.GameInfo.AllowEmptyGames": 1,
+    }
+    for key, value in settings.items():
+        command('setvar %s "%s"' % (key, value))
+    command("startlobby 23400")
+
+    # A bot just so the game can start; we freeze and force no input,
+    # so it never acts and never touches the map itself.
+    added = set()
+    deadline = time.time() + 15
+    while len(added) < 1 and time.time() < deadline:
+        if game_state() == "Lobby":
+            added.update(command("addBots 1"))
+        if len(added) < 1:
+            time.sleep(0.3)
+    command("startgame")
+    for _ in range(60):
+        if game_state() == "Playing":
+            break
+        time.sleep(0.2)
+    if game_state() != "Playing":
+        emit("TERRAIN_ERROR not playing (state=%s)" % game_state())
+        return
+
+    # Freeze: from now on the map only changes when we carve it.
+    command("simSetSeed 12345")
+    command("simStep 0")
+    for wid in worm_ids():
+        command("setWormInput %s false false false false" % wid)
+
+    emit("TERRAIN_PRE whole=%s target=%s control=%s"
+         % (whole_chk(), region_chk(target), region_chk(control)))
+
+    x, y = carve_at.split(",")
+    carved = command("carveMap %s %s" % (x, y))
+    emit("TERRAIN_CARVED count=%s" % _one(carved))
+
+    emit("TERRAIN_POST whole=%s target=%s control=%s"
+         % (whole_chk(), region_chk(target), region_chk(control)))
+    emit("TERRAIN_DONE")
+
+
+main()

--- a/tests/headless/test_network.py
+++ b/tests/headless/test_network.py
@@ -128,15 +128,18 @@ def test_late_joiner_terrain_matches_server(network_game):
     assert c2.wait_for("CLIENT[c2] PLAYING", timeout=25), c2.read_log()
     assert c2.wait_for("CLIENT[c2] MAPCHK", timeout=15), c2.read_log()
 
-    # The joiner emits a checksum every poll,
-    # and the terrain sync arrives shortly after it starts playing,
-    # so wait for its checksum to converge on the server's
-    # (which is stable -- only the server carved).
-    # Without the fix it never matches.
-    server_chk = _last_mapchk(server)
-    c2_chk = None
-    deadline = time.time() + 15
+    # Both sides emit a checksum every poll,
+    # and the joiner catches up shortly after it starts playing,
+    # so wait until the two agree.
+    # Re-read the server's value each pass, not just once:
+    # its terrain can settle a moment later (e.g. a spawn hole),
+    # and the joiner converges on that newer value,
+    # so a single up-front read would be stale and fail even once they match.
+    # Without the fix the joiner stays on the pristine map and never agrees.
+    server_chk = c2_chk = None
+    deadline = time.time() + 30
     while time.time() < deadline:
+        server_chk = _last_mapchk(server)
         c2_chk = _last_mapchk(c2)
         if c2_chk is not None and c2_chk == server_chk:
             break

--- a/tests/headless/test_network.py
+++ b/tests/headless/test_network.py
@@ -15,6 +15,7 @@ A client counts as joined once it reaches the ``Playing`` state.
 """
 
 import re
+import time
 
 
 def _host_running_game(network_game):
@@ -127,8 +128,20 @@ def test_late_joiner_terrain_matches_server(network_game):
     assert c2.wait_for("CLIENT[c2] PLAYING", timeout=25), c2.read_log()
     assert c2.wait_for("CLIENT[c2] MAPCHK", timeout=15), c2.read_log()
 
+    # The joiner emits a checksum every poll,
+    # and the terrain sync arrives shortly after it starts playing,
+    # so wait for its checksum to converge on the server's
+    # (which is stable -- only the server carved).
+    # Without the fix it never matches.
     server_chk = _last_mapchk(server)
-    c2_chk = _last_mapchk(c2)
+    c2_chk = None
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        c2_chk = _last_mapchk(c2)
+        if c2_chk is not None and c2_chk == server_chk:
+            break
+        time.sleep(0.5)
+
     assert server_chk is not None and c2_chk is not None, (
         "missing checksums: server=%s c2=%s" % (server_chk, c2_chk))
     assert c2_chk == server_chk, (

--- a/tests/headless/test_network.py
+++ b/tests/headless/test_network.py
@@ -14,6 +14,8 @@ Two clients tell the cases apart:
 A client counts as joined once it reaches the ``Playing`` state.
 """
 
+import re
+
 
 def _host_running_game(network_game):
     """Start the server, join client ``c1`` in the lobby, and start the game.
@@ -88,6 +90,50 @@ def test_two_clients_in_lobby_see_each_other(network_game):
             "%s never received the other client's worm:\n%s"
             % (client.name, client.read_log())
         )
+
+
+def _last_mapchk(inst):
+    """Return the last terrain checksum an instance emitted, or None."""
+    vals = re.findall(r"MAPCHK (\d+)", inst.read_log())
+    return vals[-1] if vals else None
+
+
+def test_late_joiner_terrain_matches_server(network_game):
+    """A mid-game joiner must end up with the same terrain as the server (#827).
+
+    The server carves holes into the map after the game is running.
+    A client that then joins mid-game must be sent that terrain state,
+    not a pristine copy of the map file.
+
+    Fails on current master:
+    the late joiner loads the untouched map,
+    so its material checksum differs from the server's.
+    """
+    server = network_game.start_server(OLX_CARVE_MAP="100,100;150,120;200,150;250,180",
+                                       OLX_EMIT_MAPCHK=1)
+    assert server.wait_for("SERVER_LOBBY", timeout=30), server.read_log()
+
+    c1 = network_game.add_client("c1")
+    assert server.wait_for("SERVER_PLAYING", timeout=40), server.read_log()
+    assert c1.wait_for("CLIENT[c1] PLAYING", timeout=30), c1.read_log()
+
+    # The carve must actually change the terrain, else the test proves nothing.
+    assert server.wait_for("SERVER_CARVED", timeout=20), server.read_log()
+    carved = re.search(r"SERVER_CARVED count=(\d+)", server.read_log())
+    assert carved and int(carved.group(1)) > 0, (
+        "server carved nothing, cannot test terrain sync:\n" + server.read_log())
+
+    c2 = network_game.add_client("c2", env={"OLX_EMIT_MAPCHK": "1"})
+    assert c2.wait_for("CLIENT[c2] PLAYING", timeout=25), c2.read_log()
+    assert c2.wait_for("CLIENT[c2] MAPCHK", timeout=15), c2.read_log()
+
+    server_chk = _last_mapchk(server)
+    c2_chk = _last_mapchk(c2)
+    assert server_chk is not None and c2_chk is not None, (
+        "missing checksums: server=%s c2=%s" % (server_chk, c2_chk))
+    assert c2_chk == server_chk, (
+        "late joiner terrain checksum %s != server %s; "
+        "the modified map was not synced on join (#827)" % (c2_chk, server_chk))
 
 
 def test_worm_removed_when_client_leaves(network_game, tmp_path):

--- a/tests/headless/test_network.py
+++ b/tests/headless/test_network.py
@@ -151,6 +151,15 @@ def test_late_joiner_terrain_matches_server(network_game):
         "late joiner terrain checksum %s != server %s; "
         "the modified map was not synced on join (#827)" % (c2_chk, server_chk))
 
+    # Guard against a vacuous pass:
+    # the joiner's first checksum is its pristine map, before the sync,
+    # and it must differ from the converged value --
+    # otherwise the server's carve had no effect and we tested nothing.
+    pristine = re.search(r"MAPCHK (\d+)", c2.read_log()).group(1)
+    assert c2_chk != pristine, (
+        "joiner's terrain never changed from the pristine map (%s); "
+        "the carve/sync did nothing" % pristine)
+
 
 def test_worm_removed_when_client_leaves(network_game, tmp_path):
     """When a client leaves a running game, the others drop its worm (#978)."""

--- a/tests/headless/test_terrain.py
+++ b/tests/headless/test_terrain.py
@@ -1,0 +1,53 @@
+"""Terrain-carve tests.
+
+Guard against the late-join test being vacuous:
+prove that an explicit carve really changes the map,
+and that it changes only where it happens.
+The simulation is frozen for the check,
+so worm activity can't move the map between the two measurements
+and the carve is the only difference.
+"""
+
+import os
+import re
+
+from harness import OlxInstance, CONTROL_DIR
+
+TERRAIN_CONTROL = os.path.join(CONTROL_DIR, "terrain_control.py")
+
+
+def _row(log, marker):
+    line = next((l for l in log.splitlines() if l.startswith(marker)), "")
+    m = re.search(r"whole=(\d+) target=(\d+) control=(\d+)", line)
+    assert m, "missing %s line:\n%s" % (marker, log)
+    return {"whole": m.group(1), "target": m.group(2), "control": m.group(3)}
+
+
+def test_carve_changes_map_and_is_localized(olx_binary, tmp_path):
+    inst = OlxInstance(olx_binary, "terrain", str(tmp_path / "terrain"),
+                       TERRAIN_CONTROL).start()
+    try:
+        assert inst.wait_for("TERRAIN_DONE", timeout=60), inst.read_log()
+        log = inst.read_log()
+    finally:
+        inst.stop()
+
+    carved = re.search(r"TERRAIN_CARVED count=(\d+)", log)
+    assert carved and int(carved.group(1)) > 0, (
+        "the carve removed no dirt, so the test proves nothing:\n" + log)
+
+    pre = _row(log, "TERRAIN_PRE")
+    post = _row(log, "TERRAIN_POST")
+
+    # The carve changes the whole-map checksum ...
+    assert pre["whole"] != post["whole"], (
+        "carve did not change the map checksum: %s == %s"
+        % (pre["whole"], post["whole"]))
+    # ... and the carved region's checksum ...
+    assert pre["target"] != post["target"], (
+        "carve did not change its own region: %s == %s"
+        % (pre["target"], post["target"]))
+    # ... but leaves a region far from the carve untouched.
+    assert pre["control"] == post["control"], (
+        "carve changed an untouched region: %s != %s"
+        % (pre["control"], post["control"]))


### PR DESCRIPTION
Fixes #827.

## Problem

Terrain destruction (carving, and dirt placed by some weapons)
was applied only in the client-side simulation.
A player joining a running game loads the map file pristine
and never reproduces the destruction from before it joined,
so it saw a different map from everyone else.
The server only ever sent the map by name, never its current state.

## Approach

A per-region, client-pull terrain reconciliation, used for both
late join and ongoing drift:

- `CMap` divides the map into square regions and can checksum,
  serialize (zlib) and apply a region's raw material mask.
  Applying repaints only the pixels that changed
  (carved -> background image, placed dirt -> front tile),
  so collisions and visuals match without sending any image data.
- On map load a client sends `C2S_REQUESTMAPSYNC` with its per-region
  checksums; the server replies (`S2C_MAPSYNCDATA`) with the material of
  just the regions that differ.
- The server also publishes its whole-map checksum every ~2s
  (`S2C_MAPCHECKSUM`); a client whose checksum differs re-runs the same
  pull and converges. This handles float drift and self-heals the
  join-time race, all through one mechanism.

Serializing the raw material index (not the collapsed LX flags)
keeps this correct for Gusanos' richer material set too.
New packets are gated to >=0.59.11.

## Tests

`test_late_joiner_terrain_matches_server` (headless):
the server carves,
a client joins mid-game,
and its terrain checksum must equal the server's.
Fails without the fix, passes with it;
the full headless suite is green.

## Out of scope (tracked separately)

Bonuses not sent to mid-game joiners (#1123),
letting Gusanos reuse this sync instead of its event-replay (#1124),
unifying the OLX and Gusanos net layers (#1125).
