### PR TITLE
Cap shoot-list run length at 255

### DIFF
--- a/include/CShootList.h
+++ b/include/CShootList.h
@@ -130,6 +130,7 @@ public:
 	AbsTime		getLastWrite()			{ return m_fLastWrite; }
 
 	friend void test_CShootListSpeedRoundtrip();  // unit test: writeSingle/readSingle
+	friend void test_CShootListMultiRoundtrip();  // unit test: writeMulti/readMulti run length
 };
 
 

--- a/src/common/CShootList.cpp
+++ b/src/common/CShootList.cpp
@@ -226,7 +226,9 @@ void CShootList::writeMulti( CBytestream *bs, const Version& receiverVer, int in
 			abs(m_psShoot[i].nSpeed - m_psShoot[i-1].nSpeed) > 255 ||
 			abs((int)m_psShoot[i].cWormVel.x - (int)m_psShoot[i-1].cWormVel.x) > 255 ||
 			abs((int)m_psShoot[i].cWormVel.y - (int)m_psShoot[i-1].cWormVel.y) > 255 ||
-			num > 255) {
+			// the count goes out as one byte,
+			// and the receiver caps it at MAX_SHOOTINGS-1
+			num >= 255) {
 
 			break;
 		}

--- a/tests/unit/test_CShootList.cpp
+++ b/tests/unit/test_CShootList.cpp
@@ -10,6 +10,7 @@
 #include "Version.h"
 #include "CBytestream.h"
 #include "CShootList.h"
+#include "Protocol.h"  // S2C_SINGLESHOOT, S2C_MULTISHOOT
 
 // Regression for #1115:
 // a single shot with a large negative speed (nSpeed < -255)
@@ -51,4 +52,55 @@ void test_CShootListSpeedRoundtrip() {
 		CHECK(dst.m_psShoot[0].nAngle == 90);
 		CHECK(dst.m_psShoot[0].nWormID == 3);
 	}
+}
+
+// Regression for #1128:
+// a run of 256 similar shots overflowed the one-byte run count (256 -> 0),
+// so writeMulti() still wrote the small shots
+// while readMulti() dropped them and desynced the stream.
+// A full shoot list must round-trip.
+void test_CShootListMultiRoundtrip() {
+	const Version ver = OLXBetaVersion(0,57,0);
+	const int max_weapon_id = 10;
+	const int N = MAX_SHOOTINGS;  // 256: exactly the run-count overflow
+
+	// All shots identical, so they run-length encode into one run.
+	CShootList src;
+	CHECK(src.Initialize());
+	for(int i = 0; i < N; ++i) {
+		shoot_t& s = src.m_psShoot[i];
+		s.fTime = TimeDiff();
+		s.nWeapon = 5;
+		s.cPos = CVec(10, 20);
+		s.cWormVel = CVec(0, 0);
+		s.nAngle = 90;
+		s.nRandom = 0;
+		s.nSpeed = 100;
+		s.nWormID = 3;
+		s.release = false;
+	}
+	src.m_nNumShootings = N;
+
+	CBytestream bs;
+	src.writeMulti(&bs, ver, 0);
+
+	// Read the sub-packets back and count every shot that arrives.
+	bs.ResetPosToBegin();
+	int got = 0;
+	while(!bs.isPosAtEnd()) {
+		const byte type = bs.readByte();
+		CShootList dst;
+		CHECK(dst.Initialize());
+		if(type == S2C_SINGLESHOOT)
+			dst.readSingle(&bs, ver, max_weapon_id);
+		else if(type == S2C_MULTISHOOT)
+			dst.readMulti(&bs, ver, max_weapon_id);
+		else {
+			// A small-shot byte parsed as a packet id: the stream desynced.
+			CHECK(type == S2C_SINGLESHOOT || type == S2C_MULTISHOOT);
+			break;
+		}
+		got += dst.getNumShots();
+	}
+	CHECK(got == N);
 }

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -36,6 +36,7 @@ void test_OmfgScriptHugeIntegerLiteral();
 void test_OmfgScriptHugeNumberFirstToken();
 void test_LinenoiseRefreshLineZeroCols();
 void test_CShootListSpeedRoundtrip();
+void test_CShootListMultiRoundtrip();
 
 int main() {
 	printf("Running OLX unit tests...\n");
@@ -58,6 +59,7 @@ int main() {
 	test_OmfgScriptHugeNumberFirstToken();
 	test_LinenoiseRefreshLineZeroCols();
 	test_CShootListSpeedRoundtrip();
+	test_CShootListMultiRoundtrip();
 
 	if(g_olxTestFailures) {
 		printf("FAILED: %d check(s)\n", g_olxTestFailures);


### PR DESCRIPTION
`CShootList::writeMulti()` counts a run of similar shots,
but checks the counter before incrementing it,
so the run could reach 256.
It is then written as a single byte, truncating 256 to 0,
while the small shots for the run were still written out.

The receiver reads the count as `MIN(readByte(), MAX_SHOOTINGS-1)`,
so a sent 256 arrives as 0:
`readMulti()` consumes the header shot and no small shots,
leaving the rest of the run in the stream and desyncing it
(the next byte is parsed as a packet id).

`MAX_SHOOTINGS` is 256, so a full shoot list can hit this.

Fix: break the run at 255, so the count always fits a byte
and matches the receiver's `MAX_SHOOTINGS-1` limit.

Adds a `writeMulti`/`readMulti` round-trip test over a 256-shot list
(reached through a friend declaration, like the speed test).
Verified it fails before the fix -- the stream desyncs and the count is wrong --
and passes after.

Fixes #1128.
