### PR TITLE
Fix gamepad joystick in weapon select menu

### DIFF
--- a/doc/dev/GAMEPAD.md
+++ b/doc/dev/GAMEPAD.md
@@ -40,8 +40,9 @@ This section covers the analog-stick half. A few behaviours worth knowing:
   through it, in the walk direction, no matter where you're aiming.
 - **Aim holds when released.** The aim only updates while a stick is outside its
   deadzone; let go of both sticks and the worm keeps its last aim.
-- **Weapon select.** On the weapon-selection screen the left stick moves the
-  cursor up/down (one row per push, then auto-repeats if held), alongside the
+- **Weapon select.** On the weapon-selection screen the left stick does what the
+  arrow keys do: up/down moves the cursor, left/right changes the weapon on the
+  selected row (one step per push, then auto-repeats if held), alongside the
   usual keyboard/d-pad keys.
 
 ### Design rules (how the layering works)

--- a/include/CWormHuman.h
+++ b/include/CWormHuman.h
@@ -114,11 +114,19 @@ private:
 	bool walkingRight;
 
 	// Gamepad left-stick navigation in the weapon-selection menu (the analog
-	// sticks aren't bindable, so the menu reads the pad directly). Tracks the
-	// stick so one push moves one row, with keyboard-style auto-repeat while held.
-	AbsTime	fLastWeaponSelStickMove;
-	bool	weaponSelStickHeld;
-	bool	weaponSelStickRepeated;
+	// sticks aren't bindable, so the menu reads the pad directly). One instance
+	// tracks one stick axis, so a push moves one step and then auto-repeats
+	// while held, like key-repeat.
+	struct WeaponSelStickAxis {
+		AbsTime	fLastMove;
+		bool	held;
+		bool	repeated;
+		WeaponSelStickAxis() : held(false), repeated(false) {}
+		// This frame's step (-1, 0 or +1) for a raw SDL axis value.
+		int step(int axisValue);
+	};
+	WeaponSelStickAxis	weaponSelStickY;	// moves the selection up/down
+	WeaponSelStickAxis	weaponSelStickX;	// changes the weapon left/right
 };
 
 #endif  //  __CWORMHUMAN_H__

