### PR TITLE
Draw rect projectiles with their y radius

### DIFF
--- a/src/common/CProjectile.cpp
+++ b/src/common/CProjectile.cpp
@@ -308,7 +308,7 @@ void CProjectile::Draw(SDL_Surface * bmpDest, CViewport *view)
 			return;
 			
 		case PRJ_RECT:
-			DrawRectFill(bmpDest, p.x - radius.x*2, p.y - radius.y*2, p.x + radius.x*2, p.y + radius.x*2, iColour);
+			DrawRectFill(bmpDest, p.x - radius.x*2, p.y - radius.y*2, p.x + radius.x*2, p.y + radius.y*2, iColour);
 			return;
 			
 		case PRJ_POLYGON:


### PR DESCRIPTION
`CProjectile::Draw` rendered a `PRJ_RECT` projectile with

```cpp
DrawRectFill(bmpDest, p.x - radius.x*2, p.y - radius.y*2,
                      p.x + radius.x*2, p.y + radius.x*2, iColour);
```

The bottom edge used `radius.x*2` for the y coordinate.
A rect projectile whose x and y radii differ drew with the wrong height.
Use `radius.y*2`.

Fixes #1131.
