### PR TITLE
Build the Linux packages with DEBUG=No

### DIFF
--- a/.github/workflows/build-linux.sh
+++ b/.github/workflows/build-linux.sh
@@ -2,6 +2,6 @@
 set -euo pipefail
 
 cd $(dirname $0)"/../.."
-cmake -S . -B build-output -DCMAKE_BUILD_TYPE=Release -DHAWKNL_BUILTIN=Yes
+cmake -S . -B build-output -DCMAKE_BUILD_TYPE=Release -DDEBUG=No -DHAWKNL_BUILTIN=Yes
 mkdir -p build-output/bin
 cmake --build build-output -j$(nproc)


### PR DESCRIPTION
`build-linux.sh` omitted `-DDEBUG=No`,
so it built with the default `OPTION(DEBUG ... Yes)` (CMakeOlxCommon.cmake:22)
and shipped the debug code in the Linux bundle and `.deb`
(`package-linux-bundle.yml`, `package-linux-deb.yml`).
`build-windows.sh` and `package-mac.yml` already pass `-DDEBUG=No`;
Linux was the odd one out.

The costly part is `attrUpdateAddCallInfo` in `src/game/Attr.cpp`,
under `#ifdef DEBUG`:
it captures a full callstack (`GetCallstack`) plus a value copy
on every attribute write,
and attributes are written per worm per frame in the physics loop.

Measured on a dedicated server (8 bots + 2 connected clients, in combat)
with macOS `sample`:

- default build (`DEBUG=Yes`): 54.9% CPU
- `-DDEBUG=No`: 8.3% CPU

so roughly a 6.6x server-CPU reduction, with no gameplay change.
Dedicated servers are overwhelmingly Linux, so this hit real deployments.

One line: add `-DDEBUG=No`, matching the Windows and Mac builds.
Verified the `DEBUG=No` binary passes the full headless suite (16 passed).

Fixes #1136.
