### PR TITLE
Don't apply REPORTDAMAGE to a dead worm

### DIFF
--- a/src/client/CClient_Parse.cpp
+++ b/src/client/CClient_Parse.cpp
@@ -2133,7 +2133,10 @@ void CClientNetEngineBeta9::ParseReportDamage(CBytestream *bs)
 	
 	w->getDamageReport()[offender->getID()].damage += damage;
 	w->getDamageReport()[offender->getID()].lastTime = tLX->currentTime;
-	w->injure(damage);	// Calculate correct healthbar
+	// Skip a dead worm, like CClient::InjureWorm does:
+	// a stale REPORTDAMAGE around respawn would re-kill the fresh worm (#588).
+	if(w->getAlive())
+		w->injure(damage);	// Calculate correct healthbar
 	// Update worm damage count (it gets updated in UPDATESCORE packet, we do local calculations here, but they are wrong if we connected during game)
 	//notes << "CClientNetEngineBeta9::ParseReportDamage() offender " << offender->getID() << " dmg " << damage << " victim " << id << endl;
 	offender->addDamage( damage, w, false );


### PR DESCRIPTION
## Problem

Fixes #588.

`CClientNetEngineBeta9::ParseReportDamage` applied the reported damage
to the worm's health with no alive-check,
while `CClient::InjureWorm` guards with `if(!w->getAlive()) return;`.

A `REPORTDAMAGE` packet arriving around the death/respawn boundary
-- common with mods whose weapons deal more than a worm's max health
(the issue names Element Madness' Blood and Cruel's Iron Snake) --
would deplete a freshly respawned worm and immediately re-kill it,
which is the "sticky damage after respawn" loop reported.

## Fix

Guard the `injure()` call with `getAlive()`, matching `InjureWorm`.
`CWorm::Spawn` resets health to 100,
so a stale report for a prior life is simply ignored.
The damage-report and offender-score bookkeeping are left unchanged.

## Testing

- Builds clean (macOS, SDL2).
- Full headless suite passes (16/16).
- Caveat: the loop is a client/server timing bug
  that needs a live remote client plus a >max-health-damage mod to trigger,
  so I could not reproduce it deterministically in the headless harness.
  The change only mirrors the guard `InjureWorm` already has,
  so it can at most drop damage that would have hit a non-alive worm.
