### PR TITLE
Detach a timer from its data before freeing it

### DIFF
--- a/include/Timer.h
+++ b/include/Timer.h
@@ -132,7 +132,11 @@ public:
 	bool start();
 	bool startHeadless(); // start independent timer
 	void stop();
-	
+
+	// Internal: the event handler calls this when a TimerData is freed,
+	// so a finished/stopped timer never dereferences it.
+	void detachData(TimerData* d);
+
 private:
 	bool m_running;
 	TimerData* m_lastData;	// it's TimerData* intern

--- a/src/common/Timer.cpp
+++ b/src/common/Timer.cpp
@@ -387,6 +387,18 @@ void Timer::stop()
 }
 
 
+//////////////////
+// Detach from a TimerData that is about to be freed,
+// so stop()/start()/the destructor won't touch it
+void Timer::detachData(TimerData* d)
+{
+	if(m_lastData == d) {
+		m_lastData = NULL;
+		m_running = false;
+	}
+}
+
+
 
 ///////////////
 // Handle the timer event, called from HandleNextEvent
@@ -425,6 +437,8 @@ static void Timer_handleEvent(InternTimerEventData data)
 	
 	if(data.lastEvent)  { // last-event-signal
 		// we can delete here as we have ensured that this is realy the last event
+		if(timer_data->timer)  // detach the owner so it won't dereference the freed data
+			timer_data->timer->detachData(timer_data);
 		delete timer_data;
 	}
 }


### PR DESCRIPTION
A `this`-bound `Timer` keeps a raw pointer to its `TimerData` in `m_lastData`,
but `Timer_handleEvent` frees that data on the last event
(the `once` fire or the quit signal) without telling the `Timer`.
The owning object is then left with a dangling `m_lastData` and `m_running == true`,
so a later `stop()`, `start()`, or the destructor dereferences freed memory.

The pure `once=true` + `this`-bound form is unused today
(every `once=true` timer is a headless temporary),
but the same hazard reaches the `this`-bound Console and Cursor animation timers
at shutdown, where the data is freed on the quit signal
while the object still points at it.

Fix: when the data is freed, detach the owning `Timer`
(guarded on `m_lastData == data`), so `stop()`/`start()`/`~Timer`
become safe no-ops.

The timer system runs its events through the main-loop pump,
so this has no unit test; verified by building,
running the game through a clean shutdown,
and the headless suite (which starts and stops a dedicated server).

Fixes #1134.
