### PR TITLE
Compare the task state instead of a constant

### DIFF
--- a/src/common/TaskManager.cpp
+++ b/src/common/TaskManager.cpp
@@ -116,7 +116,7 @@ void TaskManager::start(Task* t, QueueType queue) {
 			}
 			{
 				Mutex::ScopedLock lock(*task->mutex);
-				task->state = Task::TS_QUEUED ? Task::TS_RUNNINGQUEUED : Task::TS_RUNNING;
+				task->state = task->state == Task::TS_QUEUED ? Task::TS_RUNNINGQUEUED : Task::TS_RUNNING;
 			}
 			Result ret = task->breakSignal ?
 						Result("breaked even before start") :


### PR DESCRIPTION
`TaskManager::TaskHandler` set the running state with

```cpp
task->state = Task::TS_QUEUED ? Task::TS_RUNNINGQUEUED : Task::TS_RUNNING;
```

`Task::TS_QUEUED` is the enum constant 0, not a comparison,
so the condition is always false
and a task started from the queue was always marked `TS_RUNNING`,
never `TS_RUNNINGQUEUED`.

Compare `task->state`, as intended.
The visible effect is the CLI task-list status string
(`running from queue` vs `running independently`).

Fixes #1130.