--- a/src/common/CWormHuman.cpp
+++ b/src/common/CWormHuman.cpp
@@ -623,8 +623,6 @@ WormType* PRF_HUMAN = &PRF_HUMAN_instance;
 CWormHumanInputHandler::CWormHumanInputHandler(CWorm* w) : CWormInputHandler(w) {
 	bRopeDown = bRopeDownOnce = false;
 	m_localPlayerSlot = -1;
-	weaponSelStickHeld = false;
-	weaponSelStickRepeated = false;
 	gusInit();
 	
 	game.onNewPlayer( this );
@@ -752,6 +750,40 @@ void CWormHumanInputHandler::initWeaponSelection() {
 
 
 ///////////////////
+// One step of gamepad left-stick navigation in the weapon selection, from a raw
+// SDL axis value (left/up negative, right/down positive). A push steps once on
+// the rising edge, then auto-repeats while the stick is held, mimicking key-repeat.
+int CWormHumanInputHandler::WeaponSelStickAxis::step(int axisValue)
+{
+	const int dz = getPadStickDeadzone();
+	const int dir = (axisValue < -dz) ? -1 : (axisValue > dz) ? 1 : 0;
+
+	if(dir == 0) {
+		held = false;
+		return 0;
+	}
+
+	if(!held) {
+		// rising edge: step right away
+		held = true;
+		repeated = false;
+		fLastMove = tLX->currentTime;
+		return dir;
+	}
+
+	// held: wait longer before the first repeat, then repeat faster
+	const float delay = repeated ? 0.12f : 0.4f;
+	if(tLX->currentTime - fLastMove >= delay) {
+		repeated = true;
+		fLastMove = tLX->currentTime;
+		return dir;
+	}
+
+	return 0;
+}
+
+
+///////////////////
 // Draw/Process the weapon selection screen
 void CWormHumanInputHandler::doWeaponSelectionFrame(SDL_Surface * bmpDest, CViewport *v)
 {
@@ -811,6 +843,20 @@ void CWormHumanInputHandler::doWeaponSelectionFrame(SDL_Surface * bmpDest, CView
 	// Touch only drives the first local player in split-screen.
 	const bool touchForThisWorm = isFirstLocalHumanWorm(m_worm);
 
+	// Gamepad left stick navigates the menu too, doing what the arrow keys do:
+	// up/down moves the selection, left/right changes the weapon on the selected
+	// row. The sticks aren't bindable (the in-game twin-stick path owns them), so
+	// read the pad directly via the same helpers and slot mapping (player N ->
+	// pad N). Both axes are read once here, before the rows consume the
+	// left/right step below; the up/down step is applied after them.
+	int stickWeaponChange = 0;
+	int stickSelectionChange = 0;
+	const int padSlot = localHumanWormIndex(m_worm);
+	if(!bChat_Typing && padSlot >= 0 && isPadPresent(padSlot)) {
+		stickWeaponChange = weaponSelStickX.step(getPadLeftStickX(padSlot));
+		stickSelectionChange = weaponSelStickY.step(getPadLeftStickY(padSlot));
+	}
+
 	int y = t + 100;
 	for(size_t i=0;i<m_worm->tWeapons.size();i++) {
 		
@@ -835,6 +881,7 @@ void CWormHumanInputHandler::doWeaponSelectionFrame(SDL_Surface * bmpDest, CView
 				change += TouchScreenInput::tapCount(1, TouchScreenInput::Action::Right);
 				change -= TouchScreenInput::tapCount(1, TouchScreenInput::Action::Left);
 			}
+			change += stickWeaponChange;
 			if(cSelWeapon.isDown()) change *= 6; // jump with multiple speed if selWeapon is pressed
 			int id = m_worm->tWeapons[i].weapon() ? m_worm->tWeapons[i].weapon()->ID : 0;
 			if(change > 0) while(change) {
@@ -945,33 +992,7 @@ void CWormHumanInputHandler::doWeaponSelectionFrame(SDL_Surface * bmpDest, CView
 			change -= TouchScreenInput::tapCount(1, TouchScreenInput::Action::Up);
 		}
 
-		// Gamepad left stick navigates up/down too. The sticks aren't bindable
-		// (the in-game twin-stick path owns them), so read the pad directly via
-		// the same helpers and slot mapping (player N -> pad N). Push up/down to
-		// move one row, then it auto-repeats while held, mimicking key-repeat.
-		const int padSlot = localHumanWormIndex(m_worm);
-		if(padSlot >= 0 && isPadPresent(padSlot)) {
-			const int ly = getPadLeftStickY(padSlot); // SDL: up negative, down positive
-			const int dz = getPadStickDeadzone();
-			const int dir = (ly < -dz) ? -1 : (ly > dz) ? 1 : 0;
-			if(dir == 0) {
-				weaponSelStickHeld = false;
-			} else if(!weaponSelStickHeld) {
-				// rising edge: move one row right away
-				change += dir;
-				weaponSelStickHeld = true;
-				weaponSelStickRepeated = false;
-				fLastWeaponSelStickMove = tLX->currentTime;
-			} else {
-				// held: wait longer before the first repeat, then repeat faster
-				const float delay = weaponSelStickRepeated ? 0.12f : 0.4f;
-				if(tLX->currentTime - fLastWeaponSelStickMove >= delay) {
-					change += dir;
-					weaponSelStickRepeated = true;
-					fLastWeaponSelStickMove = tLX->currentTime;
-				}
-			}
-		}
+		change += stickSelectionChange;
 
 		m_worm->iCurrentWeapon += change;
 		m_worm->iCurrentWeapon %= (int)m_worm->tWeapons.size() + 2;


### PR DESCRIPTION
The weapon-selection menu already let the gamepad left stick move the cursor up/down, but changing the weapon on the selected row still needed the arrow keys or the d-pad, so a pad player had to reach back to the keyboard half way through the menu.

Read the stick's X axis next to the Y axis and feed it into the same "change" the left/right keys drive: a push steps one weapon and then auto-repeats while held, just as up/down already did. It is added before the select-weapon multiplier, so holding that key jumps six weapons at a time with the stick too, exactly like the keys.

Both axes now share WeaponSelStickAxis::step(), which owns the deadzone test and the rising-edge/auto-repeat state, instead of up/down keeping that logic inline; the axes differ only in which raw value they read. Both are read once per frame before the weapon rows, since the left/right step is consumed inside a row while the up/down step is applied after them.